### PR TITLE
feat: enhance confidence meter props

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -102,8 +102,7 @@ const AgentCard: React.FC<Props> = ({
         <span className="text-sm text-gray-700">Favored: {result.team}</span>
       )}
       <ConfidenceMeter
-        value={scorePct}
-        showLabel={false}
+        confidence={scorePct}
         gradientClass="from-green-400 via-blue-500 to-purple-600"
       />
       <div className="text-xs text-gray-600 flex items-center">

--- a/components/ConfidenceMeter.tsx
+++ b/components/ConfidenceMeter.tsx
@@ -1,21 +1,26 @@
 import React, { useEffect, useState } from 'react';
 
+interface Team {
+  name: string;
+}
+
 interface Props {
+  teamA?: Team;
+  teamB?: Team;
   /** confidence value in percent (0-100) */
-  value: number;
-  /** optional label to show above bar */
-  label?: string;
-  /** whether to show numeric percentage label */
-  showLabel?: boolean;
+  confidence: number;
+  /** optional history of previous confidences */
+  history?: number[];
   /** gradient classes for the bar */
   gradientClass?: string;
   className?: string;
 }
 
 const ConfidenceMeter: React.FC<Props> = ({
-  value,
-  label = 'Confidence',
-  showLabel = true,
+  teamA,
+  teamB,
+  confidence,
+  history = [],
   gradientClass = 'from-green-400 to-red-500',
   className = '',
 }) => {
@@ -23,6 +28,7 @@ const ConfidenceMeter: React.FC<Props> = ({
   const [display, setDisplay] = useState(0);
 
   useEffect(() => {
+    const value = Math.max(0, Math.min(100, confidence));
     setFill(0);
     setDisplay(0);
     const duration = 700;
@@ -43,16 +49,21 @@ const ConfidenceMeter: React.FC<Props> = ({
       clearInterval(counter);
       clearTimeout(timer);
     };
-  }, [value]);
+  }, [confidence]);
+
+  const teamALabel = teamA?.name;
+  const teamBLabel = teamB?.name;
+  const showTeams = Boolean(teamALabel || teamBLabel);
 
   return (
-    <div aria-label={`Confidence ${value}%`} className={className}>
-      {showLabel && (
-        <div className="flex justify-between items-center mb-1">
-          <span className="font-semibold">{label}</span>
-          <span className="font-bold">{display}%</span>
-        </div>
-      )}
+    <div aria-label={`Confidence ${confidence}%`} className={className}>
+      <div
+        className={`flex items-center mb-1 ${showTeams ? 'justify-between' : 'justify-end'}`}
+      >
+        {showTeams && <span className="font-semibold">{teamALabel}</span>}
+        <span className="font-bold">{display}%</span>
+        {showTeams && <span className="font-semibold">{teamBLabel}</span>}
+      </div>
       <div className="relative w-full h-3 bg-gray-200 rounded overflow-hidden">
         <div
           className={`absolute inset-0 bg-gradient-to-r ${gradientClass} opacity-20 blur-sm animate-pulse`}
@@ -60,14 +71,13 @@ const ConfidenceMeter: React.FC<Props> = ({
         <div
           className={`relative h-full bg-gradient-to-r ${gradientClass} transition-[width] duration-700 ease-out`}
           style={{ width: `${fill}%` }}
-        >
-          {showLabel && (
-            <span className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 bg-gray-800 text-white text-xs px-1 py-0.5 rounded shadow">
-              {display}%
-            </span>
-          )}
-        </div>
+        />
       </div>
+      {history.length > 0 && (
+        <div className="mt-1 text-xs text-gray-500">
+          {history.join(', ')}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- broaden ConfidenceMeter to accept team objects, percentage confidence, and history
- show team names with animated bar and optional history list
- adjust AgentCard to use new ConfidenceMeter props

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6892a70731a48323be33846acd4a4324