### PR TITLE
feat: rename week param to match day

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Current agents include:
 
 Run all agents for a matchup via:
 
-GET /api/run-agents?teamA=<team>&teamB=<team>&week=<number>
+GET /api/run-agents?teamA=<team>&teamB=<team>&matchDay=<number>
 
 yaml
 Copy
@@ -64,7 +64,7 @@ You can find these values in your Supabase dashboard under **Project Settings â†
 npm install             # install dependencies
 npm run dev             # start dev server (localhost:3000)
 
-curl "http://localhost:3000/api/run-agents?teamA=BOS&teamB=LAL&week=1" # sample multi-sport matchup request
+curl "http://localhost:3000/api/run-agents?teamA=BOS&teamB=LAL&matchDay=1" # sample multi-sport matchup request
 ```
 
 ðŸ§± Adding New Agents or Data Sources

--- a/codex-prompts/run-agents-prompt.md
+++ b/codex-prompts/run-agents-prompt.md
@@ -2,10 +2,10 @@
 Create an API route that runs the EdgePicks agent pipeline for a given NFL matchup. This route gathers data from InjuryScout, LineWatcher, and StatCruncher, processes them with PickBot, and returns a complete pick with confidence and reasoning.
 
 # API Endpoint
-`GET /api/run-agents?teamA=49ers&teamB=Cowboys&week=1`
+`GET /api/run-agents?teamA=49ers&teamB=Cowboys&matchDay=1`
 
 # Responsibilities
-1. Accept teamA, teamB, week from query params  
+1. Accept teamA, teamB, matchDay from query params
 2. Call each modular agent:  
    - `injuryScout(matchup)`  
    - `lineWatcher(matchup)`  

--- a/components/MatchupInputForm.tsx
+++ b/components/MatchupInputForm.tsx
@@ -7,19 +7,19 @@ export type Props = {
 const MatchupInputForm: React.FC<Props> = ({ onResult }) => {
   const [teamA, setTeamA] = useState('');
   const [teamB, setTeamB] = useState('');
-  const [week, setWeek] = useState('');
+  const [matchDay, setMatchDay] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!teamA || !teamB || !week) {
+    if (!teamA || !teamB || !matchDay) {
       setError('All fields are required');
       return;
     }
-    const weekNum = parseInt(week, 10);
-    if (isNaN(weekNum)) {
-      setError('Week must be a number');
+    const matchDayNum = parseInt(matchDay, 10);
+    if (isNaN(matchDayNum)) {
+      setError('Match day must be a number');
       return;
     }
 
@@ -27,11 +27,11 @@ const MatchupInputForm: React.FC<Props> = ({ onResult }) => {
     setLoading(true);
     try {
       const res = await fetch(
-        `/api/run-agents?teamA=${encodeURIComponent(teamA)}&teamB=${encodeURIComponent(teamB)}&week=${weekNum}`
+        `/api/run-agents?teamA=${encodeURIComponent(teamA)}&teamB=${encodeURIComponent(teamB)}&matchDay=${matchDayNum}`
       );
       if (!res.ok) throw new Error('Network error');
       const data = await res.json();
-      onResult({ ...data, teamA, teamB, week: weekNum });
+      onResult({ ...data, teamA, teamB, matchDay: matchDayNum });
     } catch (e) {
       setError('Failed to fetch result');
     } finally {
@@ -46,7 +46,7 @@ const MatchupInputForm: React.FC<Props> = ({ onResult }) => {
     >
       <div className="flex-1">
         <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="teamA">
-          Team A
+          Team/Player A
         </label>
         <input
           id="teamA"
@@ -55,11 +55,12 @@ const MatchupInputForm: React.FC<Props> = ({ onResult }) => {
           value={teamA}
           onChange={(e) => setTeamA(e.target.value)}
           disabled={loading}
+          placeholder="e.g., BOS or Federer"
         />
       </div>
       <div className="flex-1">
         <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="teamB">
-          Team B
+          Team/Player B
         </label>
         <input
           id="teamB"
@@ -68,19 +69,21 @@ const MatchupInputForm: React.FC<Props> = ({ onResult }) => {
           value={teamB}
           onChange={(e) => setTeamB(e.target.value)}
           disabled={loading}
+          placeholder="e.g., LAL or Nadal"
         />
       </div>
       <div className="w-full sm:w-24">
-        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="week">
-          Week
+        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="matchDay">
+          Match Day
         </label>
         <input
-          id="week"
+          id="matchDay"
           type="number"
           className="w-full border rounded px-3 py-2"
-          value={week}
-          onChange={(e) => setWeek(e.target.value)}
+          value={matchDay}
+          onChange={(e) => setMatchDay(e.target.value)}
           disabled={loading}
+          placeholder="e.g., 1"
         />
       </div>
       <div className="sm:self-end">

--- a/lib/logToSupabase.ts
+++ b/lib/logToSupabase.ts
@@ -11,7 +11,7 @@ export async function logToSupabase(
   const { error } = await client.from('matchups').insert({
     team_a: matchup.homeTeam,
     team_b: matchup.awayTeam,
-    week: matchup.week,
+    match_day: matchup.matchDay,
     agents,
     pick,
     created_at: loggedAt,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 export interface Matchup {
   homeTeam: string;
   awayTeam: string;
-  week?: number;
+  matchDay?: number;
 }
 
 export interface AgentResult {

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -6,20 +6,20 @@ import { AgentResult, AgentOutputs, Matchup, PickSummary } from '../../lib/types
 import { logToSupabase } from '../../lib/logToSupabase';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { teamA, teamB, week } = req.query;
+  const { teamA, teamB, matchDay } = req.query;
 
-  if (typeof teamA !== 'string' || typeof teamB !== 'string' || typeof week !== 'string') {
-    res.status(400).json({ error: 'teamA, teamB, and week query params are required' });
+  if (typeof teamA !== 'string' || typeof teamB !== 'string' || typeof matchDay !== 'string') {
+    res.status(400).json({ error: 'teamA, teamB, and matchDay query params are required' });
     return;
   }
 
-  const weekNum = parseInt(week, 10);
-  if (isNaN(weekNum)) {
-    res.status(400).json({ error: 'week must be a number' });
+  const matchDayNum = parseInt(matchDay, 10);
+  if (isNaN(matchDayNum)) {
+    res.status(400).json({ error: 'matchDay must be a number' });
     return;
   }
 
-  const matchup: Matchup = { homeTeam: teamA, awayTeam: teamB, week: weekNum };
+  const matchup: Matchup = { homeTeam: teamA, awayTeam: teamB, matchDay: matchDayNum };
 
   const [injury, line, stats] = await Promise.all([
     injuryScout(matchup),

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ import { AgentOutputs, AgentName } from '../lib/types';
 interface ResultPayload {
   teamA: string;
   teamB: string;
-  week: number;
+  matchDay: number;
   agents: AgentOutputs;
   pick: {
     winner: string;


### PR DESCRIPTION
## Summary
- rename week fields to matchDay across types, form, and API
- clarify form labels and placeholders for cross-sport inputs
- update documentation and Supabase logging to use matchDay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689256e2fae88323a292d15729fd4f0e