### PR TITLE
Add agent comparison panel

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import ScoreBar from './ScoreBar';
+import { AgentName, AgentResult, displayNames } from '../lib/types';
+
+interface Props {
+  name: AgentName;
+  result: AgentResult;
+  weight?: number;
+  showWeight?: boolean;
+  showTeam?: boolean;
+  className?: string;
+}
+
+const AgentCard: React.FC<Props> = ({
+  name,
+  result,
+  weight = 0,
+  showWeight = false,
+  showTeam = false,
+  className = '',
+}) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(true);
+  }, []);
+
+  const scorePct = Math.round(result.score * 100);
+  const weightPct = Math.round(weight * 100);
+
+  return (
+    <div
+      className={`p-3 bg-gray-50 rounded shadow-sm flex flex-col gap-2 transition-all duration-500 ease-out ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+      } ${className}`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="font-medium">{displayNames[name]}</span>
+        {showWeight && (
+          <span className="text-xs text-gray-500">{weightPct}% weight</span>
+        )}
+      </div>
+      {showTeam && (
+        <span className="text-sm text-gray-700">Favored: {result.team}</span>
+      )}
+      <div className="flex items-center gap-2">
+        <ScoreBar percent={scorePct} />
+        <span className="w-10 text-right font-mono text-sm">{result.score.toFixed(2)}</span>
+      </div>
+      <p className="text-xs text-gray-600">{result.reason}</p>
+    </div>
+  );
+};
+
+export default AgentCard;

--- a/components/AgentComparePanel.tsx
+++ b/components/AgentComparePanel.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import AgentCard from './AgentCard';
+import { AgentOutputs, AgentName } from '../lib/types';
+
+interface Props {
+  agents: AgentOutputs;
+}
+
+const AgentComparePanel: React.FC<Props> = ({ agents }) => {
+  return (
+    <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+      {(Object.keys(agents) as AgentName[]).map((name) => (
+        <AgentCard key={name} name={name} result={agents[name]} showTeam />
+      ))}
+    </div>
+  );
+};
+
+export default AgentComparePanel;

--- a/components/AgentDebugPanel.tsx
+++ b/components/AgentDebugPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
+import ScoreBar from './ScoreBar';
 import { AgentOutputs, AgentName, displayNames } from '../lib/types';
 
 type Props = {
@@ -7,12 +8,6 @@ type Props = {
 };
 
 const AgentDebugPanel: React.FC<Props> = ({ agents, weights }) => {
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
   return (
     <div className="overflow-x-auto">
       <table className="w-full table-auto text-sm">
@@ -37,12 +32,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents, weights }) => {
                 <td className="p-2 font-medium">{displayNames[name]}</td>
                 <td className="p-2">
                   <div className="flex items-center gap-2">
-                    <div className="flex-1 h-2 bg-gray-200 rounded">
-                      <div
-                        className="h-full bg-blue-500 rounded transition-all duration-500"
-                        style={{ width: mounted ? `${scorePct}%` : 0 }}
-                      />
-                    </div>
+                    <ScoreBar percent={scorePct} />
                     <span className="w-20 text-right font-mono">
                       {result.score.toFixed(2)} ({Math.round(scorePct)}%)
                     </span>
@@ -50,12 +40,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents, weights }) => {
                 </td>
                 <td className="p-2">
                   <div className="flex items-center gap-2">
-                    <div className="flex-1 h-2 bg-gray-200 rounded">
-                      <div
-                        className="h-full bg-green-500 rounded transition-all duration-500"
-                        style={{ width: mounted ? `${weightedPct}%` : 0 }}
-                      />
-                    </div>
+                    <ScoreBar percent={weightedPct} color="bg-green-500" />
                     <span className="w-20 text-right font-mono">
                       {weighted.toFixed(2)} ({Math.round(weightedPct)}%)
                     </span>

--- a/components/AgentSummary.tsx
+++ b/components/AgentSummary.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
-import { AgentOutputs, AgentName, AgentResult, displayNames } from '../lib/types';
+import React from 'react';
+import AgentCard from './AgentCard';
+import { AgentOutputs, AgentName } from '../lib/types';
 
 interface Props {
   agents: AgentOutputs;
@@ -12,52 +13,20 @@ const weights: Record<AgentName, number> = {
 };
 
 const AgentSummary: React.FC<Props> = ({ agents }) => {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    setVisible(true);
-  }, []);
-
-  const renderAgent = (name: AgentName, result: AgentResult) => {
-    const weight = weights[name];
-    const percent = Math.round(weight * 100);
-    const scorePct = Math.round(result.score * 100);
-
-    return (
-      <li
-        key={name}
-        className={`p-3 bg-gray-50 rounded shadow-sm flex flex-col sm:flex-row sm:items-center gap-2 transition-all duration-500 ease-out ${
-          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
-        }`}
-      >
-        <div className="flex-1">
-          <div className="flex items-center justify-between">
-            <span className="font-medium">{displayNames[name]}</span>
-            <span className="text-xs text-gray-500">{percent}% weight</span>
-          </div>
-          <p className="text-xs text-gray-600 mt-1">{result.reason}</p>
-        </div>
-        <div className="w-full sm:w-40 flex items-center gap-2">
-          <div className="flex-1 h-2 bg-gray-200 rounded">
-            <div
-              className="h-full bg-blue-500 rounded"
-              style={{ width: `${scorePct}%` }}
-            />
-          </div>
-          <span className="w-10 text-right font-mono text-sm">{result.score.toFixed(2)}</span>
-        </div>
-      </li>
-    );
-  };
-
   return (
     <ul className="mt-2 text-sm space-y-3">
-      {(Object.keys(agents) as AgentName[]).map((name) =>
-        renderAgent(name, agents[name])
-      )}
+      {(Object.keys(agents) as AgentName[]).map((name) => (
+        <li key={name}>
+          <AgentCard
+            name={name}
+            result={agents[name]}
+            weight={weights[name]}
+            showWeight
+          />
+        </li>
+      ))}
     </ul>
   );
 };
 
 export default AgentSummary;
-

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import AnimatedConfidenceBar from './AnimatedConfidenceBar';
 import TeamBadge from './TeamBadge';
 import AgentSummary from './AgentSummary';
+import AgentComparePanel from './AgentComparePanel';
 import { AgentOutputs, AgentName, displayNames } from '../lib/types';
 import { getContribution } from '../lib/utils';
 
@@ -80,6 +81,7 @@ const MatchupCard: React.FC<MatchupProps> = ({
   loading,
 }) => {
   const [open, setOpen] = useState(false);
+  const [compare, setCompare] = useState(false);
   const confidencePct = Math.round(result.confidence * 100);
   const winnerColor = result.winner === teamA ? 'text-blue-600' : 'text-red-600';
 
@@ -109,6 +111,12 @@ const MatchupCard: React.FC<MatchupProps> = ({
           )}
           <button
             className="min-h-[44px] px-3 py-1 text-sm text-blue-600 underline"
+            onClick={() => setCompare((c) => !c)}
+          >
+            {compare ? 'Hide' : 'Compare Agents'}
+          </button>
+          <button
+            className="min-h-[44px] px-3 py-1 text-sm text-blue-600 underline"
             onClick={() => setOpen((o) => !o)}
           >
             {open ? 'Hide' : 'Why?'}
@@ -127,6 +135,7 @@ const MatchupCard: React.FC<MatchupProps> = ({
           <span className="mt-2 inline-block px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded text-xs">🟡 Toss-Up</span>
         )}
       </div>
+      {compare && <AgentComparePanel agents={result.agents} />}
       {open && (
         <>
           <AgentSummary agents={result.agents} />

--- a/components/ScoreBar.tsx
+++ b/components/ScoreBar.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+  percent: number; // 0-100
+  color?: string;
+}
+
+const ScoreBar: React.FC<Props> = ({ percent, color = 'bg-blue-500' }) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    <div className="flex-1 h-2 bg-gray-200 rounded">
+      <div
+        className={`h-full ${color} rounded transition-all duration-500`}
+        style={{ width: mounted ? `${percent}%` : 0 }}
+      />
+    </div>
+  );
+};
+
+export default ScoreBar;


### PR DESCRIPTION
## Summary
- add reusable `AgentCard` and `ScoreBar` components
- allow MatchupCard to toggle a Compare Agents panel
- unify agent debug rendering with shared progress bar

## Testing
- `npm test`
- `npm run build` *(fails: You cannot `@apply` the `dark:text-gray-400` utility here because it creates a circular dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68924e0fa3d08323b6f524edc4fa65de