### PR TITLE
Implement dynamic upcoming games panel with ConfidenceMeter

### DIFF
--- a/components/ConfidenceMeter.tsx
+++ b/components/ConfidenceMeter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-interface ConfidenceMeterProps {
+export interface ConfidenceMeterProps {
   teamA: { name: string };
   teamB: { name: string };
   confidence: number;

--- a/components/UpcomingGamesPanel.tsx
+++ b/components/UpcomingGamesPanel.tsx
@@ -1,19 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import AgentCard from './AgentCard';
 import TeamBadge from './TeamBadge';
+import ConfidenceMeter, { ConfidenceMeterProps } from './ConfidenceMeter';
 import { AgentExecution } from '../lib/flow/runFlow';
 
 interface UpcomingGame {
-  homeTeam: string;
-  awayTeam: string;
-  league?: string;
-  time?: string;
-  edgePick: {
-    winner: string;
-    confidence: number;
-    topReasons: string[];
-    agents: AgentExecution[];
-  };
+  homeTeam: ConfidenceMeterProps['teamA'];
+  awayTeam: ConfidenceMeterProps['teamB'];
+  confidence: number;
+  history?: number[];
+  league: string;
+  time: string;
+  edgePick: AgentExecution[];
 }
 
 const UpcomingGamesPanel: React.FC = () => {
@@ -60,12 +58,10 @@ const UpcomingGamesPanel: React.FC = () => {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
       {games.map((game, idx) => {
-        const agentResults = game.edgePick.agents
+        const agentResults = game.edgePick
           .filter((a) => a.result && a.name !== 'guardianAgent')
-          .sort((a, b) => (b.result!.score - a.result!.score));
-        const guardian = game.edgePick.agents.find(
-          (a) => a.name === 'guardianAgent'
-        );
+          .sort((a, b) => b.result!.score - a.result!.score);
+        const guardian = game.edgePick.find((a) => a.name === 'guardianAgent');
         return (
           <div
             key={idx}
@@ -74,19 +70,26 @@ const UpcomingGamesPanel: React.FC = () => {
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
               <h3 className="font-semibold flex items-center gap-2">
                 <span className="flex items-center gap-2">
-                  <TeamBadge team={game.homeTeam} />
-                  {game.homeTeam}
+                  <TeamBadge team={game.homeTeam.name} />
+                  {game.homeTeam.name}
                 </span>
                 <span className="text-gray-400">vs</span>
                 <span className="flex items-center gap-2">
-                  <TeamBadge team={game.awayTeam} />
-                  {game.awayTeam}
+                  <TeamBadge team={game.awayTeam.name} />
+                  {game.awayTeam.name}
                 </span>
               </h3>
-              <time className="text-sm text-gray-500">
-                {game.time ? new Date(game.time).toLocaleString() : 'TBD'}
-              </time>
+              <div className="text-sm text-gray-500 flex flex-col items-end">
+                <time>{game.time}</time>
+                <span>{game.league}</span>
+              </div>
             </div>
+            <ConfidenceMeter
+              teamA={game.homeTeam}
+              teamB={game.awayTeam}
+              confidence={game.confidence}
+              history={game.history}
+            />
             <div className="flex flex-col gap-2">
               {agentResults.map((exec) => (
                 <AgentCard

--- a/lib/data/liveSports.ts
+++ b/lib/data/liveSports.ts
@@ -1,29 +1,9 @@
 import { Matchup } from '../types';
 
-// Temporary hard-coded upcoming games. Replace with real sports API integration
-// (e.g., SportsDB, ESPN, etc.) when available.
-const sampleGames: Matchup[] = [
-  {
-    homeTeam: 'Lakers',
-    awayTeam: 'Warriors',
-    time: '2024-10-16T02:00:00Z',
-    league: 'NBA',
-  },
-  {
-    homeTeam: 'Yankees',
-    awayTeam: 'Red Sox',
-    time: '2024-07-04T23:00:00Z',
-    league: 'MLB',
-  },
-  {
-    homeTeam: 'Cowboys',
-    awayTeam: 'Eagles',
-    time: '2024-09-15T17:00:00Z',
-    league: 'NFL',
-  },
-];
-
 export async function fetchUpcomingGames(): Promise<Matchup[]> {
-  // TODO: Replace with real API call.
-  return sampleGames;
+  return [
+    { homeTeam: 'DAL', awayTeam: 'PHI', matchDay: 1, time: 'Aug 10, 6:30PM', league: 'NFL' },
+    { homeTeam: 'LAL', awayTeam: 'GSW', matchDay: 1, time: 'Aug 10, 8:00PM', league: 'NBA' }
+  ];
 }
+

--- a/lib/mock/agentOutput.ts
+++ b/lib/mock/agentOutput.ts
@@ -4,6 +4,8 @@ export const mockMatchups: MatchupWithPick[] = [
   {
     homeTeam: 'Patriots',
     awayTeam: 'Jets',
+    time: '',
+    league: '',
     pick: 'Patriots',
     confidence: 0.72,
     reasons: [
@@ -15,6 +17,8 @@ export const mockMatchups: MatchupWithPick[] = [
   {
     homeTeam: 'Cowboys',
     awayTeam: 'Eagles',
+    time: '',
+    league: '',
     pick: 'Eagles',
     confidence: 0.61,
     reasons: [
@@ -26,6 +30,8 @@ export const mockMatchups: MatchupWithPick[] = [
   {
     homeTeam: 'Packers',
     awayTeam: 'Bears',
+    time: '',
+    league: '',
     pick: 'Packers',
     confidence: 0.67,
     reasons: [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,8 +2,12 @@ export interface Matchup {
   homeTeam: string;
   awayTeam: string;
   matchDay?: number;
-  time?: string;
-  league?: string;
+  /** Local start time for the event */
+  time: string;
+  /** League or competition, e.g., NFL, NBA */
+  league: string;
+  /** Optional unique identifier from a sports API */
+  gameId?: string;
 }
 
 export interface AgentResult {

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -32,7 +32,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // @ts-ignore - flush may not exist in some environments
   res.flushHeaders?.();
 
-  const matchup: Matchup = { homeTeam: teamA, awayTeam: teamB, matchDay: matchDayNum };
+  const matchup: Matchup = {
+    homeTeam: teamA,
+    awayTeam: teamB,
+    matchDay: matchDayNum,
+    time: '',
+    league: '',
+  };
 
   const flowName = typeof flowNameParam === 'string' ? flowNameParam : 'football-pick';
   const flow = await loadFlow(flowName);

--- a/pages/api/trends.ts
+++ b/pages/api/trends.ts
@@ -21,7 +21,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   await runFlow(
     flow,
-    { homeTeam: '', awayTeam: '' },
+    { homeTeam: '', awayTeam: '', time: '', league: '' },
     ({ name, result, error }) => {
       if (!error && result) {
         res.write(`data: ${JSON.stringify({ type: 'agent', name, result })}\n\n`);

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -1,42 +1,36 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { fetchUpcomingGames } from '../../lib/data/liveSports';
-import { loadFlow } from '../../lib/flow/loadFlow';
 import { runFlow, AgentExecution } from '../../lib/flow/runFlow';
 import { agents as registry } from '../../lib/agents/registry';
 import type { AgentOutputs, PickSummary } from '../../lib/types';
 import { logToSupabase } from '../../lib/logToSupabase';
 
-export default async function handler(
-  _req: NextApiRequest,
-  res: NextApiResponse
-) {
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
   try {
     const games = await fetchUpcomingGames();
-    const results = [] as {
-      homeTeam: string;
-      awayTeam: string;
-      matchDay?: number;
-      league?: string;
-      time?: string;
-      edgePick: {
-        winner: string;
-        confidence: number;
-        topReasons: string[];
-        agents: AgentExecution[];
-      };
-    }[];
+    const agentList = ['injuryScout', 'lineWatcher', 'statCruncher', 'guardianAgent'] as const;
+    const results: {
+      homeTeam: { name: string };
+      awayTeam: { name: string };
+      confidence: number;
+      history?: number[];
+      time: string;
+      league: string;
+      edgePick: AgentExecution[];
+    }[] = [];
 
     for (const game of games) {
-      const flow = await loadFlow('football-pick');
       const executions: AgentExecution[] = [];
-      const outputs = await runFlow(flow, game, (exec) => executions.push(exec));
+      const outputs = await runFlow({ name: 'upcoming', agents: [...agentList] }, game, (exec) =>
+        executions.push(exec)
+      );
 
       const scores: Record<string, number> = {
         [game.homeTeam]: 0,
         [game.awayTeam]: 0,
       };
 
-      flow.agents.forEach((name) => {
+      agentList.forEach((name) => {
         const meta = registry.find((a) => a.name === name);
         const result = outputs[name];
         if (!meta || !result) return;
@@ -44,40 +38,24 @@ export default async function handler(
       });
 
       const winner =
-        scores[game.homeTeam] >= scores[game.awayTeam]
-          ? game.homeTeam
-          : game.awayTeam;
-      const confidence = Math.max(scores[game.homeTeam], scores[game.awayTeam]);
-      const topReasons = flow.agents
+        scores[game.homeTeam] >= scores[game.awayTeam] ? game.homeTeam : game.awayTeam;
+      const confidenceRaw = Math.max(scores[game.homeTeam], scores[game.awayTeam]);
+      const confidence = Math.round(confidenceRaw * 100);
+      const topReasons = agentList
         .map((name) => outputs[name]?.reason)
         .filter((r): r is string => Boolean(r));
-      const pickSummary: PickSummary = {
-        winner,
-        confidence,
-        topReasons,
-      };
 
-      logToSupabase(
-        game,
-        outputs as AgentOutputs,
-        pickSummary,
-        null,
-        'football-pick',
-        true
-      );
+      const pickSummary: PickSummary = { winner, confidence: confidenceRaw, topReasons };
+
+      logToSupabase(game, outputs as AgentOutputs, pickSummary, null, 'upcoming-games', true);
 
       results.push({
-        homeTeam: game.homeTeam,
-        awayTeam: game.awayTeam,
-        matchDay: game.matchDay,
-        league: game.league,
+        homeTeam: { name: game.homeTeam },
+        awayTeam: { name: game.awayTeam },
+        confidence,
         time: game.time,
-        edgePick: {
-          winner,
-          confidence,
-          topReasons,
-          agents: executions,
-        },
+        league: game.league,
+        edgePick: executions,
       });
     }
 
@@ -87,3 +65,4 @@ export default async function handler(
     res.status(500).json({ error: 'Failed to fetch upcoming games' });
   }
 }
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -99,7 +99,9 @@ const HomePage: React.FC = () => {
           >
             Powered by modular agents — more sports coming soon.
           </p>
-          <button onClick={handleSeeUpcomingGames}>🏈 See Upcoming Games</button>
+          <button onClick={handleSeeUpcomingGames}>
+            {showUpcomingGames ? 'Hide Upcoming Games' : '🏈 See Upcoming Games'}
+          </button>
         </header>
         {showUpcomingGames && <UpcomingGamesPanel />}
         <MatchupInputForm


### PR DESCRIPTION
## Summary
- expand Matchup type with league, time, and gameId fields
- add live sports stub and API route to run injury, line, stats and guardian agents for upcoming games
- render upcoming games panel with ConfidenceMeter and guardian warnings on landing page

## Testing
- `npm test`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892a9bc39a48323b44f1721a167c6f5