### PR TITLE
Implement exponential backoff for Supabase logging retries

### DIFF
--- a/lib/logToSupabase.ts
+++ b/lib/logToSupabase.ts
@@ -11,11 +11,14 @@ type LogEntry = {
   isAutoPick?: boolean;
   extras?: Record<string, any>;
   loggedAt: string;
+  attempts: number;
 };
 
 const queue: LogEntry[] = [];
 let processing = false;
 let lastError: string | null = null;
+const MAX_ATTEMPTS = 5;
+const BASE_DELAY_MS = 1000;
 
 async function processQueue() {
   if (processing || queue.length === 0) {
@@ -23,6 +26,7 @@ async function processQueue() {
   }
   processing = true;
   const entry = queue.shift()!;
+  let retryDelay: number | null = null;
   try {
     const client = getSupabaseClient();
     const { error } = await client.from('matchups').insert({
@@ -51,11 +55,21 @@ async function processQueue() {
   } catch (err: any) {
     console.error('Error inserting matchup log:', err);
     lastError = err.message || String(err);
-    queue.push(entry); // Re-queue for retry
+    entry.attempts += 1;
+    if (entry.attempts < MAX_ATTEMPTS) {
+      queue.push(entry); // Re-queue for retry
+      retryDelay = BASE_DELAY_MS * 2 ** (entry.attempts - 1);
+    } else {
+      console.error('Max retry attempts reached for log entry; dropping.');
+    }
   } finally {
     processing = false;
     if (queue.length > 0) {
-      setImmediate(processQueue);
+      if (retryDelay !== null) {
+        setTimeout(processQueue, retryDelay);
+      } else {
+        setImmediate(processQueue);
+      }
     }
   }
 }
@@ -79,6 +93,7 @@ export function logToSupabase(
     isAutoPick,
     extras,
     loggedAt,
+    attempts: 0,
   });
   setImmediate(processQueue);
   return loggedAt;

--- a/llms.txt
+++ b/llms.txt
@@ -216,3 +216,10 @@ Files:
 n
 
 
+Timestamp: 2025-08-06T20:35:23.287Z
+Commit: fecb806599f48c225a737aef42c3ee48ca4e0a02
+Author: Codex
+Message: Add exponential retry backoff for Supabase logging
+Files:
+- lib/logToSupabase.ts (+17/-2)
+


### PR DESCRIPTION
## Summary
- track per-entry retry attempts in log queue
- retry failed Supabase inserts with exponential backoff and drop after max attempts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893bc018d2c832380dbbb72e504edaf