### PR TITLE
feat: add agent lifecycle tracking

### DIFF
--- a/lib/agents/lifecycleAgent.ts
+++ b/lib/agents/lifecycleAgent.ts
@@ -1,0 +1,24 @@
+import type { AgentLifecycle, AgentName, Matchup, AgentOutputs, PickSummary } from '../types';
+import { logToSupabase } from '../logToSupabase';
+
+// Listen for agent lifecycle events and log them. Optionally persists
+// the event to Supabase using the existing logToSupabase helper when a
+// matchup is provided.
+export function lifecycleAgent(
+  event: { name: AgentName } & AgentLifecycle,
+  matchup?: Matchup
+) {
+  console.log('[lifecycleAgent]', event);
+  if (!matchup) return;
+  try {
+    const agents: AgentOutputs = {} as AgentOutputs;
+    const pick: PickSummary = {
+      winner: event.name,
+      confidence: event.durationMs ?? 0,
+      topReasons: [`status: ${event.status}`],
+    };
+    logToSupabase(matchup, agents, pick, null);
+  } catch (err) {
+    console.error('[lifecycleAgent] failed to log to Supabase:', err);
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,3 +30,10 @@ export interface PickResult {
 }
 
 export type MatchupWithPick = Matchup & PickResult;
+
+export interface AgentLifecycle {
+  status: 'started' | 'completed' | 'errored';
+  startedAt: number;
+  endedAt?: number;
+  durationMs?: number;
+}


### PR DESCRIPTION
## Summary
- add `AgentLifecycle` interface and track agent run times in `runFlow`
- log and optionally persist lifecycle events via new `lifecycleAgent`
- stream agent lifecycle updates from `run-agents` API alongside agent results

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689273ad0b688323a507d4bb22f49cd2