### PR TITLE
docs: refresh agent metadata and developer guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Metadata
+
+This project uses modular agents that provide explainable scores for each matchup.
+
+| Agent | Purpose |
+|-------|---------|
+| injuryScout | Scans injury reports and roster depth for team advantages. |
+| lineWatcher | Monitors betting line movement to flag sharp market behavior. |
+| statCruncher | Compares efficiency metrics and advanced stats. |
+| trendsAgent | Evaluates historical trends and momentum shifts. |
+| guardianAgent | Raises warnings on risky or inconsistent picks. |
+
+## Development Notes
+- Run `npm test` before committing changes.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
-🧠 EdgePicks
+Last Updated: 2025-08-05
+
+# 🧠 EdgePicks
 
 EdgePicks is an AI-powered research assistant for Pick’em players, analysts, and fans. It combines modular agent logic and transparent reasoning to surface smart, explainable picks across matchups—whether you're tracking football, basketball, baseball, or beyond.
 
-🏆 Project Purpose
+## Features
+
+- Live predictions panel
+- Transparency dashboards
+- Accuracy leaderboards
+
+## Project Purpose
 
 EdgePicks helps users make informed predictions by aggregating insights from lightweight, explainable agents. Each agent contributes a score and rationale, allowing users to understand not just what to pick—but why.
 
-Built for extensibility and clarity, EdgePicks supports:
-
-Weekly matchup analysis
-
-Per-agent insight comparison
-
-Data logging and performance tracking
-
-Multi-sport flexibility
-
-⚙️ Agent Architecture
+## Agent Architecture
 
 Agents live in lib/agents/ and return an AgentResult describing:
 
@@ -28,15 +26,24 @@ the reasoning behind the pick
 
 Current agents include:
 
-injuryScout – scans injury data for potential advantages
-
-lineWatcher – monitors line movement for sharp betting behavior
-
-statCruncher – evaluates team performance and efficiency
+- injuryScout – scans injury data for potential advantages
+- lineWatcher – monitors line movement for sharp betting behavior
+- statCruncher – evaluates team performance and efficiency
+- trendsAgent – analyzes historical and momentum trends
+- guardianAgent – raises warnings on risky or inconsistent picks
 
 pickBot – orchestrator that aggregates all agent scores into a final recommendation
 
-📱 API Endpoint
+See [AGENTS.md](AGENTS.md) for detailed agent metadata.
+
+## Project Structure
+
+- `lib/` – core agent logic, flow helpers, and utilities
+- `components/` – reusable UI elements
+- `pages/api/` – Next.js API routes
+- `supabase/` – database schema and seed helpers
+
+## API Endpoint
 
 Run all agents for a matchup via:
 
@@ -50,7 +57,7 @@ Overall winner and confidence
 
 Logs the outcome to Supabase (if configured)
 
-Log Status Endpoint
+### Log Status Endpoint
 
 Monitor the in-memory log queue via:
 
@@ -58,7 +65,7 @@ GET /api/log-status
 
 This returns the number of pending log entries and the last error encountered (if any).
 
-🌐 Environment Variables
+## Environment Variables
 
 To enable Supabase integration, create a .env file in the project root:
 
@@ -67,16 +74,25 @@ SUPABASE_ANON_KEY=<your-anon-key>
 
 You can find these values in your Supabase dashboard under Project Settings → API. They are required by lib/supabaseClient.ts to connect to your Supabase project.
 
-🧪 Example Commands
+## Development Setup
 
-npm install             # install dependencies
-npm run dev             # start dev server (localhost:3000)
+1. `npm install`
+2. Copy `.env.example` to `.env` and configure values
+3. `npm run dev` (starts dev server at `localhost:3000`)
 
-curl "http://localhost:3000/api/run-agents?teamA=BOS&teamB=LAL&matchDay=1" # sample multi-sport matchup request
+## Flow Execution
 
-📝 Updating Actual Results
+matchup → agents → `logToSupabase` → accuracy updates
 
-After games conclude, record the real-world outcome so the leaderboard can track accuracy. Update the actual_winner column in Supabase via the Table Editor or SQL:
+## Database Schema Notes
+
+- `actual_winner` – actual outcome recorded post-game
+- `is_auto_pick` – whether a selection was auto-generated
+- `extras` – JSON field for additional metadata
+
+## Updating Actual Results
+
+After games conclude, record the real-world outcome so the leaderboard can track accuracy. Update the `actual_winner` column in Supabase via the Table Editor or SQL:
 
 update matchups set actual_winner = 'BOS' where id = '<matchup-id>';
 

--- a/codex-prompts/injuryScout-prompt.md
+++ b/codex-prompts/injuryScout-prompt.md
@@ -1,2 +1,2 @@
-# InjuryScout
+# injuryScout
 Analyzes injury reports and depth charts to determine which team benefits from current player availability.

--- a/codex-prompts/lineWatcher-prompt.md
+++ b/codex-prompts/lineWatcher-prompt.md
@@ -1,2 +1,2 @@
-# LineWatcher
+# lineWatcher
 Tracks betting line movement and public money to spot sharp action and market sentiment.

--- a/codex-prompts/pickBot-prompt.md
+++ b/codex-prompts/pickBot-prompt.md
@@ -1,2 +1,2 @@
-# PickBot
-Aggregates outputs from all agents, normalizes scores, applies weights (injury > line > stats), and returns the final pick with confidence and top reasons.
+# pickBot
+Aggregates outputs from all agents, normalizes scores, applies weights (injury > line > stats > trends) and surfaces guardianAgent warnings to return the final pick with confidence and top reasons.

--- a/codex-prompts/run-agents-prompt.md
+++ b/codex-prompts/run-agents-prompt.md
@@ -1,16 +1,18 @@
 # Purpose
-Create an API route that runs the EdgePicks agent pipeline for a given NFL matchup. This route gathers data from InjuryScout, LineWatcher, and StatCruncher, processes them with PickBot, and returns a complete pick with confidence and reasoning.
+Create an API route that runs the EdgePicks agent pipeline for a given NFL matchup. This route gathers data from injuryScout, lineWatcher, statCruncher, trendsAgent, and guardianAgent, processes them with pickBot, and returns a complete pick with confidence and reasoning.
 
 # API Endpoint
 `GET /api/run-agents?teamA=49ers&teamB=Cowboys&matchDay=1`
 
 # Responsibilities
 1. Accept teamA, teamB, matchDay from query params
-2. Call each modular agent:  
-   - `injuryScout(matchup)`  
-   - `lineWatcher(matchup)`  
-   - `statCruncher(matchup)`  
-3. Pass all results to `pickBot(agentsOutput)`  
+2. Call each modular agent:
+   - `injuryScout(matchup)`
+   - `lineWatcher(matchup)`
+   - `statCruncher(matchup)`
+   - `trendsAgent(matchup)`
+   - `guardianAgent(matchup)`
+3. Pass all results to `pickBot(agentsOutput)`
 4. Return a JSON response:
 
 ```ts
@@ -18,6 +20,8 @@ type AgentOutput = {
   injuryScout: InjuryReport;
   lineWatcher: LineMovementReport;
   statCruncher: StatMatchupReport;
+  trendsAgent: TrendsReport;
+  guardianAgent: GuardianReport;
 };
 
 type PickSummary = {

--- a/codex-prompts/statCruncher-prompt.md
+++ b/codex-prompts/statCruncher-prompt.md
@@ -1,2 +1,2 @@
-# StatCruncher
+# statCruncher
 Compares advanced team and player statistics to project advantages in upcoming matchups.

--- a/components/ExplanationGlossary.tsx
+++ b/components/ExplanationGlossary.tsx
@@ -11,13 +11,19 @@ const ExplanationGlossary: React.FC<Props> = ({ onClose }) => {
         <h2 className="text-xl font-semibold mb-4">Agent Glossary</h2>
         <ul className="space-y-3 text-sm text-gray-700">
           <li>
-            <strong>InjuryScout</strong>: evaluates player injury reports and roster depth to assess how absences could sway the matchup.
+            <strong>injuryScout</strong>: evaluates player injury reports and roster depth to assess how absences could sway the matchup.
           </li>
           <li>
-            <strong>LineWatcher</strong>: monitors betting line movement to reflect the market's confidence in each team.
+            <strong>lineWatcher</strong>: monitors betting line movement to reflect the market's confidence in each team.
           </li>
           <li>
-            <strong>StatCruncher</strong>: favors efficiency metrics, defensive strength, and other advanced stats to compare teams.
+            <strong>statCruncher</strong>: favors efficiency metrics, defensive strength, and other advanced stats to compare teams.
+          </li>
+          <li>
+            <strong>trendsAgent</strong>: surfaces historical and momentum trends that may influence outcomes.
+          </li>
+          <li>
+            <strong>guardianAgent</strong>: highlights warnings when agent outputs conflict or signal risk.
           </li>
         </ul>
         <button


### PR DESCRIPTION
## Summary
- document new injuryScout, lineWatcher, statCruncher, trendsAgent, and guardianAgent modules
- add features, project structure, development, flow, and schema notes to the README
- provide central agent metadata in new AGENTS.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689288dedb088323a4ea74f966a50370