### PR TITLE
fix: correct Supabase typing in trendsAgent

### DIFF
--- a/lib/agents/trendsAgent.ts
+++ b/lib/agents/trendsAgent.ts
@@ -15,7 +15,7 @@ interface MatchupRow {
 export const trendsAgent = async (_: Matchup): Promise<TrendsResult> => {
   const client = getSupabaseClient();
   const { data, error } = await client
-    .from<MatchupRow>('matchups')
+    .from<'matchups', MatchupRow>('matchups')
     .select('flow, agents, actual_winner')
     .order('created_at', { ascending: false })
     .limit(50);
@@ -24,10 +24,12 @@ export const trendsAgent = async (_: Matchup): Promise<TrendsResult> => {
     throw error;
   }
 
+  const rows: MatchupRow[] = data ?? [];
+
   const flowCounts: Record<string, number> = {};
   const agentStats: Record<string, { correct: number; total: number }> = {};
 
-  (data || []).forEach((row) => {
+  rows.forEach((row) => {
     const flow = row.flow || 'unknown';
     flowCounts[flow] = (flowCounts[flow] || 0) + 1;
 

--- a/llms.txt
+++ b/llms.txt
@@ -235,3 +235,10 @@ Files:
 - pages/index.tsx (+55/-153)
 - tailwind.config.js (+5/-1)
 
+Timestamp: 2025-08-06T20:59:29.308Z
+Commit: f643917f9901eb25450ad2802249f2db7eba6d11
+Author: Codex
+Message: fix: correct Supabase typing in trendsAgent
+Files:
+- lib/agents/trendsAgent.ts (+4/-2)
+


### PR DESCRIPTION
## Summary
- specify both table name and row type in Supabase query so Next.js build uses correct typings
- ensure query results are cast to `MatchupRow[]` for easier use

## Testing
- `npm test`
- `npm run build` *(fails: Module not found: Can't resolve 'fs' in ./lib/env.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6893c125fda08323affb75e4536fa55e