### PR TITLE
feat: add configurable agent flows

### DIFF
--- a/components/MatchupInputForm.tsx
+++ b/components/MatchupInputForm.tsx
@@ -52,7 +52,9 @@ const MatchupInputForm: React.FC<Props> = ({ onStart, onAgent, onComplete }) => 
       es.onmessage = (event) => {
         const data = JSON.parse(event.data);
         if (data.type === 'agent') {
-          onAgent(data.name, data.result as AgentResult);
+          if (!data.error) {
+            onAgent(data.name, data.result as AgentResult);
+          }
         } else if (data.type === 'summary') {
           onComplete(data as SummaryPayload);
           setLoading(false);

--- a/flows/football-pick.json
+++ b/flows/football-pick.json
@@ -1,0 +1,4 @@
+{
+  "name": "Default NFL Flow",
+  "agents": ["injuryScout", "statCruncher", "lineWatcher"]
+}

--- a/lib/flow/loadFlow.ts
+++ b/lib/flow/loadFlow.ts
@@ -1,0 +1,18 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { AgentName } from '../types';
+
+export interface FlowConfig {
+  name: string;
+  agents: AgentName[];
+}
+
+/**
+ * Load a flow configuration by name from the flows directory.
+ */
+export async function loadFlow(flowName: string): Promise<FlowConfig> {
+  const filePath = path.join(process.cwd(), 'flows', `${flowName}.json`);
+  const data = await fs.readFile(filePath, 'utf8');
+  const config = JSON.parse(data) as FlowConfig;
+  return config;
+}

--- a/lib/flow/runFlow.ts
+++ b/lib/flow/runFlow.ts
@@ -1,0 +1,43 @@
+import type { Matchup, AgentOutputs, AgentResult, AgentName } from '../types';
+import { agents as registry } from '../agents/registry';
+import type { FlowConfig } from './loadFlow';
+
+export interface AgentExecution {
+  name: AgentName;
+  result?: AgentResult;
+  error?: true;
+}
+
+/**
+ * Execute a flow sequentially, running each agent in order.
+ * Logs input and output for each agent and marks failures.
+ */
+export async function runFlow(
+  flow: FlowConfig,
+  matchup: Matchup,
+  onAgent?: (exec: AgentExecution) => void
+): Promise<Partial<AgentOutputs>> {
+  const outputs: Partial<AgentOutputs> = {};
+
+  for (const name of flow.agents) {
+    const agent = registry.find((a) => a.name === name);
+    if (!agent) {
+      console.error(`[runFlow] Agent not found: ${name}`);
+      onAgent?.({ name, error: true });
+      continue;
+    }
+
+    console.log(`[runFlow] ${name} input:`, matchup);
+    try {
+      const result = await agent.run(matchup);
+      console.log(`[runFlow] ${name} output:`, result);
+      outputs[name] = result;
+      onAgent?.({ name, result });
+    } catch (err) {
+      console.error(`[runFlow] ${name} error:`, err);
+      onAgent?.({ name, error: true });
+    }
+  }
+
+  return outputs;
+}


### PR DESCRIPTION
## Summary
- add flow loader and runner to support JSON-defined agent sequences
- create default football-pick flow and log agent execution with error flags
- run matchup API through flow engine and ignore failed agent events on frontend

## Testing
- `npm test`
- `TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}' node -r ts-node/register scripts/test-flow.ts` *(sequential run verified; removed script before commit)*
- `TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}' node -r ts-node/register -e "const { runFlow } = require('./lib/flow/runFlow'); (async()=>{ await runFlow({name:'test',agents:['injuryScout','missingAgent']},{homeTeam:'A',awayTeam:'B',matchDay:1}, step=>console.log('step',step));})();"`
- `npm run dev` *(terminated after ready)*

------
https://chatgpt.com/codex/tasks/task_e_68926d8d1f708323816467e669650aa9