### PR TITLE
feat: add primary CTA button variant

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,16 +1,22 @@
 import * as React from 'react';
 import { cn } from '../../lib/utils';
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'primaryCTA';
+}
+
+const variants: Record<NonNullable<ButtonProps['variant']>, string> = {
+  default:
+    'px-4 py-2 bg-blue-600 text-white rounded-md transition-colors hover:bg-blue-500 focus:outline-none',
+  primaryCTA:
+    'px-6 py-3 rounded-md text-white shadow-md bg-gradient-to-r from-blue-600 to-indigo-600 transition-all hover:from-blue-500 hover:to-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-400 animate-pulse hover:animate-none',
+};
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, ...props }, ref) => (
+  ({ className, variant = 'default', ...props }, ref) => (
     <button
       ref={ref}
-      className={cn(
-        'px-4 py-2 bg-blue-600 text-white rounded-md transition-colors hover:bg-blue-500 focus:outline-none',
-        className
-      )}
+      className={cn(variants[variant], className)}
       {...props}
     />
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,7 +34,7 @@ export default function Home() {
         </motion.div>
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} whileHover={{ scale: 1.05 }}>
           <Link href="/matchups/public">
-            <Button>Explore Matchups</Button>
+            <Button variant="primaryCTA">Explore Matchups</Button>
           </Link>
         </motion.div>
         <div className="pt-8 space-y-4">


### PR DESCRIPTION
## Summary
- add `primaryCTA` variant to shared Button with gradient and pulse styling
- use new CTA variant for the home page "Explore Matchups" link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d035bdb88323887026ad264d8298