### PR TITLE
feat: support multi-league upcoming games

### DIFF
--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -8,7 +8,9 @@ import { getFallbackMatchups } from '../../lib/utils/fallbackMatchups';
 
 export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
   try {
-    let games = await fetchUpcomingGames();
+    const leagues = ['NFL', 'MLB', 'NBA', 'NHL'] as const;
+    const allGames = await Promise.all(leagues.map((l) => fetchUpcomingGames(l)));
+    let games = allGames.flat();
     if (!games.length) {
       games = getFallbackMatchups();
     }


### PR DESCRIPTION
## Summary
- load SportsDB API key and league IDs from environment variables
- refactor `fetchUpcomingGames` to accept a league and build API URLs dynamically
- aggregate upcoming games across NFL, MLB, NBA, and NHL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892d5e8b83083239604f59e5ba6eb4d