### PR TITLE
docs: expand project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,49 @@
 
 AI-powered research assistant for NFL Pick'em that combines multiple lightweight agents to surface weekly matchup edges.
 
-## Getting Started
+## Project Purpose
 
-1. Install dependencies: `npm install`
-2. Copy `.env.example` to `.env` and provide Supabase credentials
-3. Run the development server: `npm run dev`
+EdgePicks aggregates insights from modular agents so pick'em players can quickly identify advantageous matchups and understand the reasoning behind each recommendation.
 
-## Project Structure
+## Agent Architecture
 
-- `pages/` – Next.js pages. `index.tsx` lists matchups using mock data.
-- `components/` – Reusable UI pieces like `MatchupCard` and `AgentSummary`.
-- `lib/agents/` – Modular TypeScript agents such as `injuryScout`, `lineWatcher`, and `statCruncher` plus the orchestrator `pickBot`.
-- `lib/mock/agentOutput.ts` – Static JSON used for demos.
-- `codex-prompts/` – Prompt files describing each agent's role.
+Agents live in `lib/agents/` and each returns an `AgentResult` describing a favored team, score, and justification.
+
+- `injuryScout` – checks injury reports.
+- `lineWatcher` – monitors betting line movement.
+- `statCruncher` – looks at efficiency stats.
+- `pickBot` – orchestrator that combines agent scores to produce a final pick.
+
+## API Endpoints
+
+- `GET /api/run-agents?teamA=<team>&teamB=<team>&week=<number>` runs all agents for the supplied matchup and returns individual results plus an overall pick summary.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and provide:
+
+```bash
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_ANON_KEY=<your-anon-key>
+```
+
+These values are used by `lib/supabaseClient.ts` to connect to Supabase.
+
+## Example Commands
+
+```bash
+npm install            # install dependencies
+npm run dev            # start Next.js development server
+curl "http://localhost:3000/api/run-agents?teamA=NE&teamB=NYJ&week=1"  # sample API call
+```
+
+## Adding New Agents or Data Sources
+
+1. Create a new file in `lib/agents/` that exports an `AgentResult` for a `Matchup`.
+2. Import the agent in `lib/agents/pickBot.ts` and `pages/api/run-agents.ts` and adjust the weights.
+3. If the agent relies on external data, configure access (e.g., update `lib/supabaseClient.ts` or add new fetch logic) and document any required env vars.
+4. Optionally add a prompt file in `codex-prompts/` to describe the agent's role.
+5. Run the example commands above to ensure the new agent works end-to-end.
 
 ## License
 


### PR DESCRIPTION
## Summary
- document project purpose and agent architecture
- add API endpoint, environment variable, and example command sections
- outline how to add new agents or data sources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689241c6c8ac832384cf5c93565655b3