### PR TITLE
Log agent runs to Supabase

### DIFF
--- a/lib/logToSupabase.ts
+++ b/lib/logToSupabase.ts
@@ -1,0 +1,22 @@
+import { getSupabaseClient } from './supabaseClient';
+import { AgentOutputs, Matchup, PickSummary } from './types';
+
+export async function logToSupabase(
+  matchup: Matchup,
+  agents: AgentOutputs,
+  pick: PickSummary
+): Promise<void> {
+  const client = getSupabaseClient();
+  const { error } = await client.from('matchups').insert({
+    team_a: matchup.homeTeam,
+    team_b: matchup.awayTeam,
+    week: matchup.week,
+    agents,
+    pick,
+    created_at: new Date().toISOString(),
+  });
+
+  if (error) {
+    console.error('Error inserting matchup log:', error);
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,6 +14,12 @@ export type AgentName = 'injuryScout' | 'lineWatcher' | 'statCruncher';
 
 export type AgentOutputs = Record<AgentName, AgentResult>;
 
+export interface PickSummary {
+  winner: string;
+  confidence: number;
+  topReasons: string[];
+}
+
 export const displayNames: Record<AgentName, string> = {
   injuryScout: 'InjuryScout',
   lineWatcher: 'LineWatcher',


### PR DESCRIPTION
## Summary
- add PickSummary type to share agent result summary
- add `logToSupabase` helper for inserting matchups and picks
- record each run in `pages/api/run-agents` without altering response

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68924b9574a88323b419862816e256ea