### PR TITLE
feat: add agent lifecycle status panel

### DIFF
--- a/components/AgentStatusPanel.tsx
+++ b/components/AgentStatusPanel.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { agents as agentRegistry } from '../lib/agents/registry';
+import { formatAgentName } from '../lib/utils';
+import type { AgentLifecycle, AgentName } from '../lib/types';
+
+export type AgentStatusMap = Record<
+  AgentName,
+  { status: AgentLifecycle['status'] | 'idle'; durationMs?: number }
+>;
+
+interface Props {
+  statuses: Partial<AgentStatusMap>;
+}
+
+const AgentStatusPanel: React.FC<Props> = ({ statuses }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="fixed left-0 right-0 bottom-16 mx-auto max-w-md">
+      <div className="bg-white border rounded-t shadow-lg">
+        <button
+          className="w-full px-4 py-2 text-left font-medium bg-gray-100"
+          onClick={() => setOpen((o) => !o)}
+        >
+          {open ? 'Hide Agent Status' : 'Show Agent Status'}
+        </button>
+        {open && (
+          <ul className="divide-y">
+            {agentRegistry.map(({ name }) => {
+              const info = statuses[name];
+              let label = 'Waiting';
+              if (info?.status === 'started') label = 'Running…';
+              else if (info?.status === 'completed')
+                label = `Completed in ${info.durationMs ?? 0}ms`;
+              else if (info?.status === 'errored') label = 'Error';
+              return (
+                <li
+                  key={name}
+                  className="flex items-center justify-between px-4 py-2 text-sm"
+                >
+                  <span>{formatAgentName(name)}</span>
+                  <span>{label}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AgentStatusPanel;

--- a/components/MatchupInputForm.tsx
+++ b/components/MatchupInputForm.tsx
@@ -4,6 +4,7 @@ import {
   AgentResult,
   Matchup,
   PickSummary,
+  AgentLifecycle,
 } from '../lib/types';
 
 interface SummaryPayload {
@@ -17,9 +18,15 @@ export type Props = {
   onStart: (info: { teamA: string; teamB: string; matchDay: number }) => void;
   onAgent: (name: string, result: AgentResult) => void;
   onComplete: (data: SummaryPayload) => void;
+  onLifecycle: (event: { name: string } & AgentLifecycle) => void;
 };
 
-const MatchupInputForm: React.FC<Props> = ({ onStart, onAgent, onComplete }) => {
+const MatchupInputForm: React.FC<Props> = ({
+  onStart,
+  onAgent,
+  onComplete,
+  onLifecycle,
+}) => {
   const [teamA, setTeamA] = useState('');
   const [teamB, setTeamB] = useState('');
   const [matchDay, setMatchDay] = useState('');
@@ -55,6 +62,8 @@ const MatchupInputForm: React.FC<Props> = ({ onStart, onAgent, onComplete }) => 
           if (!data.error) {
             onAgent(data.name, data.result as AgentResult);
           }
+        } else if (data.type === 'lifecycle') {
+          onLifecycle(data as { name: string } & AgentLifecycle);
         } else if (data.type === 'summary') {
           onComplete(data as SummaryPayload);
           setLoading(false);


### PR DESCRIPTION
## Summary
- add collapsible AgentStatusPanel to track each agent's progress
- stream lifecycle events from MatchupInputForm to update panel in real time
- wire home page to manage agent status state and display the panel above the footer

## Testing
- `npm test`
- `TS_NODE_COMPILER_OPTIONS='{\"module\":\"CommonJS\"}' npx ts-node smoke.ts` *(lifecycle event smoke test)*


------
https://chatgpt.com/codex/tasks/task_e_6892a45561c883238b0e40b0dd5af43b