### PR TITLE
Refactor agents to compute metrics asynchronously

### DIFF
--- a/lib/agents/injuryScout.ts
+++ b/lib/agents/injuryScout.ts
@@ -9,10 +9,22 @@ interface Matchup {
   awayTeam: string;
 }
 
-export const injuryScout = (matchup: Matchup): AgentResult => {
+import { pseudoMetric } from './utils';
+
+export const injuryScout = async (matchup: Matchup): Promise<AgentResult> => {
+  const [homeInjuries, awayInjuries] = await Promise.all([
+    pseudoMetric(`${matchup.homeTeam}-injuries`, 5),
+    pseudoMetric(`${matchup.awayTeam}-injuries`, 5),
+  ]);
+
+  const favored = homeInjuries <= awayInjuries ? matchup.homeTeam : matchup.awayTeam;
+  const underdog = favored === matchup.homeTeam ? matchup.awayTeam : matchup.homeTeam;
+  const diff = Math.abs(homeInjuries - awayInjuries);
+  const score = Math.min(1, 0.5 + diff / 10);
+
   return {
-    team: matchup.homeTeam,
-    score: 0.6,
-    reason: `${matchup.awayTeam} missing key starters`,
+    team: favored,
+    score,
+    reason: `${underdog} has ${diff} more key injuries`,
   };
 };

--- a/lib/agents/lineWatcher.ts
+++ b/lib/agents/lineWatcher.ts
@@ -1,14 +1,25 @@
-import { AgentResult } from './injuryScout';
+import type { AgentResult } from './injuryScout';
+import { pseudoMetric } from './utils';
 
 interface Matchup {
   homeTeam: string;
   awayTeam: string;
 }
 
-export const lineWatcher = (matchup: Matchup): AgentResult => {
+export const lineWatcher = async (matchup: Matchup): Promise<AgentResult> => {
+  const [homeLine, awayLine] = await Promise.all([
+    pseudoMetric(`${matchup.homeTeam}-line`, 10),
+    pseudoMetric(`${matchup.awayTeam}-line`, 10),
+  ]);
+
+  const diff = homeLine - awayLine;
+  const favored = diff <= 0 ? matchup.awayTeam : matchup.homeTeam;
+  const movement = Math.abs(diff);
+  const score = Math.min(1, 0.5 + movement / 20);
+
   return {
-    team: matchup.homeTeam,
-    score: 0.55,
-    reason: 'Line moved 1.5 toward home team',
+    team: favored,
+    score,
+    reason: `Betting line favors ${favored} by ${movement.toFixed(1)} pts`,
   };
 };

--- a/lib/agents/pickBot.ts
+++ b/lib/agents/pickBot.ts
@@ -20,10 +20,12 @@ const weights = {
   stats: 0.2,
 };
 
-export const pickBot = (matchup: Matchup): PickResult => {
-  const injury = injuryScout(matchup);
-  const line = lineWatcher(matchup);
-  const stats = statCruncher(matchup);
+export const pickBot = async (matchup: Matchup): Promise<PickResult> => {
+  const [injury, line, stats] = await Promise.all([
+    injuryScout(matchup),
+    lineWatcher(matchup),
+    statCruncher(matchup),
+  ]);
 
   const teams = [matchup.homeTeam, matchup.awayTeam];
   const scores: Record<string, number> = { [teams[0]]: 0, [teams[1]]: 0 };

--- a/lib/agents/statCruncher.ts
+++ b/lib/agents/statCruncher.ts
@@ -1,14 +1,24 @@
-import { AgentResult } from './injuryScout';
+import type { AgentResult } from './injuryScout';
+import { pseudoMetric } from './utils';
 
 interface Matchup {
   homeTeam: string;
   awayTeam: string;
 }
 
-export const statCruncher = (matchup: Matchup): AgentResult => {
+export const statCruncher = async (matchup: Matchup): Promise<AgentResult> => {
+  const [homeEff, awayEff] = await Promise.all([
+    pseudoMetric(`${matchup.homeTeam}-stats`, 100),
+    pseudoMetric(`${matchup.awayTeam}-stats`, 100),
+  ]);
+
+  const favored = homeEff >= awayEff ? matchup.homeTeam : matchup.awayTeam;
+  const diff = Math.abs(homeEff - awayEff);
+  const score = Math.min(1, 0.5 + diff / 200);
+
   return {
-    team: matchup.awayTeam,
-    score: 0.52,
-    reason: 'Passing efficiency edge for away team',
+    team: favored,
+    score,
+    reason: `${favored} shows a ${diff}% efficiency edge`,
   };
 };

--- a/lib/agents/utils.ts
+++ b/lib/agents/utils.ts
@@ -1,0 +1,4 @@
+export const pseudoMetric = async (seed: string, mod: number): Promise<number> => {
+  const hash = Array.from(seed).reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+  return hash % mod;
+};


### PR DESCRIPTION
## Summary
- compute pseudo injury, line, and stat metrics asynchronously
- orchestrate agents with Promise.all and surface justification strings
- expose updated async orchestration in API route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68924181318083238b7b13df48d5d1c8