### PR TITLE
feat: hide confidence values for unauthenticated users

### DIFF
--- a/components/ConfidenceMeter.tsx
+++ b/components/ConfidenceMeter.tsx
@@ -8,6 +8,7 @@ export interface ConfidenceMeterProps {
   spread?: number;
   publicLean?: number;
   agentDelta?: number;
+  hideValues?: boolean;
 }
 
 const ConfidenceMeter: React.FC<ConfidenceMeterProps> = ({
@@ -18,6 +19,7 @@ const ConfidenceMeter: React.FC<ConfidenceMeterProps> = ({
   spread,
   publicLean,
   agentDelta,
+  hideValues = false,
 }) => {
   const [fill, setFill] = useState(0);
   const [display, setDisplay] = useState(0);
@@ -56,10 +58,14 @@ const ConfidenceMeter: React.FC<ConfidenceMeterProps> = ({
         className={`flex items-center mb-1 ${showTeams ? 'justify-between' : 'justify-end'}`}
       >
         {showTeams && <span className="font-semibold">{teamALabel}</span>}
-        <span className="font-bold">{display}%</span>
+        <span className="font-bold">{hideValues ? '??' : `${display}%`}</span>
         {showTeams && <span className="font-semibold">{teamBLabel}</span>}
       </div>
-      <div className="relative w-full h-3 bg-gray-200 rounded overflow-hidden">
+      <div
+        className={`relative w-full h-3 bg-gray-200 rounded overflow-hidden ${
+          hideValues ? 'blur-sm' : ''
+        }`}
+      >
         <div
           className={`absolute inset-0 bg-gradient-to-r from-green-400 to-red-500 opacity-20 blur-sm animate-pulse`}
         />
@@ -70,11 +76,15 @@ const ConfidenceMeter: React.FC<ConfidenceMeterProps> = ({
       </div>
       {(history.length > 0 || spread !== undefined || publicLean !== undefined || agentDelta !== undefined) && (
         <div className="mt-1 text-xs text-gray-500 flex flex-col gap-1">
-          {history.length > 0 && <div>{history.join(', ')}</div>}
+          {history.length > 0 && <div>{hideValues ? '??' : history.join(', ')}</div>}
           <div className="flex gap-2">
-            {spread !== undefined && <span>Spread {spread}</span>}
-            {publicLean !== undefined && <span>Public {publicLean}%</span>}
-            {agentDelta !== undefined && <span>Δ {Math.round(agentDelta * 100) / 100}</span>}
+            {spread !== undefined && <span>Spread {hideValues ? '??' : spread}</span>}
+            {publicLean !== undefined && (
+              <span>Public {hideValues ? '??' : `${publicLean}%`}</span>
+            )}
+            {agentDelta !== undefined && (
+              <span>Δ {hideValues ? '??' : Math.round(agentDelta * 100) / 100}</span>
+            )}
           </div>
         </div>
       )}

--- a/components/UpcomingGamesPanel.tsx
+++ b/components/UpcomingGamesPanel.tsx
@@ -39,9 +39,13 @@ const leagueIcons: Record<string, string> = {
 interface UpcomingGamesPanelProps {
   /** Maximum number of matchups to display. If set, the "Show More" button is hidden. */
   maxVisible?: number;
+  hideValues?: boolean;
 }
 
-const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({ maxVisible }) => {
+const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({
+  maxVisible,
+  hideValues = false,
+}) => {
   const [games, setGames] = useState<UpcomingGame[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -139,6 +143,7 @@ const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({ maxVisible }) =
               spread={game.odds?.spread}
               publicLean={game.publicLean}
               agentDelta={game.agentDelta}
+              hideValues={hideValues}
             />
             <div className="text-xs text-gray-500">
               Edge Δ: {Math.round(game.edgeDelta * 100)}% | Confidence Drop:{' '}

--- a/pages/matchups/public.tsx
+++ b/pages/matchups/public.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
+import { useSession } from 'next-auth/react';
 import UpcomingGamesPanel from '../../components/UpcomingGamesPanel';
 
-const PublicMatchupsPage: React.FC = () => (
-  <main className="min-h-screen bg-gray-50 p-6 space-y-4">
-    <p className="text-center text-gray-700">
-      Sign in to unlock full predictions. Here are a few upcoming matchups:
-    </p>
-    <UpcomingGamesPanel maxVisible={3} />
-  </main>
-);
+const PublicMatchupsPage: React.FC = () => {
+  const { data: session } = useSession();
+  return (
+    <main className="min-h-screen bg-gray-50 p-6 space-y-4">
+      <p className="text-center text-gray-700">
+        Sign in to unlock full predictions. Here are a few upcoming matchups:
+      </p>
+      <UpcomingGamesPanel maxVisible={3} hideValues={!session} />
+    </main>
+  );
+};
 
 export default PublicMatchupsPage;


### PR DESCRIPTION
## Summary
- add optional `hideValues` flag to `ConfidenceMeter` to blur numbers
- propagate `hideValues` through `UpcomingGamesPanel`
- hide confidence values on public matchups page until session exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c826e0fc83238122196a3a3685e9