### PR TITLE
fix: enforce agent typing

### DIFF
--- a/lib/agents/registry.ts
+++ b/lib/agents/registry.ts
@@ -18,10 +18,16 @@ const runners: Record<string, AgentFunc> = {
   statCruncher,
 };
 
-export const agents = (agentsMeta as readonly AgentMeta[]).map((meta) => ({
+export const registry: AgentMeta[] = agentsMeta as AgentMeta[];
+
+export interface Agent extends AgentMeta {
+  run: AgentFunc;
+}
+
+export const agents: Agent[] = registry.map((meta) => ({
   ...meta,
   run: runners[meta.name],
-})) as const;
+}));
 
 export type AgentDescriptor = (typeof agents)[number];
 export type AgentName = AgentDescriptor['name'];


### PR DESCRIPTION
## Summary
- enforce typing in `lib/agents/registry.ts` by introducing an `Agent` interface and `registry` export
- map metadata to runners without invalid `as const`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68926c3d7a648323b403b630b73ed2e7