### PR TITLE
feat: add responsive agent debug cards

### DIFF
--- a/components/AgentDebugPanel.tsx
+++ b/components/AgentDebugPanel.tsx
@@ -8,50 +8,91 @@ type Props = {
 };
 
 const AgentDebugPanel: React.FC<Props> = ({ agents, weights }) => {
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full table-auto text-sm">
-        <thead>
-          <tr className="text-left">
-            <th className="p-2">Agent</th>
-            <th className="p-2">Score</th>
-            <th className="p-2">Weighted</th>
-            <th className="p-2">Reason</th>
-          </tr>
-        </thead>
-        <tbody>
-          {(Object.keys(agents) as AgentName[]).map((name) => {
-            const result = agents[name];
-            const weight = weights[name] ?? 0;
-            const scorePct = result.score * 100;
-            const weighted = result.score * weight;
-            const weightedPct = weighted * 100;
+  const entries = Object.keys(agents) as AgentName[];
 
-            return (
-              <tr key={name} className="border-t">
-                <td className="p-2 font-medium">{displayNames[name]}</td>
-                <td className="p-2">
-                  <div className="flex items-center gap-2">
-                    <ScoreBar percent={scorePct} />
-                    <span className="w-20 text-right font-mono">
-                      {result.score.toFixed(2)} ({Math.round(scorePct)}%)
-                    </span>
-                  </div>
-                </td>
-                <td className="p-2">
-                  <div className="flex items-center gap-2">
-                    <ScoreBar percent={weightedPct} color="bg-green-500" />
-                    <span className="w-20 text-right font-mono">
-                      {weighted.toFixed(2)} ({Math.round(weightedPct)}%)
-                    </span>
-                  </div>
-                </td>
-                <td className="p-2 text-xs text-gray-600">{result.reason}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+  return (
+    <div>
+      <div className="space-y-4 sm:hidden">
+        {entries.map((name) => {
+          const result = agents[name];
+          const weight = weights[name] ?? 0;
+          const scorePct = result.score * 100;
+          const weighted = result.score * weight;
+          const weightedPct = weighted * 100;
+
+          return (
+            <div key={name} className="border rounded p-4">
+              <div className="font-medium">{displayNames[name]}</div>
+              <div className="mt-2">
+                <ScoreBar percent={scorePct} className="w-full" />
+                <div className="mt-1 font-mono text-sm">
+                  {result.score.toFixed(2)} ({Math.round(scorePct)}%)
+                </div>
+              </div>
+              <div className="mt-2">
+                <ScoreBar
+                  percent={weightedPct}
+                  color="bg-green-500"
+                  className="w-full"
+                />
+                <div className="mt-1 font-mono text-sm">
+                  {weighted.toFixed(2)} ({Math.round(weightedPct)}%)
+                </div>
+              </div>
+              <div className="mt-2 text-xs text-gray-600 break-words">
+                {result.reason}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="overflow-x-auto hidden sm:block">
+        <table className="w-full table-auto text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Agent</th>
+              <th className="p-2">Score</th>
+              <th className="p-2">Weighted</th>
+              <th className="p-2">Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((name) => {
+              const result = agents[name];
+              const weight = weights[name] ?? 0;
+              const scorePct = result.score * 100;
+              const weighted = result.score * weight;
+              const weightedPct = weighted * 100;
+
+              return (
+                <tr key={name} className="border-t">
+                  <td className="p-2 font-medium">{displayNames[name]}</td>
+                  <td className="p-2">
+                    <div className="flex items-center gap-2">
+                      <ScoreBar percent={scorePct} />
+                      <span className="w-20 text-right font-mono">
+                        {result.score.toFixed(2)} ({Math.round(scorePct)}%)
+                      </span>
+                    </div>
+                  </td>
+                  <td className="p-2">
+                    <div className="flex items-center gap-2">
+                      <ScoreBar percent={weightedPct} color="bg-green-500" />
+                      <span className="w-20 text-right font-mono">
+                        {weighted.toFixed(2)} ({Math.round(weightedPct)}%)
+                      </span>
+                    </div>
+                  </td>
+                  <td className="p-2 text-xs text-gray-600 break-words">
+                    {result.reason}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };

--- a/components/ScoreBar.tsx
+++ b/components/ScoreBar.tsx
@@ -16,7 +16,9 @@ const ScoreBar: React.FC<Props> = ({ percent, color = 'bg-blue-500', className }
 
   return (
     <div
-      className={`flex-1 h-2 bg-gray-200 rounded overflow-hidden ${className || ''}`}
+      className={`flex-1 min-w-0 h-2 bg-gray-200 rounded overflow-hidden ${
+        className || ''
+      }`}
     >
       <div
         className={`h-full ${color} transition-all duration-500 ease-out`}


### PR DESCRIPTION
## Summary
- show agent debug info in stacked cards on small screens
- allow ScoreBar to shrink to narrow widths

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68925525aefc8323a8e74031f8aa5b7b