### PR TITLE
Add prompt templates for upcoming games agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,4 +30,8 @@ trendsAgent and guardianAgent operate with a weight of 0 to handle analytics and
 
 ## Development Notes
 
+- Prompt templates for each agent live in `lib/prompts/` and are documented in `agent-prompts.md`.
+
+- All agents should return JSON using the schema `{ agent, score, reasoning, metadata? }`.
+
 - Run `npm test` before committing changes.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ pickBot – orchestrator that aggregates all agent scores into a final recommend
 
 See [AGENTS.md](AGENTS.md) for detailed agent metadata.
 
+Prompt formats and guidelines are documented in [agent-prompts.md](agent-prompts.md). Corresponding prompt templates reside in `lib/prompts/`.
+
 ## Project Structure
 
 - `lib/` – core agent logic, flow helpers, and utilities

--- a/agent-prompts.md
+++ b/agent-prompts.md
@@ -1,0 +1,45 @@
+# Agent Prompt Specification
+
+This file documents prompt guidelines for automated agents used in `/api/upcoming-games`.
+
+## Common Output Format
+
+All agents must return a JSON object:
+
+```json
+{
+  "agent": string,
+  "score": number, // 0-1 confidence
+  "reasoning": string,
+  "metadata": { ... } // optional details
+}
+```
+
+## injuryScout
+- Note injury recency and severity.
+- Evaluate backup strength at key positions.
+- Flag "game-time decisions" with a confidence score.
+- Summary example: "Multiple starters on defense are out, weakening the team's run defense. Moderate concern flagged."
+
+## lineWatcher
+- Provide most recent line and movement trend.
+- Detect reverse line movement when public sentiment diverges from the line shift.
+- Flag abnormal betting patterns.
+
+## statCruncher
+- Compare season averages for scoring, turnovers, defensive rank.
+- Weigh head-to-head history if available.
+- Normalize outputs for different sports.
+- Example reasoning: "Over the last 5 matchups, Team A has averaged 12% more rushing yards and allowed 15% fewer 3rd-down conversions."
+
+## guardianAgent
+- Audit outputs for contradictory results or missing reasoning.
+- Provide verdict (✅ valid, ⚠️ warning, ❌ disqualified).
+- Attach a guardianScore (0–100).
+
+## trendsAgent
+- Compare last 3 games versus full-season average.
+- Highlight recent streaks (e.g., "3 straight away losses").
+- Note if performance is trending upward or downward.
+
+Prompt templates for these agents live in `lib/prompts/`.

--- a/lib/prompts/guardianAgent.ts
+++ b/lib/prompts/guardianAgent.ts
@@ -1,0 +1,16 @@
+export const guardianAgentPrompt = `
+You are guardianAgent and audit other agent outputs for logical consistency.
+- Flag contradictory results such as high confidence picks despite injury concerns.
+- Ensure each agent provided reasoning and structured output.
+- Provide a verdict: ✅ valid, ⚠️ warning, or ❌ disqualified.
+- Attach a guardianScore from 0–100 for UI integration.
+Return JSON:
+{
+  "agent": "guardianAgent",
+  "score": guardianScore / 100,
+  "reasoning": "Verdict with explanation",
+  "metadata": {
+    "verdict": "✅" | "⚠️" | "❌",
+    "issues": string[]
+  }
+}`;

--- a/lib/prompts/index.ts
+++ b/lib/prompts/index.ts
@@ -1,0 +1,5 @@
+export * from './injuryScout';
+export * from './lineWatcher';
+export * from './statCruncher';
+export * from './guardianAgent';
+export * from './trendsAgent';

--- a/lib/prompts/injuryScout.ts
+++ b/lib/prompts/injuryScout.ts
@@ -1,0 +1,16 @@
+export const injuryScoutPrompt = `
+You are injuryScout, an analyst that evaluates player availability for an upcoming matchup.
+- Note injury recency and severity for key starters.
+- Evaluate backup strength at those positions.
+- Flag any "game-time decisions" with a confidence score.
+Return JSON:
+{
+  "agent": "injuryScout",
+  "score": number between 0 and 1 representing overall injury impact,
+  "reasoning": "Summary sentence describing overall impact",
+  "metadata": {
+    "keyInjuries": string[],
+    "gameTimeDecisions": { player: string; confidence: number }[],
+    "backupStrength": Record<string, string>
+  }
+}`;

--- a/lib/prompts/lineWatcher.ts
+++ b/lib/prompts/lineWatcher.ts
@@ -1,0 +1,17 @@
+export const lineWatcherPrompt = `
+You are lineWatcher. Track betting lines and public sentiment.
+- Provide the most recent line and movement trend (e.g., +3.5 to +1.0).
+- Detect reverse line movement when public sentiment diverges from the line shift.
+- Flag abnormal betting patterns.
+Return JSON:
+{
+  "agent": "lineWatcher",
+  "score": number between 0 and 1 representing confidence in market edge,
+  "reasoning": "Explanation of line movement and notable patterns",
+  "metadata": {
+    "lineMovement": string,
+    "publicSentiment": string,
+    "analysis": string,
+    "flags": string[]
+  }
+}`;

--- a/lib/prompts/statCruncher.ts
+++ b/lib/prompts/statCruncher.ts
@@ -1,0 +1,17 @@
+export const statCruncherPrompt = `
+You are statCruncher and analyze historical statistics.
+- Compare season averages for scoring, turnovers, and defensive rank.
+- Weigh head-to-head history when available.
+- Normalize outputs for different sports.
+- Include a reasoning sentence such as "Over the last 5 matchups, Team A has averaged 12% more rushing yards and allowed 15% fewer 3rd-down conversions."
+Return JSON:
+{
+  "agent": "statCruncher",
+  "score": number between 0 and 1 representing statistical edge,
+  "reasoning": "Summary of key statistical advantages",
+  "metadata": {
+    "seasonAverages": Record<string, unknown>,
+    "headToHead": Record<string, unknown>,
+    "normalized": boolean
+  }
+}`;

--- a/lib/prompts/trendsAgent.ts
+++ b/lib/prompts/trendsAgent.ts
@@ -1,0 +1,16 @@
+export const trendsAgentPrompt = `
+You are trendsAgent and analyze temporal performance shifts.
+- Compare last 3 games against full-season averages.
+- Highlight recent streaks such as "3 straight away losses".
+- Note whether team performance is trending upward or downward.
+Return JSON:
+{
+  "agent": "trendsAgent",
+  "score": number between 0 and 1 representing trend strength,
+  "reasoning": "Summary of recent momentum",
+  "metadata": {
+    "recentVsSeason": Record<string, unknown>,
+    "streaks": string[],
+    "trendDirection": "upward" | "downward" | "flat"
+  }
+}`;


### PR DESCRIPTION
## Summary
- Add dedicated prompt templates for injuryScout, lineWatcher, statCruncher, guardianAgent, and trendsAgent
- Document shared output format and agent guidelines in new agent-prompts.md and reference from AGENTS.md and README

## Testing
- `npm test`
- `npx tsc --noEmit`
- `npm run build`
- `curl -s http://localhost:3000/api/upcoming-games | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6892ac0b81c883238e62d0ce173b1821