### PR TITLE
Add agent lifecycle visualizer and dashboard

### DIFF
--- a/lib/dashboard/AgentTimeline.tsx
+++ b/lib/dashboard/AgentTimeline.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import type { FlowNode } from './useFlowVisualizer';
+
+interface Props {
+  nodes: FlowNode[];
+  startTime?: number | null;
+}
+
+const statusColors: Record<FlowNode['status'], string> = {
+  pending: 'bg-gray-300',
+  running: 'bg-blue-400 animate-pulse',
+  completed: 'bg-green-400',
+  errored: 'bg-red-400',
+};
+
+/**
+ * Visual representation of agents over time. Each agent renders as a row with
+ * a bar that spans its execution window relative to the flow's start time.
+ */
+const AgentTimeline: React.FC<Props> = ({ nodes, startTime }) => {
+  const now = Date.now();
+  if (!nodes.length) {
+    return <p className="text-sm text-gray-500">Waiting for agents...</p>;
+  }
+
+  const start = startTime ?? Math.min(...nodes.map((n) => n.startedAt ?? now));
+  const end = Math.max(...nodes.map((n) => n.endedAt ?? now));
+  const total = end - start || 1;
+
+  return (
+    <div className="space-y-4 w-full">
+      {nodes.map((n) => {
+        const s = n.startedAt ?? start;
+        const e = n.endedAt ?? now;
+        const offset = ((s - start) / total) * 100;
+        const width = ((e - s) / total) * 100;
+        const color = statusColors[n.status];
+        return (
+          <div key={n.id}>
+            <div className="flex justify-between text-sm mb-1">
+              <span>{n.label}</span>
+              {n.durationMs != null && <span>{(n.durationMs / 1000).toFixed(2)}s</span>}
+            </div>
+            <div className="relative h-2 bg-gray-200 rounded">
+              <div
+                className={`absolute h-2 rounded ${color}`}
+                style={{ left: `${offset}%`, width: `${width}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AgentTimeline;
+

--- a/lib/dashboard/useFlowVisualizer.ts
+++ b/lib/dashboard/useFlowVisualizer.ts
@@ -1,0 +1,88 @@
+import { useCallback, useRef, useState } from 'react';
+import type { AgentLifecycle, AgentName } from '../types';
+
+export type NodeStatus = 'pending' | 'running' | 'completed' | 'errored';
+
+export interface FlowNode {
+  id: AgentName;
+  label: AgentName;
+  status: NodeStatus;
+  startedAt?: number;
+  endedAt?: number;
+  durationMs?: number;
+}
+
+export interface FlowEdge {
+  id: string;
+  source: AgentName;
+  target: AgentName;
+}
+
+/**
+ * Hook that translates agent lifecycle events from the SSE stream into
+ * structures that are easier to visualize (nodes, edges, timestamps).
+ */
+export default function useFlowVisualizer() {
+  const [nodes, setNodes] = useState<Record<AgentName, FlowNode>>({});
+  const [edges, setEdges] = useState<FlowEdge[]>([]);
+  const flowStartRef = useRef<number | null>(null);
+  const lastNodeRef = useRef<AgentName | null>(null);
+
+  const handleLifecycleEvent = useCallback(
+    (event: { name: AgentName } & AgentLifecycle) => {
+      setNodes((prev) => {
+        const existing =
+          prev[event.name] || ({
+            id: event.name,
+            label: event.name,
+            status: 'pending' as NodeStatus,
+          } as FlowNode);
+
+        const updated: FlowNode = { ...existing };
+
+        if (event.status === 'started') {
+          updated.status = 'running';
+          updated.startedAt = event.startedAt;
+          if (flowStartRef.current === null || event.startedAt < flowStartRef.current) {
+            flowStartRef.current = event.startedAt;
+          }
+          // Link to previous node to form a simple chain/DAG
+          if (lastNodeRef.current) {
+            setEdges((es) => [
+              ...es,
+              {
+                id: `${lastNodeRef.current}-${event.name}`,
+                source: lastNodeRef.current as AgentName,
+                target: event.name,
+              },
+            ]);
+          }
+          lastNodeRef.current = event.name;
+        } else if (event.status === 'completed') {
+          updated.status = 'completed';
+          updated.endedAt = event.endedAt;
+          updated.durationMs = event.durationMs;
+        } else if (event.status === 'errored') {
+          updated.status = 'errored';
+          updated.endedAt = event.endedAt;
+          updated.durationMs = event.durationMs;
+        }
+
+        return { ...prev, [event.name]: updated };
+      });
+    },
+    []
+  );
+
+  const nodeList = Object.values(nodes).sort(
+    (a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0)
+  );
+
+  return {
+    nodes: nodeList,
+    edges,
+    startTime: flowStartRef.current,
+    handleLifecycleEvent,
+  };
+}
+

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import AgentTimeline from '../lib/dashboard/AgentTimeline';
+import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
+
+const DashboardPage: React.FC = () => {
+  const { nodes, startTime, handleLifecycleEvent } = useFlowVisualizer();
+
+  useEffect(() => {
+    const es = new EventSource('/api/run-agents?teamA=LAL&teamB=BOS&matchDay=1');
+    es.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      if (data.type === 'lifecycle') {
+        handleLifecycleEvent(data);
+      }
+    };
+    return () => es.close();
+  }, [handleLifecycleEvent]);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Agent Dashboard</h1>
+      <AgentTimeline nodes={nodes} startTime={startTime} />
+    </div>
+  );
+};
+
+export default DashboardPage;
+


### PR DESCRIPTION
## Summary
- add `useFlowVisualizer` hook to translate lifecycle events into graph-friendly nodes and edges
- create `AgentTimeline` component with status-based styling to show agent durations
- add `/dashboard` page wiring SSE stream to visualizer for real-time updates

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689275fbdd408323aa98ec70c284a9f2