### PR TITLE
feat: track autopicks in supabase logs

### DIFF
--- a/lib/logToSupabase.ts
+++ b/lib/logToSupabase.ts
@@ -8,6 +8,7 @@ type LogEntry = {
   pick: PickSummary;
   actualWinner: string | null;
   flow: string;
+  isAutoPick?: boolean;
   extras?: Record<string, any>;
   loggedAt: string;
 };
@@ -32,6 +33,7 @@ async function processQueue() {
       pick: entry.pick,
       flow: entry.flow,
       actual_winner: entry.actualWinner,
+      is_auto_pick: entry.isAutoPick,
       extras: entry.extras,
       created_at: entry.loggedAt,
     });
@@ -64,10 +66,20 @@ export function logToSupabase(
   pick: PickSummary,
   actualWinner: string | null = null,
   flow: string = 'unknown',
+  isAutoPick: boolean = false,
   extras: Record<string, any> = {},
   loggedAt: string = new Date().toISOString()
 ): string {
-  queue.push({ matchup, agents, pick, actualWinner, flow, extras, loggedAt });
+  queue.push({
+    matchup,
+    agents,
+    pick,
+    actualWinner,
+    flow,
+    isAutoPick,
+    extras,
+    loggedAt,
+  });
   setImmediate(processQueue);
   return loggedAt;
 }

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -63,7 +63,7 @@ export default async function handler(
         pickSummary,
         null,
         'football-pick',
-        { isAutoPick: true }
+        true
       );
 
       results.push({

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -9,6 +9,8 @@ create table if not exists matchups (
   pick jsonb not null,
   flow text not null default 'football-pick',
   actual_winner text,
+  is_auto_pick boolean,
+  extras jsonb,
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- allow `logToSupabase` to flag and persist auto-generated picks
- record autopicks when logging upcoming games
- add `is_auto_pick` field to Supabase schema

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68928622164883239192683422ff38a7