### PR TITLE
fix: remove fs import from env to restore Vercel build

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,9 +1,3 @@
-import { config } from 'dotenv';
-import fs from 'fs';
-
-const envFile = fs.existsSync('.env.local') ? '.env.local' : '.env';
-config({ path: envFile });
-
 const required = ['NEXTAUTH_SECRET', 'NEXTAUTH_URL'];
 const missing = required.filter((key) => !process.env[key]);
 if (missing.length) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,3 @@
-import '../lib/env';
 import { signIn, useSession } from 'next-auth/react';
 import { motion } from 'framer-motion';
 import { Button } from '../components/ui/button';


### PR DESCRIPTION
## Summary
- remove Node-only dotenv/fs logic from `lib/env.ts`
- drop client import of `env` from home page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c2efc7808323bb871ca797a050cc