### PR TITLE
Add prediction tracker gating to public matchups

### DIFF
--- a/components/UpcomingGamesPanel.tsx
+++ b/components/UpcomingGamesPanel.tsx
@@ -40,11 +40,18 @@ interface UpcomingGamesPanelProps {
   /** Maximum number of matchups to display. If set, the "Show More" button is hidden. */
   maxVisible?: number;
   hideValues?: boolean;
+  /** Optional wrapper for each game card, allowing custom reveal logic */
+  cardWrapper?: (args: {
+    game: UpcomingGame;
+    index: number;
+    children: React.ReactNode;
+  }) => React.ReactElement;
 }
 
 const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({
   maxVisible,
   hideValues = false,
+  cardWrapper,
 }) => {
   const [games, setGames] = useState<UpcomingGame[]>([]);
   const [loading, setLoading] = useState(true);
@@ -109,11 +116,8 @@ const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
       {games.slice(0, visibleCount).map((game, idx) => {
         const guardian = game.edgePick.find((a) => a.name === 'guardianAgent');
-        return (
-          <div
-            key={idx}
-            className="bg-white rounded shadow p-4 flex flex-col gap-4"
-          >
+        const card = (
+          <div className="bg-white rounded shadow p-4 flex flex-col gap-4">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
               <h3 className="font-semibold flex items-center gap-2">
                 <span className="flex items-center gap-2">
@@ -146,7 +150,7 @@ const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({
               hideValues={hideValues}
             />
             <div className="text-xs text-gray-500">
-              Edge Δ: {Math.round(game.edgeDelta * 100)}% | Confidence Drop:{' '}
+              Edge Δ: {Math.round(game.edgeDelta * 100)}% | Confidence Drop{' '}
               {Math.round(game.confidenceDrop * 100)}%
             </div>
             <AgentRationalePanel executions={game.edgePick} winner={game.winner} />
@@ -164,6 +168,10 @@ const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({
             )}
           </div>
         );
+        const element = cardWrapper
+          ? cardWrapper({ game, index: idx, children: card })
+          : card;
+        return React.cloneElement(element as React.ReactElement, { key: idx });
       })}
       {!maxVisible && visibleCount < games.length && (
         <div className="sm:col-span-2 text-center">

--- a/llms.txt
+++ b/llms.txt
@@ -265,3 +265,11 @@ Files:
 - components/PredictionTracker.tsx (+52/-0)
 
 
+Timestamp: 2025-08-06T21:38:18.700Z
+Commit: a3e4d1711e5375657474311f97c4b1fbc1cad12a
+Author: Codex
+Message: Add prediction tracker gating to public matchups
+Files:
+- components/UpcomingGamesPanel.tsx (+14/-6)
+- pages/matchups/public.tsx (+38/-2)
+

--- a/pages/matchups/public.tsx
+++ b/pages/matchups/public.tsx
@@ -1,15 +1,51 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSession } from 'next-auth/react';
+import { AnimatePresence, motion } from 'framer-motion';
 import UpcomingGamesPanel from '../../components/UpcomingGamesPanel';
+import PredictionTracker from '../../components/PredictionTracker';
+import SignInModal from '../../components/SignInModal';
 
 const PublicMatchupsPage: React.FC = () => {
   const { data: session } = useSession();
+  const [revealed, setRevealed] = useState<Record<number, boolean>>({});
+  const [showModal, setShowModal] = useState(false);
+
+  const handleReveal = (idx: number) => {
+    if (session) {
+      setRevealed((prev) => ({ ...prev, [idx]: true }));
+    } else {
+      setShowModal(true);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-gray-50 p-6 space-y-4">
       <p className="text-center text-gray-700">
         Sign in to unlock full predictions. Here are a few upcoming matchups:
       </p>
-      <UpcomingGamesPanel maxVisible={3} hideValues={!session} />
+      <UpcomingGamesPanel
+        maxVisible={3}
+        hideValues={!session}
+        cardWrapper={({ index, children }) => (
+          <div className="w-full">
+            <AnimatePresence mode="wait" initial={false}>
+              {revealed[index] ? (
+                <motion.div
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -8 }}
+                  transition={{ duration: 0.4 }}
+                >
+                  {children}
+                </motion.div>
+              ) : (
+                <PredictionTracker onReveal={() => handleReveal(index)} />
+              )}
+            </AnimatePresence>
+          </div>
+        )}
+      />
+      <SignInModal isOpen={showModal} onClose={() => setShowModal(false)} />
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- gate public matchup cards behind animated PredictionTracker
- allow UpcomingGamesPanel cards to be wrapped for custom reveal logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c9ce96848323ac76f1810b6456c7