### PR TITLE
feat: add agent registry metadata

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ScoreBar from './ScoreBar';
 import { AgentName, AgentResult } from '../lib/types';
+import { agents as agentRegistry } from '../lib/agents/registry';
 import { formatAgentName } from '../lib/utils';
 
 interface Props {
@@ -21,6 +22,7 @@ const AgentCard: React.FC<Props> = ({
   className = '',
 }) => {
   const [visible, setVisible] = useState(false);
+  const meta = agentRegistry.find((a) => a.name === name);
 
   useEffect(() => {
     setVisible(true);
@@ -36,7 +38,9 @@ const AgentCard: React.FC<Props> = ({
       } ${className}`}
     >
       <div className="flex items-center justify-between">
-        <span className="font-medium">{formatAgentName(name)}</span>
+        <span className="font-medium" title={meta?.description}>
+          {formatAgentName(name)}
+        </span>
         {showWeight && (
           <span className="text-xs text-gray-500">{weightPct}% weight</span>
         )}

--- a/components/AgentDebugPanel.tsx
+++ b/components/AgentDebugPanel.tsx
@@ -4,10 +4,10 @@ import { AgentOutputs } from '../lib/types';
 import { agents as agentRegistry } from '../lib/agents/registry';
 import { formatAgentName } from '../lib/utils';
 
-const agentMeta: Record<string, { badge: string; about: string }> = {
-  injuryScout: { badge: '🏥 Injury', about: 'Tracks player injuries and availability.' },
-  lineWatcher: { badge: '📈 Line', about: 'Monitors betting line movement and market signals.' },
-  statCruncher: { badge: '🧠 Stat', about: 'Crunches historical statistics for trends.' },
+const typeBadge: Record<string, string> = {
+  injury: '🏥 Injury',
+  line: '📈 Line',
+  stat: '🧠 Stat',
 };
 
 type Props = {
@@ -18,7 +18,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
   return (
     <div>
       <div className="space-y-4 sm:hidden">
-        {agentRegistry.map(({ name, weight }) => {
+        {agentRegistry.map(({ name, weight, type, description }) => {
           const result = agents[name];
           const display = formatAgentName(name);
           if (!result) {
@@ -32,7 +32,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
           const scorePct = result.score * 100;
           const weighted = result.score * weight;
           const weightedPct = weighted * 100;
-          const meta = agentMeta[name];
+          const badge = typeBadge[type] || type;
 
           return (
             <div
@@ -41,7 +41,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
             >
               <div className="flex items-center justify-between">
                 <div className="font-medium">{display}</div>
-                <span className="text-xs px-2 py-0.5 bg-gray-200 rounded">{meta.badge}</span>
+                <span className="text-xs px-2 py-0.5 bg-gray-200 rounded">{badge}</span>
               </div>
               <div className="mt-2">
                 <ScoreBar percent={scorePct} className="w-full" />
@@ -64,7 +64,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               </div>
               <details className="mt-2 text-xs">
                 <summary className="cursor-pointer text-blue-600">About This Agent</summary>
-                <p className="mt-1">{meta.about}</p>
+                <p className="mt-1">{description}</p>
               </details>
             </div>
           );
@@ -82,7 +82,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
             </tr>
           </thead>
           <tbody>
-            {agentRegistry.map(({ name, weight }) => {
+            {agentRegistry.map(({ name, weight, type, description }) => {
               const result = agents[name];
               const display = formatAgentName(name);
               if (!result) {
@@ -98,13 +98,13 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               const scorePct = result.score * 100;
               const weighted = result.score * weight;
               const weightedPct = weighted * 100;
-              const meta = agentMeta[name];
+              const badge = typeBadge[type] || type;
 
               return (
                 <tr key={name} className="border-t ring-1 ring-blue-500">
                   <td className="p-2 font-medium flex items-center gap-2">
                     {display}
-                    <span className="text-xs px-2 py-0.5 bg-gray-200 rounded">{meta.badge}</span>
+                    <span className="text-xs px-2 py-0.5 bg-gray-200 rounded">{badge}</span>
                   </td>
                   <td className="p-2">
                     <div className="flex items-center gap-2">
@@ -126,7 +126,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
                     <div className="truncate" title={result.reason}>{result.reason}</div>
                     <details>
                       <summary className="cursor-pointer text-blue-600">About This Agent</summary>
-                      <p className="mt-1">{meta.about}</p>
+                      <p className="mt-1">{description}</p>
                     </details>
                   </td>
                 </tr>

--- a/lib/agents/agents.json
+++ b/lib/agents/agents.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "injuryScout",
+    "description": "Tracks player injuries and availability.",
+    "type": "injury",
+    "weight": 0.5,
+    "sources": ["espn", "teamReports"]
+  },
+  {
+    "name": "lineWatcher",
+    "description": "Monitors betting line movement and market signals.",
+    "type": "line",
+    "weight": 0.3,
+    "sources": ["marketData"]
+  },
+  {
+    "name": "statCruncher",
+    "description": "Crunches historical statistics for trends.",
+    "type": "stat",
+    "weight": 0.2,
+    "sources": ["statsApi"]
+  }
+]

--- a/lib/agents/registry.ts
+++ b/lib/agents/registry.ts
@@ -1,18 +1,27 @@
 import type { AgentFunc } from '../types';
+import agentsMeta from './agents.json';
 import { injuryScout } from './injuryScout';
 import { lineWatcher } from './lineWatcher';
 import { statCruncher } from './statCruncher';
 
-export interface AgentDescriptor {
+export interface AgentMeta {
   name: string;
+  description: string;
+  type: string;
   weight: number;
-  run: AgentFunc;
+  sources: string[];
 }
 
-export const agents = [
-  { name: 'injuryScout', weight: 0.5, run: injuryScout },
-  { name: 'lineWatcher', weight: 0.3, run: lineWatcher },
-  { name: 'statCruncher', weight: 0.2, run: statCruncher },
-] as const satisfies readonly AgentDescriptor[];
+const runners: Record<string, AgentFunc> = {
+  injuryScout,
+  lineWatcher,
+  statCruncher,
+};
 
-export type AgentName = (typeof agents)[number]['name'];
+export const agents = (agentsMeta as readonly AgentMeta[]).map((meta) => ({
+  ...meta,
+  run: runners[meta.name],
+})) as const;
+
+export type AgentDescriptor = (typeof agents)[number];
+export type AgentName = AgentDescriptor['name'];


### PR DESCRIPTION
## Summary
- load agent definitions from a JSON registry
- surface agent type and descriptions in AgentCard and AgentDebugPanel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68926a23c81c832393361a7e33b2a8ed