### PR TITLE
Add public matchups page with limited upcoming games

### DIFF
--- a/components/UpcomingGamesPanel.tsx
+++ b/components/UpcomingGamesPanel.tsx
@@ -36,12 +36,17 @@ const leagueIcons: Record<string, string> = {
   MLS: '⚽',
 };
 
-const UpcomingGamesPanel: React.FC = () => {
+interface UpcomingGamesPanelProps {
+  /** Maximum number of matchups to display. If set, the "Show More" button is hidden. */
+  maxVisible?: number;
+}
+
+const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({ maxVisible }) => {
   const [games, setGames] = useState<UpcomingGame[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
-  const [visibleCount, setVisibleCount] = useState(3);
+  const [visibleCount, setVisibleCount] = useState(maxVisible ?? 3);
 
   useEffect(() => {
     let cancelled = false;
@@ -155,7 +160,7 @@ const UpcomingGamesPanel: React.FC = () => {
           </div>
         );
       })}
-      {visibleCount < games.length && (
+      {!maxVisible && visibleCount < games.length && (
         <div className="sm:col-span-2 text-center">
           <button
             onClick={() => setVisibleCount((c) => c + 3)}

--- a/llms.txt
+++ b/llms.txt
@@ -242,3 +242,11 @@ Message: fix: correct Supabase typing in trendsAgent
 Files:
 - lib/agents/trendsAgent.ts (+4/-2)
 
+Timestamp: 2025-08-06T21:22:24.804Z
+Commit: 79a8425ad265d926f7b876119a7aea9ed0973988
+Author: Codex
+Message: Add public matchups page with limited upcoming games
+Files:
+- components/UpcomingGamesPanel.tsx (+8/-3)
+- pages/matchups/public.tsx (+13/-0)
+

--- a/pages/matchups/public.tsx
+++ b/pages/matchups/public.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import UpcomingGamesPanel from '../../components/UpcomingGamesPanel';
+
+const PublicMatchupsPage: React.FC = () => (
+  <main className="min-h-screen bg-gray-50 p-6 space-y-4">
+    <p className="text-center text-gray-700">
+      Sign in to unlock full predictions. Here are a few upcoming matchups:
+    </p>
+    <UpcomingGamesPanel maxVisible={3} />
+  </main>
+);
+
+export default PublicMatchupsPage;


### PR DESCRIPTION
## Summary
- add optional `maxVisible` prop to `UpcomingGamesPanel` to cap displayed matchups
- introduce `/matchups/public` page showing three upcoming games and sign-in prompt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c6aa9cd08323bdf669015c7fa87c