### PR TITLE
feat: automate llms changelog

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,1 @@
+node scripts/update-llms-log.js

--- a/llms.txt
+++ b/llms.txt
@@ -98,3 +98,20 @@ Files:
 - README.md
 - package-lock.json
 - package.json
+Timestamp: 2025-08-06T04:35:34.940Z
+Commit: 671427f39dd513fb6fe4a0ed1e7e8c8e1ea09bf5
+Author: Codex
+Message: feat: automate llms log on commit
+Files:
+- .husky/post-commit (+4/-0)
+- package.json (+1/-1)
+- scripts/update-llms-log.js (+61/-0)
+- scripts/update-llms-log.test.js (+42/-0)
+
+Timestamp: 2025-08-06T04:36:27.171Z
+Commit: ff71ec898de7c67aa04c6a54741d19922c29fab5
+Author: Codex
+Message: chore: fix post-commit hook style
+Files:
+- .husky/post-commit (+0/-3)
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "echo \"No tests\"",
+    "test": "node scripts/update-llms-log.test.js",
     "postinstall": "node -e \"try{require.resolve('@types/react')}catch(e){console.warn('@types/react not found')}\"",
     "postpush": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/log-llms-entry.ts",
     "prepare": "husky"

--- a/scripts/update-llms-log.js
+++ b/scripts/update-llms-log.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function run(cmd) {
+  return execSync(cmd, { stdio: ['pipe', 'pipe', 'ignore'] }).toString().trim();
+}
+
+function getTaskName(message, branch) {
+  const firstLine = message.split('\n')[0].trim();
+  if (firstLine.startsWith('codex:')) {
+    return firstLine.slice('codex:'.length).trim();
+  }
+  if (branch.startsWith('codex/')) {
+    return branch.slice('codex/'.length).trim();
+  }
+  return null;
+}
+
+function main() {
+  const commitMsg = run('git log -1 --pretty=%B');
+  if (/\[skip-llms\]/.test(commitMsg)) return;
+
+  const hash = run('git rev-parse HEAD');
+  const author = run('git log -1 --pretty=%an');
+  const timestamp = new Date().toISOString();
+  const branch = run('git rev-parse --abbrev-ref HEAD');
+  const task = getTaskName(commitMsg, branch);
+
+  const numstat = run('git show --numstat --format="" HEAD');
+  const files = numstat
+    .split('\n')
+    .filter(Boolean)
+    .map(line => {
+      const [added, removed, file] = line.split('\t');
+      return `- ${file} (+${added}/-${removed})`;
+    })
+    .join('\n');
+
+  let entry = `Timestamp: ${timestamp}\nCommit: ${hash}\nAuthor: ${author}\nMessage: ${commitMsg.split('\n')[0]}\n`;
+  if (task) entry += `Task: ${task}\n`;
+  entry += `Files:\n${files}\n\n`;
+
+  const logPath = path.join(process.cwd(), 'llms.txt');
+  fs.appendFileSync(logPath, entry);
+
+  run('git add llms.txt');
+  run('git commit --no-verify -m "chore: update llms log [skip-llms]"');
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+module.exports = { run, getTaskName, main };

--- a/scripts/update-llms-log.test.js
+++ b/scripts/update-llms-log.test.js
@@ -1,0 +1,42 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const assert = require('assert');
+
+const script = path.join(__dirname, 'update-llms-log.js');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'llms-log-test-'));
+
+function run(cmd) {
+  return execSync(cmd, { cwd: tmp, stdio: 'pipe' }).toString().trim();
+}
+
+// initialize repo
+run('git init');
+fs.writeFileSync(path.join(tmp, 'llms.txt'), '');
+fs.writeFileSync(path.join(tmp, 'a.txt'), 'hello');
+run('git add .');
+run('git commit -m "feat: initial"');
+
+// run script and verify log
+run(`node ${script}`);
+const log1 = fs.readFileSync(path.join(tmp, 'llms.txt'), 'utf8');
+assert(log1.includes('feat: initial'), 'log should include commit message');
+assert(/Commit: [0-9a-f]{7,}/.test(log1), 'log should include commit hash');
+assert(log1.includes('a.txt'), 'log should list changed file');
+const count1 = run('git rev-list --count HEAD');
+assert.strictEqual(count1, '2');
+const lastMsg1 = run('git log -1 --pretty=%s');
+assert(lastMsg1.includes('[skip-llms]'), 'log commit should contain skip flag');
+
+// create commit that should be skipped
+fs.writeFileSync(path.join(tmp, 'b.txt'), 'more');
+run('git add b.txt');
+run('git commit -m "chore: ignore [skip-llms]"');
+run(`node ${script}`);
+const count2 = run('git rev-list --count HEAD');
+assert.strictEqual(count2, '3', 'no extra commit for skipped log');
+const log2 = fs.readFileSync(path.join(tmp, 'llms.txt'), 'utf8');
+assert(!log2.includes('chore: ignore'), 'skipped commit should not be logged');
+
+console.log('All update-llms-log tests passed');


### PR DESCRIPTION
## Summary
- add update-llms-log.js to capture commit metadata and append entries to llms.txt
- wire up husky post-commit hook for automatic logging
- add tests for logging behavior and skip flag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892dab19c148323922a81a0cd831313