### PR TITLE
Add guardian agent to flag inconsistent reasoning

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -45,7 +45,7 @@ const AgentCard: React.FC<Props> = ({
           <span className="text-xs text-gray-500">{weightPct}% weight</span>
         )}
       </div>
-      {showTeam && (
+      {showTeam && !result.warnings && (
         <span className="text-sm text-gray-700">Favored: {result.team}</span>
       )}
       <div className="flex items-center gap-2">
@@ -55,6 +55,13 @@ const AgentCard: React.FC<Props> = ({
       <p className="text-xs text-gray-600 truncate" title={result.reason}>
         {result.reason}
       </p>
+      {result.warnings && result.warnings.length > 0 && (
+        <ul className="text-xs text-yellow-700 list-disc pl-4">
+          {result.warnings.map((w, i) => (
+            <li key={i}>{w}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/components/AgentDebugPanel.tsx
+++ b/components/AgentDebugPanel.tsx
@@ -62,6 +62,13 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               <div className="mt-2 text-xs text-gray-600 truncate" title={result.reason}>
                 {result.reason}
               </div>
+              {result.warnings && result.warnings.length > 0 && (
+                <ul className="mt-2 text-xs text-yellow-700 list-disc pl-4">
+                  {result.warnings.map((w, i) => (
+                    <li key={i}>{w}</li>
+                  ))}
+                </ul>
+              )}
               <details className="mt-2 text-xs">
                 <summary className="cursor-pointer text-blue-600">About This Agent</summary>
                 <p className="mt-1">{description}</p>
@@ -124,6 +131,13 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
                   </td>
                   <td className="p-2 text-xs text-gray-600 max-w-xs">
                     <div className="truncate" title={result.reason}>{result.reason}</div>
+                    {result.warnings && result.warnings.length > 0 && (
+                      <ul className="mt-1 list-disc pl-4 text-yellow-700">
+                        {result.warnings.map((w, i) => (
+                          <li key={i}>{w}</li>
+                        ))}
+                      </ul>
+                    )}
                     <details>
                       <summary className="cursor-pointer text-blue-600">About This Agent</summary>
                       <p className="mt-1">{description}</p>

--- a/flows/football-pick.json
+++ b/flows/football-pick.json
@@ -1,4 +1,4 @@
 {
   "name": "Default NFL Flow",
-  "agents": ["injuryScout", "statCruncher", "lineWatcher"]
+  "agents": ["injuryScout", "statCruncher", "lineWatcher", "guardianAgent"]
 }

--- a/lib/agents/agents.json
+++ b/lib/agents/agents.json
@@ -19,5 +19,12 @@
     "type": "stat",
     "weight": 0.2,
     "sources": ["statsApi"]
+  },
+  {
+    "name": "guardianAgent",
+    "description": "Reviews outputs for inconsistent or incomplete reasoning.",
+    "type": "guardian",
+    "weight": 0,
+    "sources": []
   }
 ]

--- a/lib/agents/guardianAgent.ts
+++ b/lib/agents/guardianAgent.ts
@@ -1,0 +1,40 @@
+import { AgentOutputs, AgentResult, Matchup } from '../types';
+
+/**
+ * Reviews previous agent outputs for inconsistencies or missing data
+ * and returns any warnings discovered. Does not contribute to scoring
+ * but surfaces potential issues with agent reasoning.
+ */
+export const guardianAgent = async (
+  matchup: Matchup,
+  agents: Partial<AgentOutputs> = {}
+): Promise<AgentResult> => {
+  const warnings: string[] = [];
+  const results = Object.entries(agents);
+
+  if (results.length === 0) {
+    warnings.push('No agent outputs available for review.');
+  } else {
+    // Check for missing reasoning
+    for (const [name, result] of results) {
+      if (!result.reason || result.reason.trim().length < 5) {
+        warnings.push(`Agent ${name} provided incomplete reasoning.`);
+      }
+    }
+
+    // Check if agents disagree on predicted winner
+    const teams = new Set(results.map(([_, r]) => r.team));
+    if (teams.size > 1) {
+      warnings.push('Agents disagree on the predicted winner.');
+    }
+  }
+
+  return {
+    team: matchup.homeTeam,
+    score: 0,
+    reason: 'Guardian review completed',
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
+};
+
+export default guardianAgent;

--- a/lib/agents/registry.ts
+++ b/lib/agents/registry.ts
@@ -3,6 +3,7 @@ import agentsMeta from './agents.json';
 import { injuryScout } from './injuryScout';
 import { lineWatcher } from './lineWatcher';
 import { statCruncher } from './statCruncher';
+import { guardianAgent } from './guardianAgent';
 
 export interface AgentMeta {
   name: string;
@@ -16,6 +17,7 @@ const runners: Record<string, AgentFunc> = {
   injuryScout,
   lineWatcher,
   statCruncher,
+  guardianAgent,
 };
 
 export const registry: AgentMeta[] = agentsMeta as AgentMeta[];

--- a/lib/flow/runFlow.ts
+++ b/lib/flow/runFlow.ts
@@ -38,7 +38,7 @@ export async function runFlow(
     const start = Date.now();
     onLifecycle?.({ name, status: 'started', startedAt: start });
     try {
-      const result = await agent.run(matchup);
+      const result = await agent.run(matchup, outputs);
       const end = Date.now();
       const duration = end - start;
       console.log(`[runFlow] ${name} output:`, result);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,14 +8,18 @@ export interface AgentResult {
   team: string;
   score: number; // higher score favors team
   reason: string;
+  warnings?: string[];
 }
 
 import type { AgentName } from './agents/registry';
 export type { AgentName } from './agents/registry';
 
-export type AgentFunc = (matchup: Matchup) => Promise<AgentResult>;
-
 export type AgentOutputs = Record<AgentName, AgentResult>;
+
+export type AgentFunc = (
+  matchup: Matchup,
+  agentOutputs?: Partial<AgentOutputs>
+) => Promise<AgentResult>;
 
 export interface PickSummary {
   winner: string;

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -45,7 +45,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     ({ name, result, error }) => {
       if (!error && result) {
         agentsOutput[name] = result;
-        res.write(`data: ${JSON.stringify({ type: 'agent', name, result })}\n\n`);
+        res.write(
+          `data: ${JSON.stringify({
+            type: 'agent',
+            name,
+            result,
+            warnings: result.warnings,
+          })}\n\n`
+        );
       } else {
         res.write(`data: ${JSON.stringify({ type: 'agent', name, error: true })}\n\n`);
       }

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -69,6 +69,13 @@ const HistoryPage: React.FC = () => {
                       <div className="text-xs text-gray-600">
                         Score: {result.score.toFixed(2)} – {result.reason}
                       </div>
+                      {result.warnings && result.warnings.length > 0 && (
+                        <ul className="mt-1 text-xs text-yellow-700 list-disc pl-4">
+                          {result.warnings.map((w, i) => (
+                            <li key={i}>{w}</li>
+                          ))}
+                        </ul>
+                      )}
                     </li>
                   );
                 })}


### PR DESCRIPTION
## Summary
- implement guardianAgent to review previous agent outputs and raise warnings
- register guardian agent in registry and flows
- surface guardian warnings through API and UI

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689275fb2d38832395d5a69d5a95af19