### PR TITLE
feat: colorblind-friendly theme and accessible agent cards

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -41,6 +41,7 @@ const AgentCard: React.FC<Props> = ({
   loading = false,
 }) => {
   const [visible, setVisible] = useState(false);
+  const [open, setOpen] = useState(false);
   const meta = agentRegistry.find((a) => a.name === name);
 
   useEffect(() => {
@@ -63,19 +64,24 @@ const AgentCard: React.FC<Props> = ({
   const scorePct = Math.round(result.score * 100);
   const glowColor =
     result.score > 0.66
-      ? 'rgba(34,197,94,0.6)'
+      ? 'rgba(var(--color-positive),0.6)'
       : result.score > 0.33
-      ? 'rgba(250,204,21,0.6)'
-      : 'rgba(239,68,68,0.6)';
+      ? 'rgba(var(--color-neutral),0.6)'
+      : 'rgba(var(--color-negative),0.6)';
   const Icon = (agentIcons[name] || Info) as LucideIcon;
 
   return (
-    <div
-      className={`relative p-4 bg-gray-50 rounded-xl border flex flex-col gap-2 transition-all duration-500 ease-out ${
-        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
-      } ${className}`}
-      style={{ boxShadow: `0 0 8px ${glowColor}` }}
-    >
+    <>
+      <button
+        type="button"
+        aria-label={`View details for ${formatAgentName(name)}`}
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        className={`relative p-4 bg-gray-50 rounded-xl border flex flex-col text-left gap-2 transition-all duration-500 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 ${
+          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+        } ${className}`}
+        style={{ boxShadow: `0 0 8px ${glowColor}` }}
+      >
       <div className="flex items-center justify-between">
         <span className="flex items-center gap-2 font-medium" title={meta?.description}>
           <Icon className="w-4 h-4" />
@@ -90,7 +96,7 @@ const AgentCard: React.FC<Props> = ({
       )}
       <div className="relative w-full h-3 bg-gray-200 rounded overflow-hidden">
         <div
-          className="h-full bg-gradient-to-r from-green-400 via-blue-500 to-purple-600 transition-[width] duration-700"
+          className="h-full bg-gradient-to-r from-positive via-blue-500 to-purple-600 transition-[width] duration-700"
           style={{ width: `${scorePct}%` }}
         />
         <div className="absolute inset-0 bg-white/20" />
@@ -107,7 +113,38 @@ const AgentCard: React.FC<Props> = ({
           ))}
         </ul>
       )}
-    </div>
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg max-w-md w-full">
+            <h2 className="text-xl font-semibold mb-4">
+              {formatAgentName(name)} Details
+            </h2>
+            <p className="mb-2"><strong>Favored:</strong> {result.team}</p>
+            <p className="mb-4 text-sm" aria-label="Agent rationale">{result.reason}</p>
+            {result.warnings && result.warnings.length > 0 && (
+              <ul className="mb-4 text-sm list-disc pl-4 text-yellow-700">
+                {result.warnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            )}
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close agent details"
+              className="mt-2 px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/components/AgentComparePanel.tsx
+++ b/components/AgentComparePanel.tsx
@@ -8,9 +8,11 @@ interface Props {
 
 const AgentComparePanel: React.FC<Props> = ({ agents }) => {
   return (
-    <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div className="mt-4 flex gap-4 overflow-x-auto snap-x snap-mandatory sm:grid sm:grid-cols-3">
       {(Object.keys(agents) as AgentName[]).map((name) => (
-        <AgentCard key={name} name={name} result={agents[name]} showTeam />
+        <div key={name} className="flex-shrink-0 w-64 snap-center sm:w-auto">
+          <AgentCard name={name} result={agents[name]} showTeam />
+        </div>
       ))}
     </div>
   );

--- a/components/AgentDebugPanel.tsx
+++ b/components/AgentDebugPanel.tsx
@@ -52,7 +52,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               <div className="mt-2">
                 <ScoreBar
                   percent={weightedPct}
-                  color="bg-green-500"
+                  color="bg-positive"
                   className="w-full"
                 />
                 <div className="mt-1 font-mono text-sm">
@@ -123,7 +123,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
                   </td>
                   <td className="p-2">
                     <div className="flex items-center gap-2">
-                      <ScoreBar percent={weightedPct} color="bg-green-500" />
+                      <ScoreBar percent={weightedPct} color="bg-positive" />
                       <span className="w-20 text-right font-mono">
                         {weighted.toFixed(2)} ({Math.round(weightedPct)}%)
                       </span>

--- a/components/AgentSummary.tsx
+++ b/components/AgentSummary.tsx
@@ -9,11 +9,11 @@ interface Props {
 
 const AgentSummary: React.FC<Props> = ({ agents }) => {
   return (
-    <ul className="mt-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <ul className="mt-2 flex gap-4 overflow-x-auto snap-x snap-mandatory sm:grid sm:grid-cols-2 lg:grid-cols-3">
       {agentRegistry.map(({ name, weight }) => {
         const result = agents[name];
         return (
-          <li key={name} className="list-none">
+          <li key={name} className="list-none flex-shrink-0 w-64 snap-center sm:w-auto">
             {result ? (
               <AgentCard name={name} result={result} weight={weight} showWeight />
             ) : (

--- a/components/AnimatedConfidenceBar.tsx
+++ b/components/AnimatedConfidenceBar.tsx
@@ -42,9 +42,9 @@ const AnimatedConfidenceBar: React.FC<Props> = ({ confidence }) => {
         <span className="font-bold">{display}%</span>
       </div>
       <div className="relative w-full h-3 bg-gray-200 rounded overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-r from-green-400 to-red-500 opacity-20 blur-sm animate-pulse" />
+        <div className="absolute inset-0 bg-gradient-to-r from-positive to-negative opacity-20 blur-sm animate-pulse" />
         <div
-          className="relative h-full bg-gradient-to-r from-green-400 to-red-500 transition-[width] duration-700 ease-out"
+          className="relative h-full bg-gradient-to-r from-positive to-negative transition-[width] duration-700 ease-out"
           style={{ width: `${fill}%` }}
         >
           <span className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 bg-gray-800 text-white text-xs px-1 py-0.5 rounded shadow">

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -44,9 +44,9 @@ const Leaderboard: React.FC = () => {
         {agents.length === 0 ? (
           <p className="text-center text-gray-600">No data</p>
         ) : (
-          <ol className="max-w-2xl mx-auto space-y-2">
+          <ol className="flex gap-4 overflow-x-auto snap-x snap-mandatory sm:block sm:max-w-2xl sm:mx-auto sm:space-y-2">
             {agents.map((a, idx) => (
-              <li key={a.name} className="bg-white rounded shadow p-4 flex items-center">
+              <li key={a.name} className="bg-white rounded shadow p-4 flex items-center flex-shrink-0 w-64 snap-center sm:w-full">
                 <span className="w-6 text-lg font-bold">{idx + 1}</span>
                 <span className="flex-1 font-semibold">
                   {formatAgentName(a.name)}
@@ -67,9 +67,9 @@ const Leaderboard: React.FC = () => {
         {flows.length === 0 ? (
           <p className="text-center text-gray-600">No data</p>
         ) : (
-          <ol className="max-w-2xl mx-auto space-y-2">
+          <ol className="flex gap-4 overflow-x-auto snap-x snap-mandatory sm:block sm:max-w-2xl sm:mx-auto sm:space-y-2">
             {flows.map((f, idx) => (
-              <li key={f.name} className="bg-white rounded shadow p-4 flex items-center">
+              <li key={f.name} className="bg-white rounded shadow p-4 flex items-center flex-shrink-0 w-64 snap-center sm:w-full">
                 <span className="w-6 text-lg font-bold">{idx + 1}</span>
                 <span className="flex-1 font-semibold">{f.name}</span>
                 <span className="text-sm text-gray-500 mr-2">

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -120,10 +120,10 @@ const MatchupCard: React.FC<MatchupProps> = ({
       <div className="mb-4">
         <AnimatedConfidenceBar confidence={confidencePct} />
         {confidencePct > 80 && (
-          <span className="mt-2 inline-block px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs">🟢 High Confidence</span>
+          <span className="mt-2 inline-block px-2 py-0.5 bg-positive/20 text-positive rounded text-xs">🟢 High Confidence</span>
         )}
         {confidencePct < 55 && (
-          <span className="mt-2 inline-block px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded text-xs">🟡 Toss-Up</span>
+          <span className="mt-2 inline-block px-2 py-0.5 bg-neutral/20 text-neutral rounded text-xs">🟡 Toss-Up</span>
         )}
       </div>
       {compare && <AgentComparePanel agents={result.agents} />}

--- a/components/TeamBadge.tsx
+++ b/components/TeamBadge.tsx
@@ -18,7 +18,7 @@ const TeamBadge: React.FC<TeamBadgeProps> = ({ team, isWinner }) => {
   const [useFallback, setUseFallback] = useState(false);
 
   const badgeClasses = `w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center overflow-hidden ${
-    isWinner ? 'ring-2 ring-green-400 transition-transform hover:scale-105' : ''
+    isWinner ? 'ring-2 ring-positive transition-transform hover:scale-105' : ''
   }`;
 
   if (!useFallback) {

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,25 +1,49 @@
 import React, { useEffect, useState } from 'react';
 
-const storageKey = 'theme';
+const themeKey = 'theme';
+const colorKey = 'colorblind';
 
 const ThemeToggle: React.FC = () => {
   const [isDark, setIsDark] = useState(false);
+  const [isColorblind, setIsColorblind] = useState(false);
 
   useEffect(() => {
-    setIsDark(document.documentElement.classList.contains('dark'));
+    const html = document.documentElement;
+    setIsDark(html.classList.contains('dark'));
+    setIsColorblind(html.classList.contains('colorblind'));
   }, []);
 
-  const toggleTheme = () => {
+  const toggleDark = () => {
     const html = document.documentElement;
     const next = html.classList.toggle('dark');
-    localStorage.setItem(storageKey, next ? 'dark' : 'light');
+    localStorage.setItem(themeKey, next ? 'dark' : 'light');
     setIsDark(next);
   };
 
+  const toggleColorblind = () => {
+    const html = document.documentElement;
+    const next = html.classList.toggle('colorblind');
+    localStorage.setItem(colorKey, next ? 'colorblind' : 'normal');
+    setIsColorblind(next);
+  };
+
   return (
-    <button onClick={toggleTheme} aria-label="Toggle dark mode">
-      {isDark ? '🌙' : '☀️'}
-    </button>
+    <div className="flex gap-2">
+      <button
+        onClick={toggleDark}
+        aria-label="Toggle dark mode"
+        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+      >
+        {isDark ? '🌙' : '☀️'}
+      </button>
+      <button
+        onClick={toggleColorblind}
+        aria-label="Toggle colorblind-friendly colors"
+        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+      >
+        {isColorblind ? '👁️‍🗨️' : '👁️'}
+      </button>
+    </div>
   );
 };
 

--- a/components/UpcomingGamesPanel.tsx
+++ b/components/UpcomingGamesPanel.tsx
@@ -87,14 +87,15 @@ const UpcomingGamesPanel: React.FC = () => {
                 {game.time ? new Date(game.time).toLocaleString() : 'TBD'}
               </time>
             </div>
-            <div className="flex flex-col gap-2">
+            <div className="flex gap-2 overflow-x-auto snap-x snap-mandatory sm:flex-col">
               {agentResults.map((exec) => (
-                <AgentCard
-                  key={exec.name}
-                  name={exec.name as any}
-                  result={exec.result!}
-                  showTeam
-                />
+                <div key={exec.name} className="flex-shrink-0 w-64 snap-center sm:w-auto">
+                  <AgentCard
+                    name={exec.name as any}
+                    result={exec.result!}
+                    showTeam
+                  />
+                </div>
               ))}
             </div>
             {guardian?.result?.warnings && (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,12 @@ function MyApp({ Component, pageProps }: AppProps) {
         <ThemeToggle />
       </header>
       <Component {...pageProps} />
+      <style jsx global>{`
+        :focus-visible {
+          outline: 2px solid #3b82f6;
+          outline-offset: 2px;
+        }
+      `}</style>
     </>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -10,10 +10,15 @@ export default function Document() {
               (function() {
                 try {
                   var storageKey = 'theme';
+                  var colorKey = 'colorblind';
                   var stored = localStorage.getItem(storageKey);
+                  var colorPref = localStorage.getItem(colorKey);
                   var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
                   if (stored === 'dark' || (!stored && prefersDark)) {
                     document.documentElement.classList.add('dark');
+                  }
+                  if (colorPref === 'colorblind') {
+                    document.documentElement.classList.add('colorblind');
                   }
                 } catch (e) {}
               })();

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,6 +3,18 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --color-positive: 34 197 94; /* green-500 */
+    --color-neutral: 250 204 21; /* yellow-400 */
+    --color-negative: 239 68 68; /* red-500 */
+  }
+
+  .colorblind {
+    --color-positive: 0 92 175; /* blue for colorblind-safe */
+    --color-neutral: 161 217 155; /* soft green */
+    --color-negative: 217 95 2; /* orange */
+  }
+
   html {
     @apply text-[16px] sm:text-[17px];
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,13 @@ module.exports = {
   darkMode: 'class',
   content: ['./pages/**/*.{ts,tsx}', './components/**/*.{ts,tsx}', './lib/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        positive: 'rgb(var(--color-positive) / <alpha-value>)',
+        negative: 'rgb(var(--color-negative) / <alpha-value>)',
+        neutral: 'rgb(var(--color-neutral) / <alpha-value>)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- make agent cards expandable with full-screen modal details
- add colorblind-friendly palette and toggle
- enable horizontal scrolling for agent lists on small screens and improve focus styling

## Testing
- `npm test`
- Manual keyboard navigation across agent cards and toggles

------
https://chatgpt.com/codex/tasks/task_e_6892a02083f48323a22134547de3ec62