### PR TITLE
feat: add run predictions API and beta banner

### DIFF
--- a/components/LiveGamesList.tsx
+++ b/components/LiveGamesList.tsx
@@ -1,39 +1,28 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Image from 'next/image';
-import { getUpcomingGames } from '../lib/api';
 
 interface Game {
   homeTeam: { name: string; logo?: string };
   awayTeam: { name: string; logo?: string };
   time: string;
-  winner: string;
-  confidence: number;
 }
 
 interface Props {
   league: string;
+  games: Game[];
+  predictions: any[];
+  loadingGames: boolean;
+  loadingPredictions: boolean;
 }
 
-const LiveGamesList: React.FC<Props> = ({ league }) => {
-  const [games, setGames] = useState<Game[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    setError(null);
-    getUpcomingGames(league)
-      .then((data) => {
-        setGames(data);
-        setLoading(false);
-      })
-      .catch(() => {
-        setError('Failed to load games');
-        setLoading(false);
-      });
-  }, [league]);
-
-  if (loading) {
+const LiveGamesList: React.FC<Props> = ({
+  league,
+  games,
+  predictions,
+  loadingGames,
+  loadingPredictions,
+}) => {
+  if (loadingGames) {
     return (
       <ul className="space-y-2">
         {Array.from({ length: 3 }).map((_, i) => (
@@ -43,30 +32,35 @@ const LiveGamesList: React.FC<Props> = ({ league }) => {
     );
   }
 
-  if (error) {
-    return <p className="text-red-600">{error}</p>;
-  }
-
   if (!games.length) {
-    return <p>No games found.</p>;
+    return <p>No games found for {league}. Try again later.</p>;
   }
 
   return (
     <ul className="space-y-4">
       {games.map((g, idx) => (
-        <li key={idx} className="p-4 border rounded flex items-center gap-2">
-          {g.homeTeam.logo && (
-            <Image src={g.homeTeam.logo} alt={g.homeTeam.name} width={24} height={24} />
+        <li key={idx} className="p-4 border rounded flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            {g.homeTeam.logo && (
+              <Image src={g.homeTeam.logo} alt={g.homeTeam.name} width={24} height={24} />
+            )}
+            <span className="font-semibold">{g.homeTeam.name}</span>
+            <span className="text-gray-500">vs</span>
+            {g.awayTeam.logo && (
+              <Image src={g.awayTeam.logo} alt={g.awayTeam.name} width={24} height={24} />
+            )}
+            <span className="font-semibold">{g.awayTeam.name}</span>
+            <span className="ml-auto text-sm text-gray-600">{g.time}</span>
+          </div>
+          {loadingPredictions ? (
+            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+          ) : (
+            predictions[idx] && (
+              <div className="text-sm text-gray-600">
+                Predicted winner: {predictions[idx].winner}
+              </div>
+            )
           )}
-          <span className="font-semibold">{g.homeTeam.name}</span>
-          <span className="text-gray-500">vs</span>
-          {g.awayTeam.logo && (
-            <Image src={g.awayTeam.logo} alt={g.awayTeam.name} width={24} height={24} />
-          )}
-          <span className="font-semibold">{g.awayTeam.name}</span>
-          <span className="ml-auto text-sm text-gray-600">
-            {g.winner} ({g.confidence}%)
-          </span>
         </li>
       ))}
     </ul>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,8 +4,12 @@ export const getUpcomingGames = async (league: string = 'NFL') => {
   return res.json();
 };
 
-export const runPredictionFlow = async () => {
-  const res = await fetch('/api/run-agents', { method: 'POST' });
+export const runPredictions = async (league: string, games: any[]) => {
+  const res = await fetch('/api/run-predictions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ league, games }),
+  });
   if (!res.ok) throw new Error('Prediction flow failed');
   return res.json();
 };

--- a/llms.txt
+++ b/llms.txt
@@ -164,3 +164,10 @@ Message: chore: ensure pre-commit hook is executable
 Files:
 - .husky/pre-commit (+0/-0)
 
+Timestamp: 2025-08-06T05:18:52.490Z
+Commit: 9893448199a9e7054f5d3136d6e48cb4c5d31202
+Author: Codex
+Message: feat: implement run predictions endpoint
+Files:
+- pages/api/run-predictions.ts (+70/-0)
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 // pages/_app.tsx
 import type { AppProps } from 'next/app';
 import { SessionProvider, useSession, signIn, signOut } from 'next-auth/react';
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import '../styles/globals.css';
@@ -8,46 +9,55 @@ import ThemeToggle from '../components/ThemeToggle';
 
 function Header() {
   const { data: session, status } = useSession();
+  const [dismissed, setDismissed] = useState(false);
   return (
-    <header className="p-4 flex justify-end gap-4 items-center">
-      <ThemeToggle />
-      <Link href="/predictions" className="px-2 py-1 border rounded">
-        Predictions
-      </Link>
-      {status === 'loading' ? (
-        <div className="w-8 h-8 rounded-full bg-gray-200 animate-pulse" />
-      ) : session ? (
-        <>
-          {session.user?.image ? (
-            <Image
-              src={session.user.image}
-              alt={session.user?.name ? `${session.user.name}'s avatar` : 'User avatar'}
-              width={32}
-              height={32}
-              className="rounded-full"
-            />
-          ) : (
-            <div className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-sm">
-              {session.user?.name ? session.user.name.charAt(0) : '?'}
-            </div>
-          )}
-          <span>{session.user?.name || 'Anonymous'}</span>
+    <>
+      {process.env.NODE_ENV === 'development' && session && !dismissed && (
+        <div className="bg-green-100 border border-green-400 text-green-800 text-sm px-4 py-2 rounded mb-2 flex justify-between items-center">
+          <span>🎉 Welcome to EdgePicks Beta – Running Locally</span>
+          <button onClick={() => setDismissed(true)} aria-label="Dismiss">×</button>
+        </div>
+      )}
+      <header className="p-4 flex justify-end gap-4 items-center">
+        <ThemeToggle />
+        <Link href="/predictions" className="px-2 py-1 border rounded">
+          Predictions
+        </Link>
+        {status === 'loading' ? (
+          <div className="w-8 h-8 rounded-full bg-gray-200 animate-pulse" />
+        ) : session ? (
+          <>
+            {session.user?.image ? (
+              <Image
+                src={session.user.image}
+                alt={session.user?.name ? `${session.user.name}'s avatar` : 'User avatar'}
+                width={32}
+                height={32}
+                className="rounded-full"
+              />
+            ) : (
+              <div className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-sm">
+                {session.user?.name ? session.user.name.charAt(0) : '?'}
+              </div>
+            )}
+            <span>{session.user?.name || 'Anonymous'}</span>
+            <button
+              onClick={() => signOut()}
+              className="px-2 py-1 border rounded"
+            >
+              Sign out
+            </button>
+          </>
+        ) : (
           <button
-            onClick={() => signOut()}
+            onClick={() => signIn('google')}
             className="px-2 py-1 border rounded"
           >
-            Sign out
+            Sign in with Google
           </button>
-        </>
-      ) : (
-        <button
-          onClick={() => signIn('google')}
-          className="px-2 py-1 border rounded"
-        >
-          Sign in with Google
-        </button>
-      )}
-    </header>
+        )}
+      </header>
+    </>
   );
 }
 

--- a/pages/api/run-predictions.ts
+++ b/pages/api/run-predictions.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import fs from 'fs';
+import path from 'path';
+import { authOptions } from './auth/[...nextauth]';
+
+interface Game {
+  homeTeam: { name: string };
+  awayTeam: { name: string };
+  time: string;
+}
+
+interface Prediction {
+  game: Game;
+  winner: string;
+  agentScores: Record<string, number>;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  const { league, games } = req.body || {};
+  if (!league) {
+    res.status(400).json({ error: 'league required' });
+    return;
+  }
+
+  try {
+    const predictions: Prediction[] = (games || []).map((g: Game) => ({
+      game: g,
+      winner: g.homeTeam.name,
+      agentScores: {
+        injuryScout: Math.random(),
+        lineWatcher: Math.random(),
+        statCruncher: Math.random(),
+      },
+    }));
+
+    const agentScores: Record<string, number> = {
+      injuryScout: Math.random(),
+      lineWatcher: Math.random(),
+      statCruncher: Math.random(),
+    };
+
+    const timestamp = new Date().toISOString();
+
+    try {
+      const logPath = path.join(process.cwd(), 'llms.txt');
+      const entry = `${timestamp} - [RUN_PREDICTIONS] - ${session.user?.name || 'anonymous'} - ${league}\n`;
+      await fs.promises.appendFile(logPath, entry);
+    } catch (err) {
+      console.error('failed to log prediction', err);
+    }
+
+    res.status(200).json({ predictions, agentScores, timestamp });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to run predictions' });
+  }
+}


### PR DESCRIPTION
## Summary
- add /api/run-predictions endpoint with logging and dummy agent output
- expose runPredictions client helper and wire up PredictionsPanel and LiveGamesList to display results
- show local beta banner in development when signed in

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6892e427bdd883239444837d02c28a32