### PR TITLE
Queue Supabase logs for retry and expose status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Returns:
 - Overall winner and confidence
 - Logs the outcome to Supabase (if configured)
 
+### Log Status Endpoint
+
+Monitor the in-memory log queue via:
+
+GET /api/log-status
+
+This returns the number of pending log entries and the last error encountered (if any).
+
 ---
 
 ## 🌐 Environment Variables

--- a/lib/logToSupabase.ts
+++ b/lib/logToSupabase.ts
@@ -1,25 +1,63 @@
 import { getSupabaseClient } from './supabaseClient';
 import { AgentOutputs, Matchup, PickSummary } from './types';
 
-export async function logToSupabase(
+type LogEntry = {
+  matchup: Matchup;
+  agents: AgentOutputs;
+  pick: PickSummary;
+  loggedAt: string;
+};
+
+const queue: LogEntry[] = [];
+let processing = false;
+let lastError: string | null = null;
+
+async function processQueue() {
+  if (processing || queue.length === 0) {
+    return;
+  }
+  processing = true;
+  const entry = queue.shift()!;
+  try {
+    const client = getSupabaseClient();
+    const { error } = await client.from('matchups').insert({
+      team_a: entry.matchup.homeTeam,
+      team_b: entry.matchup.awayTeam,
+      match_day: entry.matchup.matchDay,
+      agents: entry.agents,
+      pick: entry.pick,
+      created_at: entry.loggedAt,
+    });
+    if (error) {
+      throw error;
+    }
+    lastError = null;
+  } catch (err: any) {
+    console.error('Error inserting matchup log:', err);
+    lastError = err.message || String(err);
+    queue.push(entry);
+  } finally {
+    processing = false;
+    if (queue.length > 0) {
+      setImmediate(processQueue);
+    }
+  }
+}
+
+export function logToSupabase(
   matchup: Matchup,
   agents: AgentOutputs,
   pick: PickSummary,
   loggedAt: string = new Date().toISOString()
-): Promise<string> {
-  const client = getSupabaseClient();
-  const { error } = await client.from('matchups').insert({
-    team_a: matchup.homeTeam,
-    team_b: matchup.awayTeam,
-    match_day: matchup.matchDay,
-    agents,
-    pick,
-    created_at: loggedAt,
-  });
-
-  if (error) {
-    console.error('Error inserting matchup log:', error);
-  }
-
+): string {
+  queue.push({ matchup, agents, pick, loggedAt });
+  setImmediate(processQueue);
   return loggedAt;
+}
+
+export function getLogStatus() {
+  return {
+    pending: queue.length,
+    lastError,
+  };
 }

--- a/pages/api/log-status.ts
+++ b/pages/api/log-status.ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getLogStatus } from '../../lib/logToSupabase';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json(getLogStatus());
+}

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -59,7 +59,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     topReasons,
   };
 
-  const loggedAt = await logToSupabase(matchup, agentsOutput as AgentOutputs, pickSummary);
+  const loggedAt = logToSupabase(matchup, agentsOutput as AgentOutputs, pickSummary);
 
   res.write(
     `data: ${JSON.stringify({


### PR DESCRIPTION
## Summary
- enqueue Supabase log inserts and retry failures asynchronously
- return run-agents responses immediately
- add `/api/log-status` endpoint and docs for monitoring

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68925cc254b88323bc4191b7569221ca