### PR TITLE
refactor: polish predictions ui

### DIFF
--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface Props {
+  message: string;
+  className?: string;
+}
+
+const EmptyState: React.FC<Props> = ({ message, className = '' }) => (
+  <p
+    role="status"
+    aria-live="polite"
+    className={`text-center text-gray-600 ${className}`}
+  >
+    {message}
+  </p>
+);
+
+export default EmptyState;

--- a/components/LiveGamesList.tsx
+++ b/components/LiveGamesList.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
+import LoadingShimmer from './LoadingShimmer';
+import EmptyState from './EmptyState';
 
 interface Game {
   homeTeam: { name: string; logo?: string };
@@ -23,23 +25,20 @@ const LiveGamesList: React.FC<Props> = ({
   loadingPredictions,
 }) => {
   if (loadingGames) {
-    return (
-      <ul className="space-y-2">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <li key={i} className="h-16 bg-gray-200 rounded animate-pulse" />
-        ))}
-      </ul>
-    );
+    return <LoadingShimmer lines={3} lineClassName="h-16" />;
   }
 
   if (!games.length) {
-    return <p>No games found for {league}. Try again later.</p>;
+    return <EmptyState message={`No games found for ${league}. Try again later.`} />;
   }
 
   return (
-    <ul className="space-y-4">
+    <ul
+      className={`space-y-4 ${predictions.length ? 'divide-y divide-gray-200' : ''}`}
+      aria-live="polite"
+    >
       {games.map((g, idx) => (
-        <li key={idx} className="p-4 border rounded flex flex-col gap-2">
+        <li key={idx} className="p-4 flex flex-col gap-2" aria-busy={loadingPredictions}>
           <div className="flex items-center gap-2">
             {g.homeTeam.logo && (
               <Image src={g.homeTeam.logo} alt={g.homeTeam.name} width={24} height={24} />
@@ -53,7 +52,7 @@ const LiveGamesList: React.FC<Props> = ({
             <span className="ml-auto text-sm text-gray-600">{g.time}</span>
           </div>
           {loadingPredictions ? (
-            <div className="h-4 bg-gray-200 rounded animate-pulse" />
+            <LoadingShimmer lines={1} />
           ) : (
             predictions[idx] && (
               <div className="text-sm text-gray-600">

--- a/components/LoadingShimmer.tsx
+++ b/components/LoadingShimmer.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface Props {
+  lines?: number;
+  lineClassName?: string;
+  containerClassName?: string;
+}
+
+const LoadingShimmer: React.FC<Props> = ({
+  lines = 3,
+  lineClassName = 'h-4',
+  containerClassName = 'space-y-2',
+}) => (
+  <div
+    role="status"
+    aria-live="polite"
+    className={`animate-pulse ${containerClassName}`}
+  >
+    {Array.from({ length: lines }).map((_, i) => (
+      <div key={i} className={`bg-gray-200 rounded ${lineClassName}`} />
+    ))}
+    <span className="sr-only">Loading...</span>
+  </div>
+);
+
+export default LoadingShimmer;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,7 +1,14 @@
 export const getUpcomingGames = async (league: string = 'NFL') => {
   const res = await fetch(`/api/upcoming-games?league=${league}`);
   if (!res.ok) throw new Error('Failed to fetch upcoming games');
-  return res.json();
+  if (res.headers.get('x-missing-api-key')) {
+    console.warn('No SPORTS_DB_API_KEY is set. Using mock data for games.');
+  }
+  const data = await res.json();
+  if (Array.isArray(data) && data.some((g) => g.useFallback || g.source === 'fallback')) {
+    console.warn('Mock data is being used for predictions.');
+  }
+  return data;
 };
 
 export const runPredictions = async (league: string, games: any[]) => {

--- a/llms.txt
+++ b/llms.txt
@@ -171,3 +171,16 @@ Message: feat: implement run predictions endpoint
 Files:
 - pages/api/run-predictions.ts (+70/-0)
 
+Timestamp: 2025-08-06T05:29:39.118Z
+Commit: 7a2d855ac200ccfe0e4ed8d33b4b1b59906bbc84
+Author: Codex
+Message: refactor: polish predictions ui
+Files:
+- components/EmptyState.tsx (+18/-0)
+- components/LiveGamesList.tsx (+10/-11)
+- components/LoadingShimmer.tsx (+26/-0)
+- components/PredictionsPanel.tsx (+37/-7)
+- lib/api.ts (+8/-1)
+- pages/_app.tsx (+20/-6)
+- pages/api/run-predictions.ts (+11/-1)
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,7 @@
 // pages/_app.tsx
 import type { AppProps } from 'next/app';
 import { SessionProvider, useSession, signIn, signOut } from 'next-auth/react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import '../styles/globals.css';
@@ -10,15 +10,29 @@ import ThemeToggle from '../components/ThemeToggle';
 function Header() {
   const { data: session, status } = useSession();
   const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!dismissed) {
+      const timer = setTimeout(() => setDismissed(true), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [dismissed]);
+
   return (
     <>
-      {process.env.NODE_ENV === 'development' && session && !dismissed && (
-        <div className="bg-green-100 border border-green-400 text-green-800 text-sm px-4 py-2 rounded mb-2 flex justify-between items-center">
-          <span>🎉 Welcome to EdgePicks Beta – Running Locally</span>
-          <button onClick={() => setDismissed(true)} aria-label="Dismiss">×</button>
+      {!dismissed && (
+        <div className="fixed top-0 left-0 w-full z-50 bg-green-100 border-b border-green-400 text-green-800 text-sm px-4 py-2 flex flex-col sm:flex-row items-center justify-between space-y-2 sm:space-y-0">
+          <span className="text-center w-full">🎉 Welcome to EdgePicks Beta</span>
+          <button
+            onClick={() => setDismissed(true)}
+            aria-label="Dismiss"
+            className="self-end sm:self-auto"
+          >
+            ×
+          </button>
         </div>
       )}
-      <header className="p-4 flex justify-end gap-4 items-center">
+      <header className={`p-4 flex justify-end gap-4 items-center ${!dismissed ? 'mt-12' : ''}`}>
         <ThemeToggle />
         <Link href="/predictions" className="px-2 py-1 border rounded">
           Predictions


### PR DESCRIPTION
## Summary
- add reusable LoadingShimmer and EmptyState components for consistent loading/empty states
- polish PredictionsPanel with timestamped results, friendlier prompts, and consistent toasts
- log run-predictions calls and warn when mock data or missing API key is detected

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6892e647f42c83238071a570d67b7995