### PR TITLE
Add animated confidence bar to MatchupCard

### DIFF
--- a/components/AnimatedConfidenceBar.tsx
+++ b/components/AnimatedConfidenceBar.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+
+type Props = {
+  confidence: number; // value between 0–100
+};
+
+const AnimatedConfidenceBar: React.FC<Props> = ({ confidence }) => {
+  const [fill, setFill] = useState(0);
+  const [display, setDisplay] = useState(0);
+
+  useEffect(() => {
+    setFill(0);
+    setDisplay(0);
+
+    const duration = 700;
+    const stepTime = 20;
+    const steps = duration / stepTime;
+    const increment = confidence / steps;
+    let current = 0;
+
+    const counter = setInterval(() => {
+      current += increment;
+      if (current >= confidence) {
+        current = confidence;
+        clearInterval(counter);
+      }
+      setDisplay(Math.round(current));
+    }, stepTime);
+
+    const timer = setTimeout(() => setFill(confidence), 50);
+
+    return () => {
+      clearInterval(counter);
+      clearTimeout(timer);
+    };
+  }, [confidence]);
+
+  const barColor =
+    confidence >= 80
+      ? 'bg-green-500'
+      : confidence >= 55
+      ? 'bg-yellow-500'
+      : 'bg-red-500';
+
+  return (
+    <div aria-label={`Confidence ${confidence}%`}>
+      <div className="flex justify-between items-center mb-1">
+        <span className="font-semibold">Confidence</span>
+        <span className="font-bold">{display}%</span>
+      </div>
+      <div className="w-full h-2 bg-gray-200 rounded">
+        <div
+          className={`h-full ${barColor} rounded transition-all duration-700 ease-in-out`}
+          style={{ width: `${fill}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default AnimatedConfidenceBar;

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import AnimatedConfidenceBar from './AnimatedConfidenceBar';
 
 export type MatchupProps = {
   teamA: string;
@@ -51,16 +52,7 @@ const MatchupCard: React.FC<MatchupProps> = ({
         <span className={`text-xl font-bold ${winnerColor}`}>{result.winner}</span>
       </div>
       <div className="mb-4">
-        <div className="flex justify-between items-center mb-1">
-          <span className="font-semibold">Confidence</span>
-          <span className="font-bold">{confidencePct}%</span>
-        </div>
-        <div className="w-full h-2 bg-gray-200 rounded">
-          <div
-            className="h-full bg-blue-600 rounded"
-            style={{ width: `${confidencePct}%` }}
-          />
-        </div>
+        <AnimatedConfidenceBar confidence={confidencePct} />
         {confidencePct > 80 && (
           <span className="mt-2 inline-block px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs">🟢 High Confidence</span>
         )}


### PR DESCRIPTION
## Summary
- add AnimatedConfidenceBar with animated fill and color thresholds
- integrate animated confidence meter into MatchupCard

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68923dafaae08323826f0dc68f476fb1