### PR TITLE
Add placeholder live sports data fetcher

### DIFF
--- a/lib/data/liveSports.ts
+++ b/lib/data/liveSports.ts
@@ -1,0 +1,29 @@
+import { Matchup } from '../types';
+
+// Temporary hard-coded upcoming games. Replace with real sports API integration
+// (e.g., SportsDB, ESPN, etc.) when available.
+const sampleGames: Matchup[] = [
+  {
+    homeTeam: 'Lakers',
+    awayTeam: 'Warriors',
+    time: '2024-10-16T02:00:00Z',
+    league: 'NBA',
+  },
+  {
+    homeTeam: 'Yankees',
+    awayTeam: 'Red Sox',
+    time: '2024-07-04T23:00:00Z',
+    league: 'MLB',
+  },
+  {
+    homeTeam: 'Cowboys',
+    awayTeam: 'Eagles',
+    time: '2024-09-15T17:00:00Z',
+    league: 'NFL',
+  },
+];
+
+export async function fetchUpcomingGames(): Promise<Matchup[]> {
+  // TODO: Replace with real API call.
+  return sampleGames;
+}


### PR DESCRIPTION
## Summary
- add `fetchUpcomingGames` returning hard-coded matchups for now
- include comments noting future integration with a sports API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892828e9ac08323920603f806a46987