### PR TITLE
refactor: replace glossary modal with slideover

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -77,7 +77,20 @@ const AgentCard: React.FC<Props> = ({
       style={{ boxShadow: `0 0 8px ${glowColor}` }}
     >
       <div className="flex items-center justify-between">
-        <span className="flex items-center gap-2 font-medium" title={meta?.description}>
+        <span
+          className="flex items-center gap-2 font-medium"
+          title={meta?.description}
+          onMouseEnter={() =>
+            window.dispatchEvent(
+              new CustomEvent('glossary-hover', { detail: name })
+            )
+          }
+          onMouseLeave={() =>
+            window.dispatchEvent(
+              new CustomEvent('glossary-hover', { detail: null })
+            )
+          }
+        >
           <Icon className="w-4 h-4" />
           {formatAgentName(name)}
         </span>

--- a/components/ExplanationGlossary.tsx
+++ b/components/ExplanationGlossary.tsx
@@ -1,38 +1,119 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
 
 type Props = {
   onClose: () => void;
+  highlightAgent?: string | null;
 };
 
-const ExplanationGlossary: React.FC<Props> = ({ onClose }) => {
+const ExplanationGlossary: React.FC<Props> = ({ onClose, highlightAgent }) => {
+  const [activeTab, setActiveTab] = useState<'agents' | 'scoring' | 'disagreements'>('agents');
+  const [highlighted, setHighlighted] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (highlightAgent) {
+      setActiveTab('agents');
+      setHighlighted(highlightAgent);
+      const el = document.getElementById(`agent-${highlightAgent}`);
+      el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } else {
+      setHighlighted(null);
+    }
+  }, [highlightAgent]);
+
+  const TabButton = ({ id, label }: { id: 'agents' | 'scoring' | 'disagreements'; label: string }) => (
+    <button
+      onClick={() => setActiveTab(id)}
+      className={`flex-1 px-4 py-2 text-sm transition-colors ${
+        activeTab === id ? 'border-b-2 border-blue-500 font-medium' : 'text-gray-500'
+      }`}
+    >
+      {label}
+    </button>
+  );
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white rounded-lg shadow-lg p-6 max-w-md w-full">
-        <h2 className="text-xl font-semibold mb-4">Agent Glossary</h2>
-        <ul className="space-y-3 text-sm text-gray-700">
-          <li>
-            <strong>injuryScout</strong>: evaluates player injury reports and roster depth to assess how absences could sway the matchup.
-          </li>
-          <li>
-            <strong>lineWatcher</strong>: monitors betting line movement to reflect the market's confidence in each team.
-          </li>
-          <li>
-            <strong>statCruncher</strong>: favors efficiency metrics, defensive strength, and other advanced stats to compare teams.
-          </li>
-          <li>
-            <strong>trendsAgent</strong>: surfaces historical and momentum trends that may influence outcomes.
-          </li>
-          <li>
-            <strong>guardianAgent</strong>: highlights warnings when agent outputs conflict or signal risk.
-          </li>
-        </ul>
-        <button
-          onClick={onClose}
-          className="mt-6 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-        >
-          Close
-        </button>
-      </div>
+    <div className="fixed inset-0 z-50 flex">
+      <div className="flex-1 bg-black/50" onClick={onClose} />
+      <motion.div
+        initial={{ x: '100%' }}
+        animate={{ x: 0 }}
+        exit={{ x: '100%' }}
+        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        className="w-full max-w-md bg-white h-full shadow-xl flex flex-col"
+      >
+        <div className="flex items-center justify-between p-4 border-b">
+          <h2 className="text-lg font-semibold">Agent Glossary</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close panel"
+            className="text-gray-500 hover:text-gray-700"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="flex border-b">
+          <TabButton id="agents" label="Agent Types" />
+          <TabButton id="scoring" label="Scoring Logic" />
+          <TabButton id="disagreements" label="Disagreements" />
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {activeTab === 'agents' && (
+            <ul className="p-4 space-y-3 text-sm text-gray-700">
+              <li
+                id="agent-injuryScout"
+                className={`p-2 rounded ${highlighted === 'injuryScout' ? 'bg-yellow-100' : ''}`}
+              >
+                <strong>injuryScout</strong>: evaluates player injury reports and roster depth to assess how absences could sway the matchup.
+              </li>
+              <li
+                id="agent-lineWatcher"
+                className={`p-2 rounded ${highlighted === 'lineWatcher' ? 'bg-yellow-100' : ''}`}
+              >
+                <strong>lineWatcher</strong>: monitors betting line movement to reflect the market's confidence in each team.
+              </li>
+              <li
+                id="agent-statCruncher"
+                className={`p-2 rounded ${highlighted === 'statCruncher' ? 'bg-yellow-100' : ''}`}
+              >
+                <strong>statCruncher</strong>: favors efficiency metrics, defensive strength, and other advanced stats to compare teams.
+              </li>
+              <li
+                id="agent-trendsAgent"
+                className={`p-2 rounded ${highlighted === 'trendsAgent' ? 'bg-yellow-100' : ''}`}
+              >
+                <strong>trendsAgent</strong>: surfaces historical and momentum trends that may influence outcomes.
+              </li>
+              <li
+                id="agent-guardianAgent"
+                className={`p-2 rounded ${highlighted === 'guardianAgent' ? 'bg-yellow-100' : ''}`}
+              >
+                <strong>guardianAgent</strong>: highlights warnings when agent outputs conflict or signal risk.
+              </li>
+            </ul>
+          )}
+          {activeTab === 'scoring' && (
+            <div className="p-4 text-sm text-gray-700 space-y-2">
+              <p>Each agent returns a confidence score between 0 and 1 indicating its preference for a team.</p>
+              <p>Scores are weighted and combined to derive an overall pick confidence.</p>
+            </div>
+          )}
+          {activeTab === 'disagreements' && (
+            <div className="p-4 text-sm text-gray-700 space-y-2">
+              <p>Agents may disagree when evaluating the same matchup.</p>
+              <p>The guardianAgent flags conflicting signals so you can review potential risks.</p>
+            </div>
+          )}
+        </div>
+      </motion.div>
     </div>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@supabase/supabase-js": "^2.39.5",
+        "framer-motion": "^11.18.2",
         "lucide-react": "^0.536.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
@@ -865,6 +866,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1166,6 +1194,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.5",
+    "framer-motion": "^11.18.2",
     "lucide-react": "^0.536.0",
     "next": "^14.1.0",
     "react": "^18.2.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import MatchupInputForm from '../components/MatchupInputForm';
 import ExplanationGlossary from '../components/ExplanationGlossary';
 import AgentDebugPanel from '../components/AgentDebugPanel';
@@ -20,6 +20,7 @@ interface ResultPayload {
 const HomePage: React.FC = () => {
   const [result, setResult] = useState<ResultPayload | null>(null);
   const [showGlossary, setShowGlossary] = useState(true);
+  const [highlightAgent, setHighlightAgent] = useState<string | null>(null);
   const [showDebug, setShowDebug] = useState(false);
   const [showUpcomingGames, setShowUpcomingGames] = useState(false);
 
@@ -50,6 +51,20 @@ const HomePage: React.FC = () => {
     setShowUpcomingGames((s) => !s);
   };
 
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const agent = (e as CustomEvent<string | null>).detail;
+      if (agent) {
+        setHighlightAgent(agent);
+        setShowGlossary(true);
+      } else {
+        setHighlightAgent(null);
+      }
+    };
+    window.addEventListener('glossary-hover', handler as EventListener);
+    return () => window.removeEventListener('glossary-hover', handler as EventListener);
+  }, []);
+
   return (
     <main className="min-h-screen bg-gray-50 p-6 pb-24">
       <div className="container max-w-screen-xl mx-auto space-y-8">
@@ -79,7 +94,12 @@ const HomePage: React.FC = () => {
             {showDebug && <AgentDebugPanel agents={result.agents} />}
           </div>
         )}
-        {showGlossary && <ExplanationGlossary onClose={() => setShowGlossary(false)} />}
+        {showGlossary && (
+          <ExplanationGlossary
+            onClose={() => setShowGlossary(false)}
+            highlightAgent={highlightAgent}
+          />
+        )}
       </div>
       <Footer showDebug={showDebug} onToggleDebug={() => setShowDebug((d) => !d)} />
     </main>


### PR DESCRIPTION
## Summary
- replace static glossary modal with framer-motion slideover and tabs for Agent Types, Scoring Logic, and Disagreements
- support deep linking by highlighting agent sections when hovering names in the UI
- include framer-motion dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a01790088323a018e7d129435836