### PR TITLE
feat: add trends analysis agent

### DIFF
--- a/flows/trends.json
+++ b/flows/trends.json
@@ -1,0 +1,4 @@
+{
+  "name": "Trends Analysis Flow",
+  "agents": ["trendsAgent"]
+}

--- a/lib/agents/agents.json
+++ b/lib/agents/agents.json
@@ -19,5 +19,12 @@
     "type": "stat",
     "weight": 0.2,
     "sources": ["statsApi"]
+  },
+  {
+    "name": "trendsAgent",
+    "description": "Analyzes recent matchups for flow popularity and agent hit rates.",
+    "type": "analytics",
+    "weight": 0,
+    "sources": ["supabase"]
   }
 ]

--- a/lib/agents/registry.ts
+++ b/lib/agents/registry.ts
@@ -3,6 +3,7 @@ import agentsMeta from './agents.json';
 import { injuryScout } from './injuryScout';
 import { lineWatcher } from './lineWatcher';
 import { statCruncher } from './statCruncher';
+import { trendsAgent } from './trendsAgent';
 
 export interface AgentMeta {
   name: string;
@@ -16,6 +17,7 @@ const runners: Record<string, AgentFunc> = {
   injuryScout,
   lineWatcher,
   statCruncher,
+  trendsAgent,
 };
 
 export const registry: AgentMeta[] = agentsMeta as AgentMeta[];

--- a/lib/agents/trendsAgent.ts
+++ b/lib/agents/trendsAgent.ts
@@ -1,0 +1,65 @@
+import { AgentResult, Matchup } from '../types';
+import { getSupabaseClient } from '../supabaseClient';
+
+export interface TrendsResult extends AgentResult {
+  flowPopularity: { flow: string; count: number }[];
+  agentHitRates: { agent: string; hitRate: number; correct: number; total: number }[];
+}
+
+export const trendsAgent = async (_: Matchup): Promise<TrendsResult> => {
+  const client = getSupabaseClient();
+  const { data, error } = await client
+    .from('matchups')
+    .select('flow, agents, actual_winner')
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    throw error;
+  }
+
+  const flowCounts: Record<string, number> = {};
+  const agentStats: Record<string, { correct: number; total: number }> = {};
+
+  (data || []).forEach((row: any) => {
+    const flow = row.flow || 'unknown';
+    flowCounts[flow] = (flowCounts[flow] || 0) + 1;
+
+    const actual: string | null = row.actual_winner;
+    const agents = row.agents || {};
+
+    if (actual) {
+      Object.entries(agents as Record<string, { team: string }>).forEach(([name, result]) => {
+        if (!agentStats[name]) {
+          agentStats[name] = { correct: 0, total: 0 };
+        }
+        agentStats[name].total += 1;
+        if (result.team === actual) {
+          agentStats[name].correct += 1;
+        }
+      });
+    }
+  });
+
+  const flowPopularity = Object.entries(flowCounts)
+    .map(([flow, count]) => ({ flow, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const agentHitRates = Object.entries(agentStats)
+    .map(([agent, { correct, total }]) => ({
+      agent,
+      correct,
+      total,
+      hitRate: total ? correct / total : 0,
+    }))
+    .sort((a, b) => b.hitRate - a.hitRate);
+
+  return {
+    team: 'N/A',
+    score: 0,
+    reason: 'Trends analysis',
+    flowPopularity,
+    agentHitRates,
+  };
+};
+

--- a/pages/api/trends.ts
+++ b/pages/api/trends.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { loadFlow } from '../../lib/flow/loadFlow';
+import { runFlow } from '../../lib/flow/runFlow';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  // @ts-ignore
+  res.flushHeaders?.();
+
+  const flowNameParam = req.query.flow;
+  const flowName = typeof flowNameParam === 'string' ? flowNameParam : 'trends';
+  const flow = await loadFlow(flowName);
+
+  await runFlow(
+    flow,
+    { homeTeam: '', awayTeam: '' },
+    ({ name, result, error }) => {
+      if (!error && result) {
+        res.write(`data: ${JSON.stringify({ type: 'agent', name, result })}\n\n`);
+      } else {
+        res.write(`data: ${JSON.stringify({ type: 'agent', name, error: true })}\n\n`);
+      }
+      // @ts-ignore
+      res.flush?.();
+    }
+  );
+
+  res.end();
+}


### PR DESCRIPTION
## Summary
- add trends agent to compute flow popularity and agent hit rates from Supabase
- register trends agent and expose a new API endpoint to run it
- provide dedicated flow configuration for trends analysis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689275f972d083238bea947f62259500