### PR TITLE
Handle flow loading failure before opening SSE stream

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -196,3 +196,10 @@ Files:
 - pages/api/upcoming-games.ts (+7/-0)
 - scripts/testLocal.ts (+6/-0)
 
+Timestamp: 2025-08-06T20:25:23.066Z
+Commit: ccfdad141430d20201e3dd8ec729951eea7acec5
+Author: Codex
+Message: Gracefully handle flow loading errors in run-agents
+Files:
+- pages/api/run-agents.ts (+9/-3)
+

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -26,6 +26,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
+  const flowName = typeof flowNameParam === 'string' ? flowNameParam : 'football-pick';
+  let flow;
+  try {
+    flow = await loadFlow(flowName);
+  } catch (e) {
+    res.status(500).json({ error: 'Unable to load flow' });
+    return;
+  }
+
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
@@ -39,9 +48,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     time: '',
     league: '',
   };
-
-  const flowName = typeof flowNameParam === 'string' ? flowNameParam : 'football-pick';
-  const flow = await loadFlow(flowName);
 
   const agentsOutput: Partial<AgentOutputs> = {};
 


### PR DESCRIPTION
## Summary
- ensure `run-agents` API loads the selected flow inside a try/catch
- return a 500 JSON error if the flow can't be loaded before starting the event stream

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893b982a6d48323a0872d2ff6ce8664