### PR TITLE
Fetch live picks for matchups

### DIFF
--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -1,37 +1,73 @@
 import React, { useState } from 'react';
-import AgentSummary from './AgentSummary';
-import type { Matchup } from '../lib/mock/agentOutput';
 
-interface Props {
-  matchup: Matchup;
-}
+export type MatchupProps = {
+  teamA: string;
+  teamB: string;
+  result: {
+    winner: string;
+    confidence: number;
+    topReasons: string[];
+  };
+  onRerun?: () => void;
+  loading?: boolean;
+};
 
-const MatchupCard: React.FC<Props> = ({ matchup }) => {
+const MatchupCard: React.FC<MatchupProps> = ({
+  teamA,
+  teamB,
+  result,
+  onRerun,
+  loading,
+}) => {
   const [open, setOpen] = useState(false);
+  const confidencePct = Math.round(result.confidence * 100);
 
   return (
-    <div className="border rounded p-4 shadow-sm w-full md:w-1/2">
+    <div
+      className={`border rounded p-4 shadow-sm w-full md:w-1/2 ${
+        result.confidence > 0.8 ? 'border-green-500' : ''
+      }`}
+    >
       <div className="flex justify-between items-center">
         <h3 className="font-semibold">
-          {matchup.awayTeam} @ {matchup.homeTeam}
+          {teamA} vs {teamB}
         </h3>
-        <button
-          className="text-blue-500 text-sm"
-          onClick={() => setOpen((o) => !o)}
-        >
-          {open ? 'Hide' : 'Details'}
-        </button>
+        <div className="flex gap-2 items-center">
+          {onRerun && (
+            <button
+              className="text-blue-500 text-sm disabled:opacity-50"
+              onClick={onRerun}
+              disabled={loading}
+            >
+              {loading ? '...' : 'Re-run'}
+            </button>
+          )}
+          <button
+            className="text-blue-500 text-sm"
+            onClick={() => setOpen((o) => !o)}
+          >
+            {open ? 'Hide' : 'Details'}
+          </button>
+        </div>
       </div>
       <p className="mt-2">
-        Pick: <span className="font-bold">{matchup.pick}</span> ({Math.round(matchup.confidence * 100)}%)
+        Pick: <span className="font-bold">{result.winner}</span> ({confidencePct}%)
+        {result.confidence > 0.8 && (
+          <span className="ml-2 px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs">
+            High Confidence
+          </span>
+        )}
       </p>
       {open && (
-        <div className="mt-2">
-          <AgentSummary reasons={matchup.reasons} />
-        </div>
+        <ul className="mt-2 list-disc list-inside text-sm">
+          {result.topReasons.map((reason, idx) => (
+            <li key={idx}>{reason}</li>
+          ))}
+        </ul>
       )}
     </div>
   );
 };
 
 export default MatchupCard;
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,96 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import MatchupCard from '../components/MatchupCard';
-import { mockMatchups } from '../lib/mock/agentOutput';
+
+type Matchup = {
+  teamA: string;
+  teamB: string;
+  week: number;
+};
+
+const matchups: Matchup[] = [
+  { teamA: '49ers', teamB: 'Cowboys', week: 1 },
+  { teamA: 'Jets', teamB: 'Patriots', week: 1 },
+  { teamA: 'Chiefs', teamB: 'Bills', week: 1 },
+];
+
+type PickResult = {
+  winner: string;
+  confidence: number;
+  topReasons: string[];
+};
+
+const MatchupFetcher: React.FC<Matchup> = ({ teamA, teamB, week }) => {
+  const [result, setResult] = useState<PickResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPick = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/run-agents?teamA=${encodeURIComponent(teamA)}&teamB=${encodeURIComponent(teamB)}&week=${week}`
+      );
+      if (!res.ok) throw new Error('Network error');
+      const data = await res.json();
+      const pick = data.pick ?? data;
+      if (!pick || !pick.winner) {
+        setError('Insufficient data');
+      } else {
+        setResult(pick as PickResult);
+      }
+    } catch (e) {
+      setError('Error loading pick');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPick();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamA, teamB, week]);
+
+  if (loading) {
+    return (
+      <div className="border rounded p-4 shadow-sm w-full md:w-1/2 flex justify-center">
+        <div className="w-6 h-6 border-4 border-gray-300 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error || !result) {
+    return (
+      <div className="border rounded p-4 shadow-sm w-full md:w-1/2 text-center text-red-600">
+        {error || 'Insufficient data'}
+        <button
+          className="block mt-2 text-blue-500 text-sm mx-auto"
+          onClick={fetchPick}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <MatchupCard
+      teamA={teamA}
+      teamB={teamB}
+      result={result}
+      onRerun={fetchPick}
+      loading={loading}
+    />
+  );
+};
 
 const HomePage: React.FC = () => (
   <main className="p-4 flex flex-col gap-4 items-center">
-    {mockMatchups.map((m, idx) => (
-      <MatchupCard key={idx} matchup={m} />
+    {matchups.map((m, idx) => (
+      <MatchupFetcher key={idx} {...m} />
     ))}
   </main>
 );
 
 export default HomePage;
+


### PR DESCRIPTION
## Summary
- Fetch matchup picks from `/api/run-agents` and show spinner/error states
- Display winners, confidence, and agent reasoning in `MatchupCard`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689237f7f82c8323a115ed962a63edd4