### PR TITLE
feat: add hero section with featured matchup

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import useSWR from 'swr';
+import TeamBadge from './TeamBadge';
+import ConfidenceMeter from './ConfidenceMeter';
+import { formatAgentName } from '../lib/utils';
+import type { AgentExecution } from '../lib/flow/runFlow';
+import type { ConfidenceMeterProps } from './ConfidenceMeter';
+
+interface UpcomingGame {
+  homeTeam: ConfidenceMeterProps['teamA'];
+  awayTeam: ConfidenceMeterProps['teamB'];
+  confidence: number;
+  time: string;
+  league: string;
+  edgePick: AgentExecution[];
+}
+
+const valueProps = [
+  'Injury Insights',
+  'Line Movement Alerts',
+  'Stat Crunches',
+  'Trend Analysis',
+];
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+const HeroSection: React.FC = () => {
+  const { data } = useSWR<UpcomingGame[]>('/api/upcoming-games', fetcher);
+  const game = data && data.length > 0 ? data[0] : null;
+  const [index, setIndex] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setVisible(false);
+      setTimeout(() => {
+        setIndex((i) => (i + 1) % valueProps.length);
+        setVisible(true);
+      }, 500);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleScroll = () => {
+    document
+      .getElementById('upcoming-games')
+      ?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <section className="text-center space-y-8 py-12">
+      <h1 className="text-4xl sm:text-5xl font-bold">
+        Don’t Bet Blind – AI Agents. Real Reasons. Weekly Picks with an Edge.
+      </h1>
+      <div className="h-8 text-xl text-blue-700 font-mono">
+        <span
+          className={`block transition-opacity duration-500 ease-in-out ${
+            visible ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
+          {valueProps[index]}
+        </span>
+      </div>
+      <div
+        className={`max-w-md mx-auto bg-white rounded-xl shadow p-6 transition-transform duration-300 hover:scale-105 ${
+          game ? '' : 'animate-pulse'
+        }`}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="font-semibold text-lg">Today's Edge</h2>
+          <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded">
+            AI-Powered Pick
+          </span>
+        </div>
+        {game ? (
+          <>
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                <TeamBadge team={game.homeTeam.name} />
+                <span>{game.homeTeam.name}</span>
+                <span className="text-gray-400">vs</span>
+                <TeamBadge team={game.awayTeam.name} />
+                <span>{game.awayTeam.name}</span>
+              </div>
+              <time className="text-sm text-gray-500">{game.time}</time>
+            </div>
+            <ConfidenceMeter
+              teamA={game.homeTeam}
+              teamB={game.awayTeam}
+              confidence={game.confidence}
+            />
+            <div className="mt-4 space-y-2 text-sm text-left">
+              {game.edgePick
+                .filter((e) => e.result && e.name !== 'guardianAgent')
+                .slice(0, 2)
+                .map((e) => (
+                  <p key={e.name}>
+                    <span className="font-medium">
+                      {formatAgentName(e.name)}:
+                    </span>{' '}
+                    {e.result!.reason}
+                  </p>
+                ))}
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-gray-500">Loading matchup...</p>
+        )}
+      </div>
+      <button
+        onClick={handleScroll}
+        className="mt-4 px-6 py-3 bg-blue-600 text-white rounded focus:outline-none transition ring-2 ring-transparent hover:ring-blue-400 focus:ring-blue-400"
+      >
+        See All Matchups
+      </button>
+    </section>
+  );
+};
+
+export default HeroSection;
+

--- a/llms.txt
+++ b/llms.txt
@@ -36,3 +36,9 @@ Notes:
 - Future prompts should append to this log with timestamp and rationale to maintain LLM context continuity.
 
 
+Timestamp: 2025-08-06T02:56:23Z
+codex:edgepicks-landing-emotional-hook-and-agent-preview
+- Replaced static hero with emotional copy and agent-powered subheadline rotator
+- Added featured matchup preview (with AI agent explanations) inline
+- Introduced CTA to scroll to full predictions
+- Improved visual motion and layout polish for user engagement

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "lucide-react": "^0.536.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "swr": "^2.3.4"
       },
       "devDependencies": {
         "@types/node": "^24.2.0",
@@ -736,6 +737,15 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1909,6 +1919,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -2087,6 +2110,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lucide-react": "^0.536.0",
     "next": "^14.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "swr": "^2.3.4"
   },
   "devDependencies": {
     "@types/node": "^24.2.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import AgentStatusPanel, {
   AgentStatusMap,
 } from '../components/AgentStatusPanel';
 import UpcomingGamesPanel from '../components/UpcomingGamesPanel';
+import HeroSection from '../components/HeroSection';
 import {
   AgentOutputs,
   AgentResult,
@@ -96,9 +97,8 @@ const HomePage: React.FC = () => {
   return (
     <main className="min-h-screen bg-gray-50 p-6 pb-24">
       <div className="container max-w-screen-xl mx-auto space-y-8">
-        <header className="text-center space-y-2">
-          <h1 className="text-3xl font-mono font-bold">EdgePicks</h1>
-          <p className="text-gray-600">AI-Powered Pick’em Intelligence.</p>
+        <HeroSection />
+        <div className="text-center">
           <button
             onClick={handleToggleManual}
             aria-expanded={showManual}
@@ -107,8 +107,10 @@ const HomePage: React.FC = () => {
           >
             🔀 Switch to Manual Entry
           </button>
-        </header>
-        <UpcomingGamesPanel />
+        </div>
+        <section id="upcoming-games">
+          <UpcomingGamesPanel />
+        </section>
         <div
           id="manual-entry"
           className={`transition-all duration-300 overflow-hidden ${


### PR DESCRIPTION
## Summary
- introduce `HeroSection` with rotating agent value props and featured "Today's Edge" matchup card
- hook homepage hero into upcoming games section with smooth-scroll CTA and manual entry toggle
- log emotional hero update in `llms.txt`

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6892c373de6c8323a868d2f29ac0d37d