### PR TITLE
feat: redesign agent card with icons and tooltip

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -1,17 +1,35 @@
 import React, { useEffect, useState } from 'react';
-import ScoreBar from './ScoreBar';
+import {
+  Activity,
+  LineChart,
+  BarChart2,
+  TrendingUp,
+  ShieldAlert,
+  Info,
+  LucideIcon,
+} from 'lucide-react';
 import { AgentName, AgentResult } from '../lib/types';
 import { agents as agentRegistry } from '../lib/agents/registry';
 import { formatAgentName } from '../lib/utils';
+import Tooltip from './Tooltip';
 
 interface Props {
   name: AgentName;
-  result: AgentResult;
+  result?: AgentResult;
   weight?: number;
   showWeight?: boolean;
   showTeam?: boolean;
   className?: string;
+  loading?: boolean;
 }
+
+const agentIcons: Record<AgentName, LucideIcon> = {
+  injuryScout: Activity,
+  lineWatcher: LineChart,
+  statCruncher: BarChart2,
+  trendsAgent: TrendingUp,
+  guardianAgent: ShieldAlert,
+};
 
 const AgentCard: React.FC<Props> = ({
   name,
@@ -20,6 +38,7 @@ const AgentCard: React.FC<Props> = ({
   showWeight = false,
   showTeam = false,
   className = '',
+  loading = false,
 }) => {
   const [visible, setVisible] = useState(false);
   const meta = agentRegistry.find((a) => a.name === name);
@@ -28,33 +47,59 @@ const AgentCard: React.FC<Props> = ({
     setVisible(true);
   }, []);
 
-  const scorePct = Math.round(result.score * 100);
   const weightPct = Math.round(weight * 100);
+  const isLoading = loading || !result;
+
+  if (isLoading || !result) {
+    return (
+      <div className={`p-4 rounded-xl border bg-gray-100 animate-pulse ${className}`}>
+        <div className="h-4 bg-gray-300 rounded w-1/3 mb-2" />
+        <div className="h-3 bg-gray-300 rounded w-full mb-2" />
+        <div className="h-3 bg-gray-300 rounded w-2/3" />
+      </div>
+    );
+  }
+
+  const scorePct = Math.round(result.score * 100);
+  const glowColor =
+    result.score > 0.66
+      ? 'rgba(34,197,94,0.6)'
+      : result.score > 0.33
+      ? 'rgba(250,204,21,0.6)'
+      : 'rgba(239,68,68,0.6)';
+  const Icon = (agentIcons[name] || Info) as LucideIcon;
 
   return (
     <div
-      className={`p-3 bg-gray-50 rounded shadow-sm flex flex-col gap-2 transition-all duration-500 ease-out hover:scale-[1.02] ${
+      className={`relative p-4 bg-gray-50 rounded-xl border flex flex-col gap-2 transition-all duration-500 ease-out ${
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
       } ${className}`}
+      style={{ boxShadow: `0 0 8px ${glowColor}` }}
     >
       <div className="flex items-center justify-between">
-        <span className="font-medium" title={meta?.description}>
+        <span className="flex items-center gap-2 font-medium" title={meta?.description}>
+          <Icon className="w-4 h-4" />
           {formatAgentName(name)}
         </span>
         {showWeight && (
           <span className="text-xs text-gray-500">{weightPct}% weight</span>
         )}
       </div>
-      {showTeam && !result.warnings && (
+      {showTeam && result && !result.warnings && (
         <span className="text-sm text-gray-700">Favored: {result.team}</span>
       )}
-      <div className="flex items-center gap-2">
-        <ScoreBar percent={scorePct} />
-        <span className="w-10 text-right font-mono text-sm">{result.score.toFixed(2)}</span>
+      <div className="relative w-full h-3 bg-gray-200 rounded overflow-hidden">
+        <div
+          className="h-full bg-gradient-to-r from-green-400 via-blue-500 to-purple-600 transition-[width] duration-700"
+          style={{ width: `${scorePct}%` }}
+        />
+        <div className="absolute inset-0 bg-white/20" />
       </div>
-      <p className="text-xs text-gray-600 truncate" title={result.reason}>
-        {result.reason}
-      </p>
+      <div className="text-xs text-gray-600 flex items-center">
+        <Tooltip content={result.reason}>
+          <Info className="w-4 h-4 cursor-help" />
+        </Tooltip>
+      </div>
       {result.warnings && result.warnings.length > 0 && (
         <ul className="text-xs text-yellow-700 list-disc pl-4">
           {result.warnings.map((w, i) => (

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+
+interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ content, children, className }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      className={`relative inline-block ${className || ''}`}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      {children}
+      {open && (
+        <div className="absolute z-10 w-48 p-2 text-xs text-white bg-gray-800 rounded shadow-lg -top-8 left-1/2 -translate-x-1/2">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,10 @@
     "": {
       "name": "edgepicks",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@supabase/supabase-js": "^2.39.5",
+        "lucide-react": "^0.536.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -1105,6 +1107,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.536.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
+      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.5",
+    "lucide-react": "^0.536.0",
     "next": "^14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## Summary
- redesign AgentCard with trading-card style and score-based glow
- add lucide icons and tooltip for rationale
- include skeleton and gradient progress overlay; add lucide-react dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68929ebc8a188323a5126ebfee36800a