### PR TITLE
Stream agent results via SSE

### DIFF
--- a/components/AgentDebugPanel.tsx
+++ b/components/AgentDebugPanel.tsx
@@ -5,17 +5,24 @@ import { agents as agentRegistry } from '../lib/agents/registry';
 import { formatAgentName } from '../lib/utils';
 
 type Props = {
-  agents: AgentOutputs;
+  agents: Partial<AgentOutputs>;
 };
 
 const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
-
   return (
     <div>
       <div className="space-y-4 sm:hidden">
         {agentRegistry.map(({ name, weight }) => {
           const result = agents[name];
           const display = formatAgentName(name);
+          if (!result) {
+            return (
+              <div key={name} className="border rounded p-4">
+                <div className="font-medium">{display}</div>
+                <div className="mt-2 text-sm text-gray-500">Loading...</div>
+              </div>
+            );
+          }
           const scorePct = result.score * 100;
           const weighted = result.score * weight;
           const weightedPct = weighted * 100;
@@ -61,6 +68,16 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
             {agentRegistry.map(({ name, weight }) => {
               const result = agents[name];
               const display = formatAgentName(name);
+              if (!result) {
+                return (
+                  <tr key={name} className="border-t">
+                    <td className="p-2 font-medium">{display}</td>
+                    <td className="p-2" colSpan={3}>
+                      <span className="text-gray-500">Loading...</span>
+                    </td>
+                  </tr>
+                );
+              }
               const scorePct = result.score * 100;
               const weighted = result.score * weight;
               const weightedPct = weighted * 100;

--- a/components/AgentSummary.tsx
+++ b/components/AgentSummary.tsx
@@ -4,17 +4,24 @@ import { AgentOutputs } from '../lib/types';
 import { agents as agentRegistry } from '../lib/agents/registry';
 
 interface Props {
-  agents: AgentOutputs;
+  agents: Partial<AgentOutputs>;
 }
 
 const AgentSummary: React.FC<Props> = ({ agents }) => {
   return (
     <ul className="mt-2 text-sm space-y-3">
-      {agentRegistry.map(({ name, weight }) => (
-        <li key={name}>
-          <AgentCard name={name} result={agents[name]} weight={weight} showWeight />
-        </li>
-      ))}
+      {agentRegistry.map(({ name, weight }) => {
+        const result = agents[name];
+        return (
+          <li key={name}>
+            {result ? (
+              <AgentCard name={name} result={result} weight={weight} showWeight />
+            ) : (
+              <div className="p-3 bg-gray-50 rounded shadow-sm text-gray-500">Loading...</div>
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
 };


### PR DESCRIPTION
## Summary
- stream each agent's result through an SSE API endpoint
- consume the SSE stream on the client to update state as results arrive
- show loading placeholders for agents until their output is received

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68925ab588d083239fbf6f28f3795360