### PR TITLE
feat: polish frontend ui for intelligence platform

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -31,7 +31,7 @@ const AgentCard: React.FC<Props> = ({
 
   return (
     <div
-      className={`p-3 bg-gray-50 rounded shadow-sm flex flex-col gap-2 transition-all duration-500 ease-out ${
+      className={`p-3 bg-gray-50 rounded shadow-sm flex flex-col gap-2 transition-all duration-500 ease-out hover:scale-[1.02] ${
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
       } ${className}`}
     >
@@ -48,7 +48,9 @@ const AgentCard: React.FC<Props> = ({
         <ScoreBar percent={scorePct} />
         <span className="w-10 text-right font-mono text-sm">{result.score.toFixed(2)}</span>
       </div>
-      <p className="text-xs text-gray-600">{result.reason}</p>
+      <p className="text-xs text-gray-600 truncate" title={result.reason}>
+        {result.reason}
+      </p>
     </div>
   );
 };

--- a/components/AgentDebugPanel.tsx
+++ b/components/AgentDebugPanel.tsx
@@ -4,6 +4,12 @@ import { AgentOutputs } from '../lib/types';
 import { agents as agentRegistry } from '../lib/agents/registry';
 import { formatAgentName } from '../lib/utils';
 
+const agentMeta: Record<string, { badge: string; about: string }> = {
+  injuryScout: { badge: '🏥 Injury', about: 'Tracks player injuries and availability.' },
+  lineWatcher: { badge: '📈 Line', about: 'Monitors betting line movement and market signals.' },
+  statCruncher: { badge: '🧠 Stat', about: 'Crunches historical statistics for trends.' },
+};
+
 type Props = {
   agents: Partial<AgentOutputs>;
 };
@@ -17,7 +23,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
           const display = formatAgentName(name);
           if (!result) {
             return (
-              <div key={name} className="border rounded p-4">
+              <div key={name} className="border rounded p-4 opacity-50">
                 <div className="font-medium">{display}</div>
                 <div className="mt-2 text-sm text-gray-500">Loading...</div>
               </div>
@@ -26,10 +32,17 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
           const scorePct = result.score * 100;
           const weighted = result.score * weight;
           const weightedPct = weighted * 100;
+          const meta = agentMeta[name];
 
           return (
-            <div key={name} className="border rounded p-4">
-              <div className="font-medium">{display}</div>
+            <div
+              key={name}
+              className="border rounded p-4 ring-1 ring-blue-500 transition hover:scale-[1.01]"
+            >
+              <div className="flex items-center justify-between">
+                <div className="font-medium">{display}</div>
+                <span className="text-xs px-2 py-0.5 bg-gray-200 rounded">{meta.badge}</span>
+              </div>
               <div className="mt-2">
                 <ScoreBar percent={scorePct} className="w-full" />
                 <div className="mt-1 font-mono text-sm">
@@ -46,9 +59,13 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
                   {weighted.toFixed(2)} ({Math.round(weightedPct)}%)
                 </div>
               </div>
-              <div className="mt-2 text-xs text-gray-600 break-words">
+              <div className="mt-2 text-xs text-gray-600 truncate" title={result.reason}>
                 {result.reason}
               </div>
+              <details className="mt-2 text-xs">
+                <summary className="cursor-pointer text-blue-600">About This Agent</summary>
+                <p className="mt-1">{meta.about}</p>
+              </details>
             </div>
           );
         })}
@@ -70,7 +87,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               const display = formatAgentName(name);
               if (!result) {
                 return (
-                  <tr key={name} className="border-t">
+                  <tr key={name} className="border-t opacity-50">
                     <td className="p-2 font-medium">{display}</td>
                     <td className="p-2" colSpan={3}>
                       <span className="text-gray-500">Loading...</span>
@@ -81,10 +98,14 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               const scorePct = result.score * 100;
               const weighted = result.score * weight;
               const weightedPct = weighted * 100;
+              const meta = agentMeta[name];
 
               return (
-                <tr key={name} className="border-t">
-                  <td className="p-2 font-medium">{display}</td>
+                <tr key={name} className="border-t ring-1 ring-blue-500">
+                  <td className="p-2 font-medium flex items-center gap-2">
+                    {display}
+                    <span className="text-xs px-2 py-0.5 bg-gray-200 rounded">{meta.badge}</span>
+                  </td>
                   <td className="p-2">
                     <div className="flex items-center gap-2">
                       <ScoreBar percent={scorePct} />
@@ -101,8 +122,12 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
                       </span>
                     </div>
                   </td>
-                  <td className="p-2 text-xs text-gray-600 break-words">
-                    {result.reason}
+                  <td className="p-2 text-xs text-gray-600 max-w-xs">
+                    <div className="truncate" title={result.reason}>{result.reason}</div>
+                    <details>
+                      <summary className="cursor-pointer text-blue-600">About This Agent</summary>
+                      <p className="mt-1">{meta.about}</p>
+                    </details>
                   </td>
                 </tr>
               );

--- a/components/AgentSummary.tsx
+++ b/components/AgentSummary.tsx
@@ -9,11 +9,11 @@ interface Props {
 
 const AgentSummary: React.FC<Props> = ({ agents }) => {
   return (
-    <ul className="mt-2 text-sm space-y-3">
+    <ul className="mt-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {agentRegistry.map(({ name, weight }) => {
         const result = agents[name];
         return (
-          <li key={name}>
+          <li key={name} className="list-none">
             {result ? (
               <AgentCard name={name} result={result} weight={weight} showWeight />
             ) : (

--- a/components/AnimatedConfidenceBar.tsx
+++ b/components/AnimatedConfidenceBar.tsx
@@ -35,24 +35,22 @@ const AnimatedConfidenceBar: React.FC<Props> = ({ confidence }) => {
     };
   }, [confidence]);
 
-  const barColor =
-    confidence >= 80
-      ? 'bg-green-500'
-      : confidence >= 55
-      ? 'bg-yellow-500'
-      : 'bg-red-500';
-
   return (
     <div aria-label={`Confidence ${confidence}%`}>
       <div className="flex justify-between items-center mb-1">
         <span className="font-semibold">Confidence</span>
         <span className="font-bold">{display}%</span>
       </div>
-      <div className="w-full h-2 bg-gray-200 rounded">
+      <div className="relative w-full h-3 bg-gray-200 rounded overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-r from-green-400 to-red-500 opacity-20 blur-sm animate-pulse" />
         <div
-          className={`h-full ${barColor} rounded transition-all duration-700 ease-in-out`}
+          className="relative h-full bg-gradient-to-r from-green-400 to-red-500 transition-[width] duration-700 ease-out"
           style={{ width: `${fill}%` }}
-        />
+        >
+          <span className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 bg-gray-800 text-white text-xs px-1 py-0.5 rounded shadow">
+            {display}%
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+interface Props {
+  showDebug: boolean;
+  onToggleDebug: () => void;
+}
+
+const Footer: React.FC<Props> = ({ showDebug, onToggleDebug }) => {
+  return (
+    <footer className="fixed bottom-0 left-0 w-full bg-white border-t shadow-sm">
+      <div className="container max-w-screen-xl mx-auto flex items-center justify-between p-2 text-xs sm:text-sm">
+        <div className="flex items-center gap-2">
+          <a
+            href="https://github.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 hover:opacity-80 transition"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12 2C6.477 2 2 6.484 2 12.012c0 4.424 2.865 8.181 6.839 9.504.5.092.682-.217.682-.483 0-.237-.009-.868-.014-1.703-2.782.605-3.369-1.34-3.369-1.34-.454-1.155-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.833.091-.647.35-1.088.636-1.338-2.221-.253-4.556-1.113-4.556-4.952 0-1.093.39-1.987 1.029-2.687-.103-.253-.446-1.27.098-2.646 0 0 .84-.269 2.75 1.026A9.564 9.564 0 0112 6.844a9.56 9.56 0 012.506.337c1.909-1.295 2.748-1.026 2.748-1.026.546 1.376.203 2.393.1 2.646.64.7 1.028 1.594 1.028 2.687 0 3.848-2.338 4.695-4.566 4.944.359.309.679.919.679 1.852 0 1.336-.012 2.415-.012 2.743 0 .268.18.58.688.482A10.013 10.013 0 0022 12.012C22 6.484 17.522 2 12 2z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <span>GitHub</span>
+          </a>
+          <a
+            href="https://vercel.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:opacity-80 transition"
+          >
+            <img src="/vercel.svg" alt="Vercel" className="h-4" />
+          </a>
+          <span className="hidden sm:inline">Built by modular AI agents</span>
+        </div>
+        <button
+          onClick={onToggleDebug}
+          className="px-2 py-1 border rounded hover:bg-gray-50 transition"
+        >
+          {showDebug ? 'Hide Debug' : '⚙️ Debug'}
+        </button>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/components/MatchupInputForm.tsx
+++ b/components/MatchupInputForm.tsx
@@ -74,9 +74,9 @@ const MatchupInputForm: React.FC<Props> = ({ onStart, onAgent, onComplete }) => 
   return (
     <form
       onSubmit={handleSubmit}
-      className="bg-white rounded-lg shadow p-4 sm:p-6 flex flex-col sm:flex-row sm:items-end gap-4"
+      className="bg-white rounded-lg shadow p-4 sm:p-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4"
     >
-      <div className="flex-1">
+      <div className="flex flex-col">
         <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="teamA">
           Team/Player A
         </label>
@@ -90,7 +90,7 @@ const MatchupInputForm: React.FC<Props> = ({ onStart, onAgent, onComplete }) => 
           placeholder="e.g., BOS or Federer"
         />
       </div>
-      <div className="flex-1">
+      <div className="flex flex-col">
         <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="teamB">
           Team/Player B
         </label>
@@ -104,7 +104,7 @@ const MatchupInputForm: React.FC<Props> = ({ onStart, onAgent, onComplete }) => 
           placeholder="e.g., LAL or Nadal"
         />
       </div>
-      <div className="w-full sm:w-24">
+      <div className="flex flex-col">
         <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="matchDay">
           Match Day
         </label>
@@ -121,14 +121,14 @@ const MatchupInputForm: React.FC<Props> = ({ onStart, onAgent, onComplete }) => 
       <div className="sm:self-end">
         <button
           type="submit"
-          className="min-h-[44px] px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          className="min-h-[44px] px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50 transition-transform hover:scale-105"
           disabled={loading}
         >
           {loading ? 'Loading...' : 'Run'}
         </button>
       </div>
       {error && (
-        <p className="text-red-600 text-sm sm:ml-4 sm:self-center">{error}</p>
+        <p className="text-red-600 text-sm sm:col-span-2 lg:col-span-4">{error}</p>
       )}
     </form>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import ExplanationGlossary from '../components/ExplanationGlossary';
 import AgentDebugPanel from '../components/AgentDebugPanel';
 import AgentSummary from '../components/AgentSummary';
 import PickSummary from '../components/PickSummary';
+import Footer from '../components/Footer';
 import { AgentOutputs, AgentResult, Matchup, PickSummary as PickSummaryType } from '../lib/types';
 
 interface ResultPayload {
@@ -18,6 +19,7 @@ interface ResultPayload {
 const HomePage: React.FC = () => {
   const [result, setResult] = useState<ResultPayload | null>(null);
   const [showGlossary, setShowGlossary] = useState(true);
+  const [showDebug, setShowDebug] = useState(false);
 
   const handleStart = ({ teamA, teamB, matchDay }: { teamA: string; teamB: string; matchDay: number }) => {
     setResult({ teamA, teamB, matchDay, agents: {} });
@@ -43,32 +45,35 @@ const HomePage: React.FC = () => {
   };
 
   return (
-    <main className="min-h-screen bg-gray-50 p-6">
-      <header className="text-center mb-8">
-        <h1 className="text-3xl font-mono font-bold">EdgePicks – AI Matchup Insights for Any Sport.</h1>
-        <p
-          className="text-gray-600"
-          title="Our modular agents make it easy to add support for more sports soon."
-        >
-          Powered by modular agents — more sports coming soon.
-        </p>
-      </header>
-      <MatchupInputForm onStart={handleStart} onAgent={handleAgent} onComplete={handleComplete} />
-      {result && (
-        <div className="mt-6 space-y-6">
-          {result.pick && (
-            <PickSummary
-              teamA={result.teamA}
-              teamB={result.teamB}
-              winner={result.pick.winner}
-              confidence={result.pick.confidence}
-            />
-          )}
-          <AgentSummary agents={result.agents} />
-          <AgentDebugPanel agents={result.agents} />
-        </div>
-      )}
-      {showGlossary && <ExplanationGlossary onClose={() => setShowGlossary(false)} />}
+    <main className="min-h-screen bg-gray-50 p-6 pb-24">
+      <div className="container max-w-screen-xl mx-auto space-y-8">
+        <header className="text-center">
+          <h1 className="text-3xl font-mono font-bold">EdgePicks – AI Matchup Insights for Any Sport.</h1>
+          <p
+            className="text-gray-600"
+            title="Our modular agents make it easy to add support for more sports soon."
+          >
+            Powered by modular agents — more sports coming soon.
+          </p>
+        </header>
+        <MatchupInputForm onStart={handleStart} onAgent={handleAgent} onComplete={handleComplete} />
+        {result && (
+          <div className="space-y-6">
+            {result.pick && (
+              <PickSummary
+                teamA={result.teamA}
+                teamB={result.teamB}
+                winner={result.pick.winner}
+                confidence={result.pick.confidence}
+              />
+            )}
+            <AgentSummary agents={result.agents} />
+            {showDebug && <AgentDebugPanel agents={result.agents} />}
+          </div>
+        )}
+        {showGlossary && <ExplanationGlossary onClose={() => setShowGlossary(false)} />}
+      </div>
+      <Footer showDebug={showDebug} onToggleDebug={() => setShowDebug((d) => !d)} />
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- modernized matchup form, confidence visuals, and agent panels with responsive grids, hover animations, and debug toggles
- added gradient confidence bar with animated score badge and sticky trust footer

## Testing
- `npm run dev`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68926427a3008323934fc4eed0879275