### PR TITLE
Implement agent pipeline API route

### DIFF
--- a/codex-prompts/run-agents-prompt.md
+++ b/codex-prompts/run-agents-prompt.md
@@ -1,0 +1,37 @@
+# Purpose
+Create an API route that runs the EdgePicks agent pipeline for a given NFL matchup. This route gathers data from InjuryScout, LineWatcher, and StatCruncher, processes them with PickBot, and returns a complete pick with confidence and reasoning.
+
+# API Endpoint
+`GET /api/run-agents?teamA=49ers&teamB=Cowboys&week=1`
+
+# Responsibilities
+1. Accept teamA, teamB, week from query params  
+2. Call each modular agent:  
+   - `injuryScout(matchup)`  
+   - `lineWatcher(matchup)`  
+   - `statCruncher(matchup)`  
+3. Pass all results to `pickBot(agentsOutput)`  
+4. Return a JSON response:
+
+```ts
+type AgentOutput = {
+  injuryScout: InjuryReport;
+  lineWatcher: LineMovementReport;
+  statCruncher: StatMatchupReport;
+};
+
+type PickSummary = {
+  winner: string;
+  confidence: number;
+  topReasons: string[];
+};
+```
+
+# File to Generate
+`pages/api/run-agents.ts`
+
+# Notes
+- Use TypeScript  
+- Validate query params before processing  
+- Use mocked data from agents if needed  
+- Do not depend on Supabase yet — keep this backend-logic focused


### PR DESCRIPTION
## Summary
- Add `run-agents` Codex prompt outlining responsibilities and query parameters for live agent pipeline
- Implement `/api/run-agents` route to validate query params, invoke InjuryScout, LineWatcher, and StatCruncher, and aggregate their outputs into a weighted pick summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892357805a483239d6b73ba208b2cf7