### PR TITLE
Add agent explanation glossary modal

### DIFF
--- a/components/ExplanationGlossary.tsx
+++ b/components/ExplanationGlossary.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+type Props = {
+  onClose: () => void;
+};
+
+const ExplanationGlossary: React.FC<Props> = ({ onClose }) => {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded-lg shadow-lg p-6 max-w-md w-full">
+        <h2 className="text-xl font-semibold mb-4">Agent Glossary</h2>
+        <ul className="space-y-3 text-sm text-gray-700">
+          <li>
+            <strong>InjuryScout</strong>: evaluates player injury reports and roster depth to assess how absences could sway the matchup.
+          </li>
+          <li>
+            <strong>LineWatcher</strong>: monitors betting line movement to reflect the market's confidence in each team.
+          </li>
+          <li>
+            <strong>StatCruncher</strong>: favors efficiency metrics, defensive strength, and other advanced stats to compare teams.
+          </li>
+        </ul>
+        <button
+          onClick={onClose}
+          className="mt-6 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ExplanationGlossary;
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import MatchupCard from '../components/MatchupCard';
+import ExplanationGlossary from '../components/ExplanationGlossary';
 import { AgentOutputs } from '../lib/types';
 
 type Matchup = {
@@ -89,19 +90,35 @@ const MatchupFetcher: React.FC<Matchup> = ({ teamA, teamB, week }) => {
   );
 };
 
-const HomePage: React.FC = () => (
-  <main className="min-h-screen bg-gray-50 p-6">
-    <header className="text-center mb-8">
-      <h1 className="text-3xl font-mono font-bold">EdgePicks – AI NFL Matchup Insights</h1>
-      <p className="text-gray-600">Updated weekly. Powered by modular agents.</p>
-    </header>
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      {matchups.map((m, idx) => (
-        <MatchupFetcher key={idx} {...m} />
-      ))}
-    </div>
-  </main>
-);
+const HomePage: React.FC = () => {
+  const [showGlossary, setShowGlossary] = useState(false);
+
+  return (
+    <main className="min-h-screen bg-gray-50 p-6">
+      <header className="text-center mb-8">
+        <h1 className="text-3xl font-mono font-bold">EdgePicks – AI NFL Matchup Insights</h1>
+        <p className="text-gray-600">Updated weekly. Powered by modular agents.</p>
+        <button
+          onClick={() => setShowGlossary(true)}
+          className="mt-2 mx-auto flex items-center text-blue-600 hover:text-blue-800"
+        >
+          <span className="w-5 h-5 flex items-center justify-center border border-blue-600 rounded-full text-xs font-bold mr-2">
+            ?
+          </span>
+          <span className="underline">What powers these picks?</span>
+        </button>
+      </header>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {matchups.map((m, idx) => (
+          <MatchupFetcher key={idx} {...m} />
+        ))}
+      </div>
+      {showGlossary && (
+        <ExplanationGlossary onClose={() => setShowGlossary(false)} />
+      )}
+    </main>
+  );
+};
 
 export default HomePage;
 


### PR DESCRIPTION
## Summary
- add ExplanationGlossary component describing InjuryScout, LineWatcher, and StatCruncher agents
- show “What powers these picks?” button with ? icon on the homepage to open the glossary modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68924e1b8bdc8323b20a41feb3395e77