### PR TITLE
feat(types): add time and league to Matchup

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,8 @@ export interface Matchup {
   homeTeam: string;
   awayTeam: string;
   matchDay?: number;
+  time?: string;
+  league?: string;
 }
 
 export interface AgentResult {


### PR DESCRIPTION
## Summary
- add optional `time` and `league` fields to `Matchup` interface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689281a8d8188323814ccbbf6ca9c71a