### PR TITLE
Add upcoming games API and autopick logging

### DIFF
--- a/lib/logToSupabase.ts
+++ b/lib/logToSupabase.ts
@@ -8,6 +8,7 @@ type LogEntry = {
   pick: PickSummary;
   actualWinner: string | null;
   flow: string;
+  extras?: Record<string, any>;
   loggedAt: string;
 };
 
@@ -31,6 +32,7 @@ async function processQueue() {
       pick: entry.pick,
       flow: entry.flow,
       actual_winner: entry.actualWinner,
+      extras: entry.extras,
       created_at: entry.loggedAt,
     });
 
@@ -62,9 +64,10 @@ export function logToSupabase(
   pick: PickSummary,
   actualWinner: string | null = null,
   flow: string = 'unknown',
+  extras: Record<string, any> = {},
   loggedAt: string = new Date().toISOString()
 ): string {
-  queue.push({ matchup, agents, pick, actualWinner, flow, loggedAt });
+  queue.push({ matchup, agents, pick, actualWinner, flow, extras, loggedAt });
   setImmediate(processQueue);
   return loggedAt;
 }

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -1,0 +1,89 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { fetchUpcomingGames } from '../../lib/data/liveSports';
+import { loadFlow } from '../../lib/flow/loadFlow';
+import { runFlow, AgentExecution } from '../../lib/flow/runFlow';
+import { agents as registry } from '../../lib/agents/registry';
+import type { AgentOutputs, PickSummary } from '../../lib/types';
+import { logToSupabase } from '../../lib/logToSupabase';
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const games = await fetchUpcomingGames();
+    const results = [] as {
+      homeTeam: string;
+      awayTeam: string;
+      matchDay?: number;
+      league?: string;
+      time?: string;
+      edgePick: {
+        winner: string;
+        confidence: number;
+        topReasons: string[];
+        agents: AgentExecution[];
+      };
+    }[];
+
+    for (const game of games) {
+      const flow = await loadFlow('football-pick');
+      const executions: AgentExecution[] = [];
+      const outputs = await runFlow(flow, game, (exec) => executions.push(exec));
+
+      const scores: Record<string, number> = {
+        [game.homeTeam]: 0,
+        [game.awayTeam]: 0,
+      };
+
+      flow.agents.forEach((name) => {
+        const meta = registry.find((a) => a.name === name);
+        const result = outputs[name];
+        if (!meta || !result) return;
+        scores[result.team] += result.score * meta.weight;
+      });
+
+      const winner =
+        scores[game.homeTeam] >= scores[game.awayTeam]
+          ? game.homeTeam
+          : game.awayTeam;
+      const confidence = Math.max(scores[game.homeTeam], scores[game.awayTeam]);
+      const topReasons = flow.agents
+        .map((name) => outputs[name]?.reason)
+        .filter((r): r is string => Boolean(r));
+      const pickSummary: PickSummary = {
+        winner,
+        confidence,
+        topReasons,
+      };
+
+      logToSupabase(
+        game,
+        outputs as AgentOutputs,
+        pickSummary,
+        null,
+        'football-pick',
+        { isAutoPick: true }
+      );
+
+      results.push({
+        homeTeam: game.homeTeam,
+        awayTeam: game.awayTeam,
+        matchDay: game.matchDay,
+        league: game.league,
+        time: game.time,
+        edgePick: {
+          winner,
+          confidence,
+          topReasons,
+          agents: executions,
+        },
+      });
+    }
+
+    res.status(200).json(results);
+  } catch (err) {
+    console.error('Error fetching upcoming games:', err);
+    res.status(500).json({ error: 'Failed to fetch upcoming games' });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/upcoming-games` route that fetches upcoming matchups, runs the `football-pick` flow, logs auto picks, and returns agent-backed predictions
- extend `logToSupabase` helper to accept optional metadata for logging, enabling autopick tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892834fa6d08323abe2ae7750565427