### PR TITLE
feat: add loading and empty states

### DIFF
--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,5 +1,4 @@
-import { GetServerSideProps } from 'next';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { AgentName, AgentOutputs, displayNames } from '../lib/types';
 import { getSupabaseClient } from '../lib/supabaseClient';
 
@@ -14,67 +13,75 @@ interface MatchupRow {
   };
 }
 
-interface HistoryProps {
-  matchups: MatchupRow[];
-}
+const HistoryPage: React.FC = () => {
+  const [matchups, setMatchups] = useState<MatchupRow[]>([]);
+  const [loading, setLoading] = useState(true);
 
-const HistoryPage: React.FC<HistoryProps> = ({ matchups }) => {
+  useEffect(() => {
+    const fetchMatchups = async () => {
+      const client = getSupabaseClient();
+      const { data, error } = await client
+        .from('matchups')
+        .select('*')
+        .order('created_at', { ascending: false });
+
+      if (error || !data) {
+        console.error('Error fetching matchups', error);
+        setMatchups([]);
+      } else {
+        setMatchups(data as MatchupRow[]);
+      }
+      setLoading(false);
+    };
+
+    fetchMatchups();
+  }, []);
+
   return (
     <main className="min-h-screen bg-gray-50 p-6" suppressHydrationWarning>
       <header className="text-center mb-8">
         <h1 className="text-3xl font-mono font-bold">Matchup History</h1>
         <p className="text-gray-600">Previous agent predictions</p>
       </header>
-      <div className="space-y-6 max-w-3xl mx-auto">
-        {matchups.map((m) => (
-          <div key={m.id} className="bg-white rounded-lg shadow p-6">
-            <h3 className="font-semibold mb-4">
-              {m.team_a} <span className="text-gray-400">vs</span> {m.team_b}
-            </h3>
-            <ul className="space-y-3 mb-4 text-sm">
-              {(Object.keys(m.agents) as AgentName[]).map((name) => {
-                const result = m.agents[name];
-                return (
-                  <li key={name} className="p-3 bg-gray-50 rounded">
-                    <div className="font-medium">
-                      {displayNames[name]}: {result.team}
-                    </div>
-                    <div className="text-xs text-gray-600">
-                      Score: {result.score.toFixed(2)} – {result.reason}
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-            <div className="text-sm">
-              <span className="font-medium">Winner:</span> {m.pick.winner}
-              <span className="ml-2 font-medium">Confidence:</span>{' '}
-              {Math.round(m.pick.confidence * 100)}%
+      {loading ? (
+        <div className="flex items-center justify-center h-64">
+          <div className="h-12 w-12 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+        </div>
+      ) : matchups.length === 0 ? (
+        <p className="text-center text-gray-600">No matchups logged yet</p>
+      ) : (
+        <div className="space-y-6 max-w-3xl mx-auto">
+          {matchups.map((m) => (
+            <div key={m.id} className="bg-white rounded-lg shadow p-6">
+              <h3 className="font-semibold mb-4">
+                {m.team_a} <span className="text-gray-400">vs</span> {m.team_b}
+              </h3>
+              <ul className="space-y-3 mb-4 text-sm">
+                {(Object.keys(m.agents) as AgentName[]).map((name) => {
+                  const result = m.agents[name];
+                  return (
+                    <li key={name} className="p-3 bg-gray-50 rounded">
+                      <div className="font-medium">
+                        {displayNames[name]}: {result.team}
+                      </div>
+                      <div className="text-xs text-gray-600">
+                        Score: {result.score.toFixed(2)} – {result.reason}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="text-sm">
+                <span className="font-medium">Winner:</span> {m.pick.winner}
+                <span className="ml-2 font-medium">Confidence:</span>{' '}
+                {Math.round(m.pick.confidence * 100)}%
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </main>
   );
-};
-
-export const getServerSideProps: GetServerSideProps<HistoryProps> = async () => {
-  const client = getSupabaseClient();
-  const { data, error } = await client
-    .from('matchups')
-    .select('*')
-    .order('created_at', { ascending: false });
-
-  if (error || !data) {
-    console.error('Error fetching matchups', error);
-    return { props: { matchups: [] } };
-  }
-
-  return {
-    props: {
-      matchups: data as MatchupRow[],
-    },
-  };
 };
 
 export default HistoryPage;

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import type { GetServerSideProps } from 'next';
+import React, { useEffect, useState } from 'react';
 import { getSupabaseClient } from '../lib/supabaseClient';
 import { AgentName, AgentOutputs, displayNames } from '../lib/types';
 
@@ -10,93 +9,109 @@ interface AgentStats {
   accuracy: number;
 }
 
-interface LeaderboardProps {
-  stats: AgentStats[];
-}
-
 const agentIcons: Record<AgentName, string> = {
   injuryScout: '🩺',
   lineWatcher: '📈',
   statCruncher: '📊',
 };
 
-const LeaderboardPage: React.FC<LeaderboardProps> = ({ stats }) => (
-  <main className="min-h-screen bg-gray-50 p-6" suppressHydrationWarning>
-    <header className="text-center mb-8">
-      <h1 className="text-3xl font-mono font-bold">Agent Leaderboard</h1>
-      <p className="text-gray-600">Accuracy of agent predictions</p>
-    </header>
-    <div className="max-w-2xl mx-auto space-y-4">
-      {stats.map((s, idx) => (
-        <div key={s.name} className="bg-white rounded-lg shadow p-4">
-          <div className="flex items-center mb-2">
-            <span className="w-6 text-lg font-bold">{idx + 1}</span>
-            <span className="text-2xl mr-2">{agentIcons[s.name]}</span>
-            <span className="font-semibold">{displayNames[s.name]}</span>
-            <span className="ml-auto text-sm text-gray-500">
-              {s.correct}/{s.total}
-            </span>
-          </div>
-          <div className="w-full bg-gray-200 rounded h-4">
-            <div
-              className="h-4 bg-blue-500 rounded"
-              style={{ width: `${s.accuracy}%` }}
-            />
-          </div>
-          <div className="text-right text-sm text-gray-600 mt-1">
-            {s.accuracy.toFixed(1)}%
-          </div>
-        </div>
-      ))}
-    </div>
-  </main>
-);
+const LeaderboardPage: React.FC = () => {
+  const [stats, setStats] = useState<AgentStats[]>([]);
+  const [loading, setLoading] = useState(true);
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  const client = getSupabaseClient();
-  const { data, error } = await client
-    .from('matchups')
-    .select('agents, winner, pick');
+  useEffect(() => {
+    const fetchStats = async () => {
+      const client = getSupabaseClient();
+      const { data, error } = await client
+        .from('matchups')
+        .select('agents, winner, pick');
 
-  if (error || !data) {
-    console.error('Error fetching leaderboard data:', error);
-    return { props: { stats: [] } };
-  }
-
-  const tallies: Record<AgentName, { correct: number; total: number }> = {
-    injuryScout: { correct: 0, total: 0 },
-    lineWatcher: { correct: 0, total: 0 },
-    statCruncher: { correct: 0, total: 0 },
-  };
-
-  data.forEach((row: { agents: AgentOutputs; winner?: string; pick?: { winner?: string } }) => {
-    const actualWinner = row.winner || row.pick?.winner;
-    if (!actualWinner || !row.agents) return;
-
-    (Object.keys(tallies) as AgentName[]).forEach((name) => {
-      const agentPick = row.agents[name]?.team;
-      if (agentPick) {
-        tallies[name].total += 1;
-        if (agentPick === actualWinner) {
-          tallies[name].correct += 1;
-        }
+      if (error || !data) {
+        console.error('Error fetching leaderboard data:', error);
+        setStats([]);
+        setLoading(false);
+        return;
       }
-    });
-  });
 
-  const stats: AgentStats[] = (Object.keys(tallies) as AgentName[])
-    .map((name) => {
-      const { correct, total } = tallies[name];
-      return {
-        name,
-        correct,
-        total,
-        accuracy: total > 0 ? (correct / total) * 100 : 0,
+      const tallies: Record<AgentName, { correct: number; total: number }> = {
+        injuryScout: { correct: 0, total: 0 },
+        lineWatcher: { correct: 0, total: 0 },
+        statCruncher: { correct: 0, total: 0 },
       };
-    })
-    .sort((a, b) => b.accuracy - a.accuracy);
 
-  return { props: { stats } };
+      data.forEach((row: { agents: AgentOutputs; winner?: string; pick?: { winner?: string } }) => {
+        const actualWinner = row.winner || row.pick?.winner;
+        if (!actualWinner || !row.agents) return;
+
+        (Object.keys(tallies) as AgentName[]).forEach((name) => {
+          const agentPick = row.agents[name]?.team;
+          if (agentPick) {
+            tallies[name].total += 1;
+            if (agentPick === actualWinner) {
+              tallies[name].correct += 1;
+            }
+          }
+        });
+      });
+
+      const computed: AgentStats[] = (Object.keys(tallies) as AgentName[])
+        .map((name) => {
+          const { correct, total } = tallies[name];
+          return {
+            name,
+            correct,
+            total,
+            accuracy: total > 0 ? (correct / total) * 100 : 0,
+          };
+        })
+        .sort((a, b) => b.accuracy - a.accuracy);
+
+      setStats(computed);
+      setLoading(false);
+    };
+
+    fetchStats();
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-gray-50 p-6" suppressHydrationWarning>
+      <header className="text-center mb-8">
+        <h1 className="text-3xl font-mono font-bold">Agent Leaderboard</h1>
+        <p className="text-gray-600">Accuracy of agent predictions</p>
+      </header>
+      {loading ? (
+        <div className="flex items-center justify-center h-64">
+          <div className="h-12 w-12 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+        </div>
+      ) : stats.length === 0 ? (
+        <p className="text-center text-gray-600">No data available</p>
+      ) : (
+        <div className="max-w-2xl mx-auto space-y-4">
+          {stats.map((s, idx) => (
+            <div key={s.name} className="bg-white rounded-lg shadow p-4">
+              <div className="flex items-center mb-2">
+                <span className="w-6 text-lg font-bold">{idx + 1}</span>
+                <span className="text-2xl mr-2">{agentIcons[s.name]}</span>
+                <span className="font-semibold">{displayNames[s.name]}</span>
+                <span className="ml-auto text-sm text-gray-500">
+                  {s.correct}/{s.total}
+                </span>
+              </div>
+              <div className="w-full bg-gray-200 rounded h-4">
+                <div
+                  className="h-4 bg-blue-500 rounded"
+                  style={{ width: `${s.accuracy}%` }}
+                />
+              </div>
+              <div className="text-right text-sm text-gray-600 mt-1">
+                {s.accuracy.toFixed(1)}%
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  );
 };
 
 export default LeaderboardPage;


### PR DESCRIPTION
## Summary
- show centered spinner while matchups and leaderboard stats load
- surface user-friendly messages when no matchups or stats are found

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689255303f7c832384f0d44d8727be63