### PR TITLE
feat: add cross-sport NextBigGame panel

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,27 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import useSWR from 'swr';
-import TeamBadge from './TeamBadge';
-import ConfidenceMeter from './ConfidenceMeter';
-import { formatAgentName } from '../lib/utils';
-import type { AgentExecution } from '../lib/flow/runFlow';
-import type { ConfidenceMeterProps } from './ConfidenceMeter';
-
-interface UpcomingGame {
-  homeTeam: ConfidenceMeterProps['teamA'];
-  awayTeam: ConfidenceMeterProps['teamB'];
-  confidence: number;
-  time: string;
-  league: string;
-  edgePick: AgentExecution[];
-  odds?: {
-    spread?: number;
-    overUnder?: number;
-    moneyline?: { home?: number; away?: number };
-    bookmaker?: string;
-    lastUpdate?: string;
-  };
-  source?: string;
-}
+import NextBigGame from './NextBigGame';
 
 const valueProps = [
   'Injury Insights',
@@ -30,11 +8,7 @@ const valueProps = [
   'Trend Analysis',
 ];
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
-
 const HeroSection: React.FC = () => {
-  const { data } = useSWR<UpcomingGame[]>('/api/upcoming-games', fetcher);
-  const game = data && data.length > 0 ? data[0] : null;
   const [index, setIndex] = useState(0);
   const [visible, setVisible] = useState(true);
 
@@ -69,52 +43,7 @@ const HeroSection: React.FC = () => {
           {valueProps[index]}
         </span>
       </div>
-      <div
-        className={`max-w-md mx-auto bg-white rounded-xl shadow p-6 transition-transform duration-300 hover:scale-105 ${
-          game ? '' : 'animate-pulse'
-        }`}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="font-semibold text-lg">Today's Edge</h2>
-          <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded">
-            AI-Powered Pick
-          </span>
-        </div>
-        {game ? (
-          <>
-            <div className="flex items-center justify-between mb-2">
-              <div className="flex items-center gap-2">
-                <TeamBadge team={game.homeTeam.name} logoUrl={game.homeTeam.logo} />
-                <span>{game.homeTeam.name}</span>
-                <span className="text-gray-400">vs</span>
-                <TeamBadge team={game.awayTeam.name} logoUrl={game.awayTeam.logo} />
-                <span>{game.awayTeam.name}</span>
-              </div>
-              <time className="text-sm text-gray-500">{game.time}</time>
-            </div>
-            <ConfidenceMeter
-              teamA={game.homeTeam}
-              teamB={game.awayTeam}
-              confidence={game.confidence}
-            />
-            <div className="mt-4 space-y-2 text-sm text-left">
-              {game.edgePick
-                .filter((e) => e.result && e.name !== 'guardianAgent')
-                .slice(0, 2)
-                .map((e) => (
-                  <p key={e.name}>
-                    <span className="font-medium">
-                      {formatAgentName(e.name)}:
-                    </span>{' '}
-                    {e.result!.reason}
-                  </p>
-                ))}
-            </div>
-          </>
-        ) : (
-          <p className="text-sm text-gray-500">Loading matchup...</p>
-        )}
-      </div>
+      <NextBigGame />
       <button
         onClick={handleScroll}
         className="mt-4 px-6 py-3 bg-blue-600 text-white rounded focus:outline-none transition ring-2 ring-transparent hover:ring-blue-400 focus:ring-blue-400"

--- a/components/NextBigGame.tsx
+++ b/components/NextBigGame.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import TeamBadge from './TeamBadge';
+import AgentRationalePanel from './AgentRationalePanel';
+import type { AgentExecution } from '../lib/flow/runFlow';
+
+interface BigGame {
+  homeTeam: { name: string; logo?: string; score?: number };
+  awayTeam: { name: string; logo?: string; score?: number };
+  league: string;
+  time: string;
+  confidence: number;
+  edgeDelta: number;
+  winner: string;
+  edgePick: AgentExecution[];
+  score?: { home: number; away: number };
+}
+
+const leagueIcons: Record<string, string> = {
+  NFL: '🏈',
+  NBA: '🏀',
+  MLB: '⚾',
+  NHL: '🏒',
+  MLS: '⚽',
+};
+
+const NextBigGame: React.FC = () => {
+  const [game, setGame] = useState<BigGame | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showRationale, setShowRationale] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/upcoming-games');
+        if (res.ok) {
+          const data: BigGame[] = await res.json();
+          if (data.length) setGame(data[0]);
+        }
+      } catch (err) {
+        console.error('Failed to load next big game', err);
+      } finally {
+        setLoading(false);
+        setTimeout(() => setVisible(true), 100);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return <p className="text-sm text-gray-500">Loading next game...</p>;
+  }
+
+  if (!game) {
+    return (
+      <p className="text-sm text-gray-500">
+        No live games found at this moment. Check back soon or enter a matchup manually.
+      </p>
+    );
+  }
+
+  const icon = leagueIcons[game.league] || '🏟️';
+
+  return (
+    <div
+      className={`max-w-md mx-auto bg-white rounded-xl shadow p-6 transition-all duration-700 ease-in-out delay-200 transform ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+      }`}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <span className="text-2xl" aria-hidden>{icon}</span>
+          <span className="text-sm font-medium">{game.league}</span>
+        </div>
+        <time className="text-sm text-gray-500">{game.time}</time>
+      </div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <TeamBadge team={game.homeTeam.name} logoUrl={game.homeTeam.logo} />
+          <span>{game.homeTeam.name}</span>
+        </div>
+        <span className="text-gray-400">vs</span>
+        <div className="flex items-center gap-2">
+          <TeamBadge team={game.awayTeam.name} logoUrl={game.awayTeam.logo} />
+          <span>{game.awayTeam.name}</span>
+        </div>
+      </div>
+      {game.score ? (
+        <div className="text-center text-xl font-bold">
+          {game.score.home} - {game.score.away}
+        </div>
+      ) : (
+        <p className="text-center text-sm text-gray-500">Upcoming</p>
+      )}
+      <div className="mt-4 text-sm text-left">
+        Agent Edge: {game.confidence}% | Confidence Δ {Math.round(game.edgeDelta * 100)}%
+      </div>
+      <div className="mt-2 text-left">
+        <button
+          onClick={() => setShowRationale((s) => !s)}
+          className="text-blue-600 text-sm underline focus:outline-none"
+        >
+          {showRationale ? 'Hide Rationale' : 'View Rationale'}
+        </button>
+        {showRationale && (
+          <div className="mt-2">
+            <AgentRationalePanel executions={game.edgePick} winner={game.winner} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NextBigGame;
+

--- a/llms.txt
+++ b/llms.txt
@@ -56,3 +56,9 @@ Agents now evaluate live matchups with visible rationales and edge breakdowns
 ConfidenceMeter reflects betting spreads and disagreement signals
 AgentRationalePanel added for deeper trust in each pick
 Live-data transparency surfaced in UI
+ 
+Timestamp: 2025-08-06T03:39:45Z
+codex:landing-multisport-forecast-panel
+- Added <NextBigGame /> component to highlight live cross-sport matchups
+- Included live status, team logos, agent edge, and rationale access
+- Improved fallback UI for empty schedules


### PR DESCRIPTION
## Summary
- highlight next live matchup with new `<NextBigGame />` component
- integrate panel into hero with fade-in-up animation and rationale link
- log multisport forecast panel in llms.txt

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6892cd4ff3d88323aa1bde97756b724d