### PR TITLE
feat: add team branding badges to matchup cards

### DIFF
--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import AnimatedConfidenceBar from './AnimatedConfidenceBar';
+import TeamBadge from './TeamBadge';
 
 export type MatchupProps = {
   teamA: string;
@@ -27,8 +28,16 @@ const MatchupCard: React.FC<MatchupProps> = ({
   return (
     <div className="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-6">
       <div className="flex justify-between items-center mb-4">
-        <h3 className="font-semibold">
-          {teamA} <span className="text-gray-400">vs</span> {teamB}
+        <h3 className="font-semibold flex items-center gap-3">
+          <span className="flex items-center gap-2">
+            <TeamBadge team={teamA} isWinner={result.winner === teamA} />
+            {teamA}
+          </span>
+          <span className="text-gray-400">vs</span>
+          <span className="flex items-center gap-2">
+            <TeamBadge team={teamB} isWinner={result.winner === teamB} />
+            {teamB}
+          </span>
         </h3>
         <div className="flex gap-2 items-center">
           {onRerun && (

--- a/components/TeamBadge.tsx
+++ b/components/TeamBadge.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+
+const teamFallbacks: Record<string, string> = {
+  "49ers": "🟥 SF",
+  "Cowboys": "🔵 DAL",
+  "Jets": "🟢 NYJ",
+  "Patriots": "🔴 NE",
+  "Chiefs": "❤️ KC",
+  "Bills": "💙 BUF",
+};
+
+export type TeamBadgeProps = {
+  team: string;
+  isWinner?: boolean;
+};
+
+const TeamBadge: React.FC<TeamBadgeProps> = ({ team, isWinner }) => {
+  const [useFallback, setUseFallback] = useState(false);
+
+  const badgeClasses = `w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center overflow-hidden ${
+    isWinner ? 'ring-2 ring-green-400 transition-transform hover:scale-105' : ''
+  }`;
+
+  if (!useFallback) {
+    return (
+      <img
+        src={`/logos/${team}.png`}
+        alt={`${team} logo`}
+        className={badgeClasses}
+        onError={() => setUseFallback(true)}
+      />
+    );
+  }
+
+  const fallback = teamFallbacks[team] || '🏈';
+  const [emoji, initials] = fallback.split(' ');
+
+  return (
+    <div
+      aria-label={team}
+      className={`${badgeClasses} bg-gray-100 text-xs font-semibold`}
+    >
+      <span className="text-lg leading-none">{emoji}</span>
+      {initials && <span className="ml-1 leading-none">{initials}</span>}
+    </div>
+  );
+};
+
+export default TeamBadge;
+


### PR DESCRIPTION
## Summary
- add reusable `TeamBadge` component that loads team logos or falls back to emoji initials, with winner highlighting
- integrate badges into `MatchupCard` for both teams
- scaffold `public/logos` directory for future team logos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923f7e85d8832386af382f79889194