### PR TITLE
refactor: parallelize upcoming game flows

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -196,3 +196,10 @@ Files:
 - pages/api/upcoming-games.ts (+7/-0)
 - scripts/testLocal.ts (+6/-0)
 
+Timestamp: 2025-08-06T20:26:37.523Z
+Commit: 6f7af8f4dbb30506f0d68d3aa905986ac7e0b3c9
+Author: Codex
+Message: refactor upcoming-games to parallelize game flows
+Files:
+- pages/api/upcoming-games.ts (+77/-72)
+

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -54,7 +54,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       games = getFallbackMatchups();
     }
     const agentList = ['injuryScout', 'lineWatcher', 'statCruncher', 'guardianAgent'] as const;
-    const results: {
+    type Result = {
       homeTeam: { name: string; logo?: string };
       awayTeam: { name: string; logo?: string };
       confidence: number;
@@ -77,84 +77,89 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       agentDelta?: number;
       disagreements: string[];
       edgePick: AgentExecution[];
-    }[] = [];
+    };
 
-    for (const game of games) {
-      if (!game.homeTeam || !game.awayTeam) continue;
-      try {
-        const { outputs, executions } = await runFlow(
-          { name: 'upcoming', agents: [...agentList] },
-          { ...game, isLiveData: game.source !== 'fallback', source: game.source }
-        );
+    const results: Result[] = (
+      await Promise.all(
+        games.map(async (game): Promise<Result | null> => {
+          if (!game.homeTeam || !game.awayTeam) return null;
+          try {
+            const { outputs, executions } = await runFlow(
+              { name: 'upcoming', agents: [...agentList] },
+              { ...game, isLiveData: game.source !== 'fallback', source: game.source }
+            );
 
-        const scores: Record<string, number> = {
-          [game.homeTeam]: 0,
-          [game.awayTeam]: 0,
-        };
+            const scores: Record<string, number> = {
+              [game.homeTeam]: 0,
+              [game.awayTeam]: 0,
+            };
 
-        agentList.forEach((name) => {
-          const meta = registry.find((a) => a.name === name);
-          const result = outputs[name];
-          if (!meta || !result) return;
-          scores[result.team] += result.score * meta.weight;
-        });
+            agentList.forEach((name) => {
+              const meta = registry.find((a) => a.name === name);
+              const result = outputs[name];
+              if (!meta || !result) return;
+              scores[result.team] += result.score * meta.weight;
+            });
 
-        const winner =
-          scores[game.homeTeam] >= scores[game.awayTeam] ? game.homeTeam : game.awayTeam;
-        const confidenceRaw = Math.max(scores[game.homeTeam], scores[game.awayTeam]);
-        const confidence = Math.round(confidenceRaw * 100);
-        const edgeDelta = Math.abs(scores[game.homeTeam] - scores[game.awayTeam]);
-        const confidenceDrop = 1 - confidenceRaw;
-        const publicLean = (() => {
-          const home = game.odds?.moneyline?.home;
-          const away = game.odds?.moneyline?.away;
-          if (home !== undefined && away !== undefined) {
-            const total = Math.abs(home) + Math.abs(away);
-            return total ? Math.round((Math.abs(home) / total) * 100) : undefined;
+            const winner =
+              scores[game.homeTeam] >= scores[game.awayTeam] ? game.homeTeam : game.awayTeam;
+            const confidenceRaw = Math.max(scores[game.homeTeam], scores[game.awayTeam]);
+            const confidence = Math.round(confidenceRaw * 100);
+            const edgeDelta = Math.abs(scores[game.homeTeam] - scores[game.awayTeam]);
+            const confidenceDrop = 1 - confidenceRaw;
+            const publicLean = (() => {
+              const home = game.odds?.moneyline?.home;
+              const away = game.odds?.moneyline?.away;
+              if (home !== undefined && away !== undefined) {
+                const total = Math.abs(home) + Math.abs(away);
+                return total ? Math.round((Math.abs(home) / total) * 100) : undefined;
+              }
+              return undefined;
+            })();
+            const agentDelta =
+              game.odds?.spread !== undefined ? edgeDelta - game.odds.spread : undefined;
+            const disagreements = executions
+              .filter((e) => e.result && e.result.team !== winner)
+              .map((e) => e.name);
+            const topReasons = agentList
+              .map((name) => outputs[name]?.reason)
+              .filter((r): r is string => Boolean(r));
+
+            const pickSummary: PickSummary = { winner, confidence: confidenceRaw, topReasons };
+
+            logToSupabase(
+              { ...game },
+              outputs as AgentOutputs,
+              pickSummary,
+              null,
+              'upcoming-games',
+              true
+            );
+
+            return {
+              homeTeam: { name: game.homeTeam, logo: game.homeLogo },
+              awayTeam: { name: game.awayTeam, logo: game.awayLogo },
+              confidence,
+              time: game.time,
+              league: game.league,
+              odds: game.odds,
+              source: game.source,
+              useFallback: game.useFallback,
+              winner,
+              edgeDelta,
+              confidenceDrop,
+              publicLean,
+              agentDelta,
+              disagreements,
+              edgePick: executions,
+            };
+          } catch (err) {
+            console.error('agent run failed', err);
+            return null;
           }
-          return undefined;
-        })();
-        const agentDelta =
-          game.odds?.spread !== undefined ? edgeDelta - game.odds.spread : undefined;
-        const disagreements = executions
-          .filter((e) => e.result && e.result.team !== winner)
-          .map((e) => e.name);
-        const topReasons = agentList
-          .map((name) => outputs[name]?.reason)
-          .filter((r): r is string => Boolean(r));
-
-        const pickSummary: PickSummary = { winner, confidence: confidenceRaw, topReasons };
-
-        logToSupabase(
-          { ...game },
-          outputs as AgentOutputs,
-          pickSummary,
-          null,
-          'upcoming-games',
-          true
-        );
-
-        results.push({
-          homeTeam: { name: game.homeTeam, logo: game.homeLogo },
-          awayTeam: { name: game.awayTeam, logo: game.awayLogo },
-          confidence,
-          time: game.time,
-          league: game.league,
-          odds: game.odds,
-          source: game.source,
-          useFallback: game.useFallback,
-          winner,
-          edgeDelta,
-          confidenceDrop,
-          publicLean,
-          agentDelta,
-          disagreements,
-          edgePick: executions,
-        });
-      } catch (err) {
-        console.error('agent run failed', err);
-      }
-    }
+        })
+      )
+    ).filter((r): r is Result => Boolean(r));
 
     res.status(200).json(results);
   } catch (err) {


### PR DESCRIPTION
## Summary
- run upcoming game flows concurrently with Promise.all
- keep per-game error logging and result aggregation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b9755e78832384dceb4aa5bea7e6