### PR TITLE
Add agent disagreement badge and detail toggle

### DIFF
--- a/components/AnimatedConfidenceBar.tsx
+++ b/components/AnimatedConfidenceBar.tsx
@@ -1,12 +1,23 @@
 import React, { useEffect, useState } from 'react';
+import DisagreementBadge from './DisagreementBadge';
+import { AgentOutputs } from '../lib/types';
+import { agents as agentRegistry } from '../lib/agents/registry';
+import { formatAgentName } from '../lib/utils';
 
 type Props = {
   confidence: number; // value between 0–100
+  agents?: AgentOutputs;
+  winner?: string;
 };
 
-const AnimatedConfidenceBar: React.FC<Props> = ({ confidence }) => {
+const AnimatedConfidenceBar: React.FC<Props> = ({ confidence, agents, winner }) => {
   const [fill, setFill] = useState(0);
   const [display, setDisplay] = useState(0);
+  const [showAgents, setShowAgents] = useState(false);
+
+  const agentPicks = agents ? Object.values(agents).map((a) => a.team) : [];
+  const disagreement =
+    !!winner && agentPicks.length > 0 && agentPicks.some((team) => team !== winner);
 
   useEffect(() => {
     setFill(0);
@@ -52,6 +63,37 @@ const AnimatedConfidenceBar: React.FC<Props> = ({ confidence }) => {
           </span>
         </div>
       </div>
+      {disagreement && (
+        <div className="mt-2">
+          <DisagreementBadge />
+        </div>
+      )}
+      {agents && (
+        <button
+          type="button"
+          onClick={() => setShowAgents((s) => !s)}
+          className="mt-2 text-xs text-blue-600 underline"
+        >
+          {showAgents ? 'Hide agent picks' : 'Show agent picks'}
+        </button>
+      )}
+      {showAgents && agents && (
+        <ul className="mt-2 space-y-1 text-sm">
+          {agentRegistry.map(({ name }) => {
+            const result = agents[name];
+            if (!result) return null;
+            const pct = Math.round(result.score * 100);
+            return (
+              <li key={name} className="flex justify-between">
+                <span>
+                  {formatAgentName(name)}: {result.team}
+                </span>
+                <span className="font-mono">{pct}%</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </div>
   );
 };

--- a/components/DisagreementBadge.tsx
+++ b/components/DisagreementBadge.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface Props {
+  animated?: boolean;
+}
+
+const DisagreementBadge: React.FC<Props> = ({ animated = true }) => {
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-xs rounded bg-yellow-100 text-yellow-800 font-medium ${
+        animated ? 'animate-pulse' : ''
+      }`}
+    >
+      Split Verdict
+    </span>
+  );
+};
+
+export default DisagreementBadge;

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -118,7 +118,11 @@ const MatchupCard: React.FC<MatchupProps> = ({
         <span className={`text-xl font-bold ${winnerColor}`}>{result.winner}</span>
       </div>
       <div className="mb-4">
-        <AnimatedConfidenceBar confidence={confidencePct} />
+        <AnimatedConfidenceBar
+          confidence={confidencePct}
+          agents={result.agents}
+          winner={result.winner}
+        />
         {confidencePct > 80 && (
           <span className="mt-2 inline-block px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs">🟢 High Confidence</span>
         )}


### PR DESCRIPTION
## Summary
- add `DisagreementBadge` component to highlight conflicting agent picks
- extend `AnimatedConfidenceBar` with optional badge and agent detail toggle
- wire `MatchupCard` to provide agent outputs and winner to the confidence bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a00be5a48323af3e632c0cf460c8