### PR TITLE
feat: show agent reasoning and confidence

### DIFF
--- a/components/AgentSummary.tsx
+++ b/components/AgentSummary.tsx
@@ -1,15 +1,69 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { AgentOutputs, AgentName, AgentResult } from '../lib/types';
 
 interface Props {
-  reasons: string[];
+  agents: AgentOutputs;
 }
 
-const AgentSummary: React.FC<Props> = ({ reasons }) => (
-  <ul className="list-disc list-inside text-sm">
-    {reasons.map((reason, idx) => (
-      <li key={idx}>{reason}</li>
-    ))}
-  </ul>
-);
+const displayNames: Record<AgentName, string> = {
+  injuryScout: 'InjuryScout',
+  lineWatcher: 'LineWatcher',
+  statCruncher: 'StatCruncher',
+};
+
+const weights: Record<AgentName, number> = {
+  injuryScout: 0.5,
+  lineWatcher: 0.3,
+  statCruncher: 0.2,
+};
+
+const AgentSummary: React.FC<Props> = ({ agents }) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(true);
+  }, []);
+
+  const renderAgent = (name: AgentName, result: AgentResult) => {
+    const weight = weights[name];
+    const percent = Math.round(weight * 100);
+    const scorePct = Math.round(result.score * 100);
+
+    return (
+      <li
+        key={name}
+        className={`p-3 bg-gray-50 rounded shadow-sm flex flex-col sm:flex-row sm:items-center gap-2 transition-all duration-500 ease-out ${
+          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+        }`}
+      >
+        <div className="flex-1">
+          <div className="flex items-center justify-between">
+            <span className="font-medium">{displayNames[name]}</span>
+            <span className="text-xs text-gray-500">{percent}% weight</span>
+          </div>
+          <p className="text-xs text-gray-600 mt-1">{result.reason}</p>
+        </div>
+        <div className="w-full sm:w-40 flex items-center gap-2">
+          <div className="flex-1 h-2 bg-gray-200 rounded">
+            <div
+              className="h-full bg-blue-500 rounded"
+              style={{ width: `${scorePct}%` }}
+            />
+          </div>
+          <span className="w-10 text-right font-mono text-sm">{result.score.toFixed(2)}</span>
+        </div>
+      </li>
+    );
+  };
+
+  return (
+    <ul className="mt-2 text-sm space-y-3">
+      {(Object.keys(agents) as AgentName[]).map((name) =>
+        renderAgent(name, agents[name])
+      )}
+    </ul>
+  );
+};
 
 export default AgentSummary;
+

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import AnimatedConfidenceBar from './AnimatedConfidenceBar';
 import TeamBadge from './TeamBadge';
+import AgentSummary from './AgentSummary';
+import { AgentOutputs } from '../lib/types';
 
 export type MatchupProps = {
   teamA: string;
@@ -9,6 +11,7 @@ export type MatchupProps = {
     winner: string;
     confidence: number;
     topReasons: string[];
+    agents: AgentOutputs;
   };
   onRerun?: () => void;
   loading?: boolean;
@@ -69,13 +72,7 @@ const MatchupCard: React.FC<MatchupProps> = ({
           <span className="mt-2 inline-block px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded text-xs">🟡 Toss-Up</span>
         )}
       </div>
-      {open && (
-        <ul className="mt-2 list-disc list-inside text-sm space-y-1">
-          {result.topReasons.slice(0, 3).map((reason, idx) => (
-            <li key={idx}>{reason}</li>
-          ))}
-        </ul>
-      )}
+      {open && <AgentSummary agents={result.agents} />}
     </div>
   );
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,10 @@ export interface AgentResult {
   reason: string;
 }
 
+export type AgentName = 'injuryScout' | 'lineWatcher' | 'statCruncher';
+
+export type AgentOutputs = Record<AgentName, AgentResult>;
+
 export interface PickResult {
   pick: string;
   confidence: number;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import MatchupCard from '../components/MatchupCard';
+import { AgentOutputs } from '../lib/types';
 
 type Matchup = {
   teamA: string;
@@ -13,10 +14,14 @@ const matchups: Matchup[] = [
   { teamA: 'Chiefs', teamB: 'Bills', week: 1 },
 ];
 
-type PickResult = {
+type PickSummary = {
   winner: string;
   confidence: number;
   topReasons: string[];
+};
+
+type PickResult = PickSummary & {
+  agents: AgentOutputs;
 };
 
 const MatchupFetcher: React.FC<Matchup> = ({ teamA, teamB, week }) => {
@@ -33,11 +38,12 @@ const MatchupFetcher: React.FC<Matchup> = ({ teamA, teamB, week }) => {
       );
       if (!res.ok) throw new Error('Network error');
       const data = await res.json();
-      const pick = data.pick ?? data;
+      const pick: PickSummary = data.pick ?? data;
+      const agents: AgentOutputs = data.agents ?? {};
       if (!pick || !pick.winner) {
         setError('Insufficient data');
       } else {
-        setResult(pick as PickResult);
+        setResult({ ...pick, agents });
       }
     } catch (e) {
       setError('Error loading pick');


### PR DESCRIPTION
## Summary
- expand `AgentSummary` to surface each agent's name, weight, score, and rationale with a visual confidence bar
- wire `AgentSummary` into `MatchupCard` and homepage to display per-agent insights
- add shared typings for agent names and outputs

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689245de43d483239233648b29000244