### PR TITLE
Fix live matchup fetch failure with fallback data

### DIFF
--- a/lib/data/liveSports.ts
+++ b/lib/data/liveSports.ts
@@ -25,9 +25,18 @@ interface OddsGame {
 }
 
 export async function fetchUpcomingGames(): Promise<Matchup[]> {
+  const isDev = process.env.NODE_ENV === 'development';
   try {
     const res = await fetch(SPORTSDB_EVENTS_URL);
     const json = await res.json();
+    if (isDev) {
+      console.log('TheSportsDB response', {
+        status: res.status,
+        error: res.ok ? undefined : res.statusText,
+        dataLength: json.events ? json.events.length : 0,
+        data: json,
+      });
+    }
     const events: SportsDbEvent[] = json.events ? json.events.slice(0, 5) : [];
 
     const teamIds = Array.from(
@@ -45,7 +54,7 @@ export async function fetchUpcomingGames(): Promise<Matchup[]> {
           const team = d.teams && d.teams[0];
           if (team?.strTeamBadge) logoMap[id] = team.strTeamBadge;
         } catch (err) {
-          console.error('team lookup failed', err);
+          if (isDev) console.error('team lookup failed', err);
         }
       })
     );
@@ -60,9 +69,17 @@ export async function fetchUpcomingGames(): Promise<Matchup[]> {
         if (oddsRes.ok) {
           oddsData = await oddsRes.json();
         }
+        if (isDev) {
+          console.log('OddsAPI response', {
+            status: oddsRes.status,
+            error: oddsRes.ok ? undefined : oddsRes.statusText,
+            dataLength: oddsData.length,
+            data: oddsData,
+          });
+        }
       }
     } catch (err) {
-      console.error('odds fetch failed', err);
+      if (isDev) console.error('odds fetch failed', err);
     }
 
     return events.map((e) => {
@@ -103,7 +120,7 @@ export async function fetchUpcomingGames(): Promise<Matchup[]> {
       } as Matchup;
     });
   } catch (err) {
-    console.error('fetchUpcomingGames error', err);
+    if (isDev) console.error('fetchUpcomingGames error', err);
     return [];
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,6 +25,7 @@ export interface Matchup {
   /** Flags to indicate real-time data */
   isLiveData?: boolean;
   source?: string;
+  useFallback?: boolean;
 }
 
 export interface AgentResult {

--- a/lib/utils/fallbackMatchups.ts
+++ b/lib/utils/fallbackMatchups.ts
@@ -1,0 +1,16 @@
+import { Matchup } from '../types';
+
+export function getFallbackMatchups(): (Matchup & { useFallback: true })[] {
+  return [
+    {
+      homeTeam: 'Dallas Cowboys',
+      awayTeam: 'New York Giants',
+      time: '2025-09-07T20:20:00Z',
+      league: 'NFL',
+      homeLogo: 'https://a.espncdn.com/i/teamlogos/nfl/500/dal.png',
+      awayLogo: 'https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png',
+      useFallback: true,
+      source: 'fallback',
+    },
+  ];
+}

--- a/llms.txt
+++ b/llms.txt
@@ -56,3 +56,8 @@ Agents now evaluate live matchups with visible rationales and edge breakdowns
 ConfidenceMeter reflects betting spreads and disagreement signals
 AgentRationalePanel added for deeper trust in each pick
 Live-data transparency surfaced in UI
+Timestamp: 2025-08-06T03:38:12Z
+codex:fix-liveMatchup-fetch-failure
+- Fixed bug causing "No upcoming games found" when APIs failed silently
+- Added logging for dev inspection and fallback data loader for resilience
+- Agent run flow now handles missing odds/logos safely

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -4,10 +4,14 @@ import { runFlow, AgentExecution } from '../../lib/flow/runFlow';
 import { agents as registry } from '../../lib/agents/registry';
 import type { AgentOutputs, PickSummary } from '../../lib/types';
 import { logToSupabase } from '../../lib/logToSupabase';
+import { getFallbackMatchups } from '../../lib/utils/fallbackMatchups';
 
 export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
   try {
-    const games = await fetchUpcomingGames();
+    let games = await fetchUpcomingGames();
+    if (!games.length) {
+      games = getFallbackMatchups();
+    }
     const agentList = ['injuryScout', 'lineWatcher', 'statCruncher', 'guardianAgent'] as const;
     const results: {
       homeTeam: { name: string; logo?: string };
@@ -24,6 +28,7 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
         lastUpdate?: string;
       };
       source?: string;
+      useFallback?: boolean;
       winner: string;
       edgeDelta: number;
       confidenceDrop: number;
@@ -34,73 +39,80 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
     }[] = [];
 
     for (const game of games) {
-      const { outputs, executions } = await runFlow(
-        { name: 'upcoming', agents: [...agentList] },
-        { ...game, isLiveData: true, source: 'live-nfl-api' }
-      );
+      if (!game.homeTeam || !game.awayTeam) continue;
+      try {
+        const { outputs, executions } = await runFlow(
+          { name: 'upcoming', agents: [...agentList] },
+          { ...game, isLiveData: game.source !== 'fallback', source: game.source }
+        );
 
-      const scores: Record<string, number> = {
-        [game.homeTeam]: 0,
-        [game.awayTeam]: 0,
-      };
+        const scores: Record<string, number> = {
+          [game.homeTeam]: 0,
+          [game.awayTeam]: 0,
+        };
 
-      agentList.forEach((name) => {
-        const meta = registry.find((a) => a.name === name);
-        const result = outputs[name];
-        if (!meta || !result) return;
-        scores[result.team] += result.score * meta.weight;
-      });
+        agentList.forEach((name) => {
+          const meta = registry.find((a) => a.name === name);
+          const result = outputs[name];
+          if (!meta || !result) return;
+          scores[result.team] += result.score * meta.weight;
+        });
 
-      const winner =
-        scores[game.homeTeam] >= scores[game.awayTeam] ? game.homeTeam : game.awayTeam;
-      const confidenceRaw = Math.max(scores[game.homeTeam], scores[game.awayTeam]);
-      const confidence = Math.round(confidenceRaw * 100);
-      const edgeDelta = Math.abs(scores[game.homeTeam] - scores[game.awayTeam]);
-      const confidenceDrop = 1 - confidenceRaw;
-      const publicLean = (() => {
-        const home = game.odds?.moneyline?.home;
-        const away = game.odds?.moneyline?.away;
-        if (home !== undefined && away !== undefined) {
-          const total = Math.abs(home) + Math.abs(away);
-          return total ? Math.round((Math.abs(home) / total) * 100) : undefined;
-        }
-        return undefined;
-      })();
-      const agentDelta = game.odds?.spread !== undefined ? edgeDelta - game.odds.spread : undefined;
-      const disagreements = executions
-        .filter((e) => e.result && e.result.team !== winner)
-        .map((e) => e.name);
-      const topReasons = agentList
-        .map((name) => outputs[name]?.reason)
-        .filter((r): r is string => Boolean(r));
+        const winner =
+          scores[game.homeTeam] >= scores[game.awayTeam] ? game.homeTeam : game.awayTeam;
+        const confidenceRaw = Math.max(scores[game.homeTeam], scores[game.awayTeam]);
+        const confidence = Math.round(confidenceRaw * 100);
+        const edgeDelta = Math.abs(scores[game.homeTeam] - scores[game.awayTeam]);
+        const confidenceDrop = 1 - confidenceRaw;
+        const publicLean = (() => {
+          const home = game.odds?.moneyline?.home;
+          const away = game.odds?.moneyline?.away;
+          if (home !== undefined && away !== undefined) {
+            const total = Math.abs(home) + Math.abs(away);
+            return total ? Math.round((Math.abs(home) / total) * 100) : undefined;
+          }
+          return undefined;
+        })();
+        const agentDelta =
+          game.odds?.spread !== undefined ? edgeDelta - game.odds.spread : undefined;
+        const disagreements = executions
+          .filter((e) => e.result && e.result.team !== winner)
+          .map((e) => e.name);
+        const topReasons = agentList
+          .map((name) => outputs[name]?.reason)
+          .filter((r): r is string => Boolean(r));
 
-      const pickSummary: PickSummary = { winner, confidence: confidenceRaw, topReasons };
+        const pickSummary: PickSummary = { winner, confidence: confidenceRaw, topReasons };
 
-      logToSupabase(
-        { ...game, source: 'live-nfl-api' },
-        outputs as AgentOutputs,
-        pickSummary,
-        null,
-        'upcoming-games',
-        true
-      );
+        logToSupabase(
+          { ...game },
+          outputs as AgentOutputs,
+          pickSummary,
+          null,
+          'upcoming-games',
+          true
+        );
 
-      results.push({
-        homeTeam: { name: game.homeTeam, logo: game.homeLogo },
-        awayTeam: { name: game.awayTeam, logo: game.awayLogo },
-        confidence,
-        time: game.time,
-        league: game.league,
-        odds: game.odds,
-        source: 'live-nfl-api',
-        winner,
-        edgeDelta,
-        confidenceDrop,
-        publicLean,
-        agentDelta,
-        disagreements,
-        edgePick: executions,
-      });
+        results.push({
+          homeTeam: { name: game.homeTeam, logo: game.homeLogo },
+          awayTeam: { name: game.awayTeam, logo: game.awayLogo },
+          confidence,
+          time: game.time,
+          league: game.league,
+          odds: game.odds,
+          source: game.source,
+          useFallback: game.useFallback,
+          winner,
+          edgeDelta,
+          confidenceDrop,
+          publicLean,
+          agentDelta,
+          disagreements,
+          edgePick: executions,
+        });
+      } catch (err) {
+        console.error('agent run failed', err);
+      }
     }
 
     res.status(200).json(results);


### PR DESCRIPTION
## Summary
- log TheSportsDB and OddsAPI responses during development for easier debugging
- add hard-coded NFL fallback matchup and use it when live data is empty
- guard agent flow against missing fields and tag fallback payloads

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6892cd57f1788323b8647f5d586b345c