### PR TITLE
Centralize matchup types across agents

### DIFF
--- a/lib/agents/injuryScout.ts
+++ b/lib/agents/injuryScout.ts
@@ -1,13 +1,4 @@
-export interface AgentResult {
-  team: string;
-  score: number; // higher score favors team
-  reason: string;
-}
-
-interface Matchup {
-  homeTeam: string;
-  awayTeam: string;
-}
+import { AgentResult, Matchup } from '../types';
 
 export const injuryScout = (matchup: Matchup): AgentResult => {
   return {

--- a/lib/agents/lineWatcher.ts
+++ b/lib/agents/lineWatcher.ts
@@ -1,9 +1,4 @@
-import { AgentResult } from './injuryScout';
-
-interface Matchup {
-  homeTeam: string;
-  awayTeam: string;
-}
+import { AgentResult, Matchup } from '../types';
 
 export const lineWatcher = (matchup: Matchup): AgentResult => {
   return {

--- a/lib/agents/pickBot.ts
+++ b/lib/agents/pickBot.ts
@@ -1,18 +1,7 @@
 import { injuryScout } from './injuryScout';
 import { lineWatcher } from './lineWatcher';
 import { statCruncher } from './statCruncher';
-import type { AgentResult } from './injuryScout';
-
-interface Matchup {
-  homeTeam: string;
-  awayTeam: string;
-}
-
-export interface PickResult {
-  pick: string;
-  confidence: number;
-  reasons: string[];
-}
+import { AgentResult, Matchup, PickResult } from '../types';
 
 const weights = {
   injury: 0.5,

--- a/lib/agents/statCruncher.ts
+++ b/lib/agents/statCruncher.ts
@@ -1,9 +1,4 @@
-import { AgentResult } from './injuryScout';
-
-interface Matchup {
-  homeTeam: string;
-  awayTeam: string;
-}
+import { AgentResult, Matchup } from '../types';
 
 export const statCruncher = (matchup: Matchup): AgentResult => {
   return {

--- a/lib/mock/agentOutput.ts
+++ b/lib/mock/agentOutput.ts
@@ -1,12 +1,6 @@
-export interface Matchup {
-  homeTeam: string;
-  awayTeam: string;
-  pick: string;
-  confidence: number; // value between 0 and 1
-  reasons: string[];
-}
+import { MatchupWithPick } from '../types';
 
-export const mockMatchups: Matchup[] = [
+export const mockMatchups: MatchupWithPick[] = [
   {
     homeTeam: 'Patriots',
     awayTeam: 'Jets',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,19 @@
+export interface Matchup {
+  homeTeam: string;
+  awayTeam: string;
+  week?: number;
+}
+
+export interface AgentResult {
+  team: string;
+  score: number; // higher score favors team
+  reason: string;
+}
+
+export interface PickResult {
+  pick: string;
+  confidence: number;
+  reasons: string[];
+}
+
+export type MatchupWithPick = Matchup & PickResult;

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -2,12 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { injuryScout } from '../../lib/agents/injuryScout';
 import { lineWatcher } from '../../lib/agents/lineWatcher';
 import { statCruncher } from '../../lib/agents/statCruncher';
-
-interface AgentResult {
-  team: string;
-  score: number;
-  reason: string;
-}
+import { AgentResult, Matchup } from '../../lib/types';
 
 interface AgentOutput {
   injuryScout: AgentResult;
@@ -35,7 +30,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return;
   }
 
-  const matchup = { homeTeam: teamA, awayTeam: teamB, week: weekNum };
+  const matchup: Matchup = { homeTeam: teamA, awayTeam: teamB, week: weekNum };
 
   const injury = injuryScout(matchup);
   const line = lineWatcher(matchup);


### PR DESCRIPTION
## Summary
- Define reusable `Matchup`, `AgentResult`, and `PickResult` interfaces in `lib/types.ts`
- Update all agents, mock data, and API handler to import shared types instead of redefining them

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6892417fdba88323832caf637e94e1ca