### PR TITLE
Add persistent theme toggle

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+const storageKey = 'theme';
+
+const ThemeToggle: React.FC = () => {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setIsDark(document.documentElement.classList.contains('dark'));
+  }, []);
+
+  const toggleTheme = () => {
+    const html = document.documentElement;
+    const next = html.classList.toggle('dark');
+    localStorage.setItem(storageKey, next ? 'dark' : 'light');
+    setIsDark(next);
+  };
+
+  return (
+    <button onClick={toggleTheme} aria-label="Toggle dark mode">
+      {isDark ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default ThemeToggle;
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,16 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
+import ThemeToggle from '../components/ThemeToggle';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <header className="p-4 flex justify-end">
+        <ThemeToggle />
+      </header>
+      <Component {...pageProps} />
+    </>
+  );
 }
 
 export default MyApp;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,31 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var storageKey = 'theme';
+                  var stored = localStorage.getItem(storageKey);
+                  var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                  if (stored === 'dark' || (!stored && prefersDark)) {
+                    document.documentElement.classList.add('dark');
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ThemeToggle component to toggle dark mode and persist preference
- include theme toggle in global header
- set initial theme based on stored preference or system setting

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68925516cd888323961fb0bbd652f9f5