### PR TITLE
Add prediction tracker component

### DIFF
--- a/components/PredictionTracker.tsx
+++ b/components/PredictionTracker.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+interface Props {
+  onReveal: () => void;
+  /**
+   * Time in milliseconds before advancing to the next step.
+   * Defaults to 1500ms.
+   */
+  stepDuration?: number;
+}
+
+const steps = [
+  'Collecting Stats...',
+  'Analyzing Trends...',
+  'Crunching Agent Results...',
+  'Pick Ready – Click to Reveal',
+];
+
+const PredictionTracker: React.FC<Props> = ({ onReveal, stepDuration = 1500 }) => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (index < steps.length - 1) {
+      const timer = setTimeout(() => setIndex((i) => i + 1), stepDuration);
+      return () => clearTimeout(timer);
+    }
+  }, [index, stepDuration]);
+
+  const isFinal = index === steps.length - 1;
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={index}
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -8 }}
+        transition={{ duration: 0.4 }}
+        className={`p-4 text-center rounded ${
+          isFinal ? 'bg-blue-600 text-white cursor-pointer' : 'bg-gray-100 text-gray-700'
+        }`}
+        onClick={isFinal ? onReveal : undefined}
+      >
+        {steps[index]}
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+
+export default PredictionTracker;
+

--- a/llms.txt
+++ b/llms.txt
@@ -250,3 +250,10 @@ Files:
 - components/UpcomingGamesPanel.tsx (+8/-3)
 - pages/matchups/public.tsx (+13/-0)
 
+Timestamp: 2025-08-06T21:26:50.181Z
+Commit: e313b70aaa205f51963064654b3bfa2da0e24e7e
+Author: Codex
+Message: Add prediction tracker component
+Files:
+- components/PredictionTracker.tsx (+52/-0)
+


### PR DESCRIPTION
## Summary
- add `PredictionTracker` component that cycles through analysis steps before revealing a pick

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c8256a508323aa3f464fe9922a41