### PR TITLE
feat: default upcoming games with manual toggle

### DIFF
--- a/components/UpcomingGamesPanel.tsx
+++ b/components/UpcomingGamesPanel.tsx
@@ -3,6 +3,7 @@ import AgentCard from './AgentCard';
 import TeamBadge from './TeamBadge';
 import ConfidenceMeter, { ConfidenceMeterProps } from './ConfidenceMeter';
 import { AgentExecution } from '../lib/flow/runFlow';
+import { formatAgentName } from '../lib/utils';
 
 interface UpcomingGame {
   homeTeam: ConfidenceMeterProps['teamA'];
@@ -18,6 +19,7 @@ const UpcomingGamesPanel: React.FC = () => {
   const [games, setGames] = useState<UpcomingGame[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [visibleCount, setVisibleCount] = useState(3);
 
   useEffect(() => {
     let cancelled = false;
@@ -57,7 +59,7 @@ const UpcomingGamesPanel: React.FC = () => {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-      {games.map((game, idx) => {
+      {games.slice(0, visibleCount).map((game, idx) => {
         const agentResults = game.edgePick
           .filter((a) => a.result && a.name !== 'guardianAgent')
           .sort((a, b) => b.result!.score - a.result!.score);
@@ -91,14 +93,31 @@ const UpcomingGamesPanel: React.FC = () => {
               history={game.history}
             />
             <div className="flex flex-col gap-2">
-              {agentResults.map((exec) => (
-                <AgentCard
-                  key={exec.name}
-                  name={exec.name as any}
-                  result={exec.result!}
-                  showTeam
-                />
-              ))}
+              <div className="hidden sm:flex flex-col gap-2">
+                {agentResults.map((exec) => (
+                  <AgentCard
+                    key={exec.name}
+                    name={exec.name as any}
+                    result={exec.result!}
+                    showTeam
+                  />
+                ))}
+              </div>
+              <div className="sm:hidden flex flex-col gap-2">
+                {agentResults.map((exec) => (
+                  <details key={exec.name} className="border rounded">
+                    <summary className="cursor-pointer px-2 py-1 font-medium">
+                      {formatAgentName(exec.name)}
+                    </summary>
+                    <AgentCard
+                      name={exec.name as any}
+                      result={exec.result!}
+                      showTeam
+                      className="mt-2"
+                    />
+                  </details>
+                ))}
+              </div>
             </div>
             {guardian?.result?.warnings && (
               <div className="bg-yellow-50 border border-yellow-200 rounded p-2">
@@ -115,6 +134,16 @@ const UpcomingGamesPanel: React.FC = () => {
           </div>
         );
       })}
+      {visibleCount < games.length && (
+        <div className="sm:col-span-2 text-center">
+          <button
+            onClick={() => setVisibleCount((c) => c + 3)}
+            className="px-4 py-2 bg-blue-600 text-white rounded mt-4 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          >
+            Show More Matchups
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/lib/logUiEvent.ts
+++ b/lib/logUiEvent.ts
@@ -1,0 +1,17 @@
+import { getSupabaseClient } from './supabaseClient';
+
+export async function logUiEvent(
+  uiEvent: string,
+  extras: Record<string, any> = {}
+): Promise<void> {
+  try {
+    const client = getSupabaseClient();
+    await client.from('ui_events').insert({
+      event: uiEvent,
+      extras,
+      created_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error('Failed to log UI event', err);
+  }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -11,3 +11,12 @@ Testing:
 Notes:
 - Add `@types/react` to devDependencies to fix build.
 
+Timestamp: 2025-08-06T02:16:43Z
+Summary:
+- Landing page features UpcomingGamesPanel with hero heading and manual entry toggle.
+- Toggle logs `uiEvent: 'toggleManualEntry'` to Supabase and reveals MatchupInputForm with animation.
+- UpcomingGamesPanel shows three matchups by default, mobile agent accordions, and "Show More Matchups" loader.
+Testing:
+- npm test — passed
+- npx tsc --noEmit — passed
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,6 +17,7 @@ import {
   AgentLifecycle,
 } from '../lib/types';
 import { agents as agentRegistry } from '../lib/agents/registry';
+import { logUiEvent } from '../lib/logUiEvent';
 
 interface ResultPayload {
   teamA: string;
@@ -32,7 +33,7 @@ const HomePage: React.FC = () => {
   const [showGlossary, setShowGlossary] = useState(true);
   const [highlightAgent, setHighlightAgent] = useState<string | null>(null);
   const [showDebug, setShowDebug] = useState(false);
-  const [showUpcomingGames, setShowUpcomingGames] = useState(false);
+  const [showManual, setShowManual] = useState(false);
   const [agentStatuses, setAgentStatuses] = useState<Partial<AgentStatusMap>>({});
 
   const handleStart = ({ teamA, teamB, matchDay }: { teamA: string; teamB: string; matchDay: number }) => {
@@ -70,8 +71,12 @@ const HomePage: React.FC = () => {
     }));
   };
 
-  const handleSeeUpcomingGames = () => {
-    setShowUpcomingGames((s) => !s);
+  const handleToggleManual = () => {
+    setShowManual((s) => !s);
+    logUiEvent('toggleManualEntry', {
+      userAgent: navigator.userAgent,
+      timestamp: new Date().toISOString(),
+    }).catch(() => {});
   };
 
   useEffect(() => {
@@ -91,39 +96,46 @@ const HomePage: React.FC = () => {
   return (
     <main className="min-h-screen bg-gray-50 p-6 pb-24">
       <div className="container max-w-screen-xl mx-auto space-y-8">
-        <header className="text-center">
-          <h1 className="text-3xl font-mono font-bold">EdgePicks – AI Matchup Insights for Any Sport.</h1>
-          <p
-            className="text-gray-600"
-            title="Our modular agents make it easy to add support for more sports soon."
+        <header className="text-center space-y-2">
+          <h1 className="text-3xl font-mono font-bold">EdgePicks</h1>
+          <p className="text-gray-600">AI-Powered Pick’em Intelligence.</p>
+          <button
+            onClick={handleToggleManual}
+            aria-expanded={showManual}
+            aria-controls="manual-entry"
+            className="mt-4 px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-400"
           >
-            Powered by modular agents — more sports coming soon.
-          </p>
-          <button onClick={handleSeeUpcomingGames}>
-            {showUpcomingGames ? 'Hide Upcoming Games' : '🏈 See Upcoming Games'}
+            🔀 Switch to Manual Entry
           </button>
         </header>
-        {showUpcomingGames && <UpcomingGamesPanel />}
-        <MatchupInputForm
-          onStart={handleStart}
-          onAgent={handleAgent}
-          onComplete={handleComplete}
-          onLifecycle={handleLifecycle}
-        />
-        {result && (
-          <div className="space-y-6">
-            {result.pick && (
-              <PickSummary
-                teamA={result.teamA}
-                teamB={result.teamB}
-                winner={result.pick.winner}
-                confidence={result.pick.confidence}
-              />
-            )}
-            <AgentSummary agents={result.agents} />
-            {showDebug && <AgentDebugPanel agents={result.agents} />}
-          </div>
-        )}
+        <UpcomingGamesPanel />
+        <div
+          id="manual-entry"
+          className={`transition-all duration-300 overflow-hidden ${
+            showManual ? 'opacity-100 max-h-[5000px]' : 'opacity-0 max-h-0'
+          }`}
+        >
+          <MatchupInputForm
+            onStart={handleStart}
+            onAgent={handleAgent}
+            onComplete={handleComplete}
+            onLifecycle={handleLifecycle}
+          />
+          {result && (
+            <div className="space-y-6 mt-6">
+              {result.pick && (
+                <PickSummary
+                  teamA={result.teamA}
+                  teamB={result.teamB}
+                  winner={result.pick.winner}
+                  confidence={result.pick.confidence}
+                />
+              )}
+              <AgentSummary agents={result.agents} />
+              {showDebug && <AgentDebugPanel agents={result.agents} />}
+            </div>
+          )}
+        </div>
         {showGlossary && (
           <ExplanationGlossary
             onClose={() => setShowGlossary(false)}


### PR DESCRIPTION
## Summary
- default landing hero to upcoming matchups with AI tagline
- add manual entry toggle and logging to Supabase
- limit upcoming panel to three games with mobile accordion and loader

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6892ba2d4a74832391d93b063ec591d7