### PR TITLE
refactor: centralize card styles

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -13,6 +13,7 @@ import { formatAgentName } from '../lib/utils';
 import Tooltip from './Tooltip';
 import ConfidenceMeter from './ConfidenceMeter';
 import AgentTooltip from './AgentTooltip';
+import { agentCard, agentCardSkeleton } from '../styles/cardStyles';
 
 interface Props {
   name: AgentName;
@@ -51,7 +52,7 @@ const AgentCard: React.FC<Props> = ({
 
   if (isLoading || !result) {
     return (
-      <div className={`p-4 rounded-xl border bg-gray-100 animate-pulse ${className}`}>
+      <div className={`${agentCardSkeleton} ${className}`}>
         <div className="h-4 bg-gray-300 rounded w-1/3 mb-2" />
         <div className="h-3 bg-gray-300 rounded w-full mb-2" />
         <div className="h-3 bg-gray-300 rounded w-2/3" />
@@ -70,7 +71,7 @@ const AgentCard: React.FC<Props> = ({
 
   return (
     <div
-      className={`relative p-4 bg-gray-50 rounded-xl border flex flex-col gap-2 transition-all duration-500 ease-out ${
+      className={`${agentCard} ${
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
       } ${className}`}
       style={{ boxShadow: `0 0 8px ${glowColor}` }}

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -9,6 +9,7 @@ import { AgentOutputs } from '../lib/types';
 import { getContribution, formatAgentName } from '../lib/utils';
 import { agents as agentRegistry } from '../lib/agents/registry';
 import { getAccuracyHistory } from '../lib/accuracy';
+import { matchupCard } from '../styles/cardStyles';
 
 interface BreakdownProps {
   agents: AgentOutputs;
@@ -86,7 +87,7 @@ const MatchupCard: React.FC<MatchupProps> = ({
   }, []);
 
   return (
-    <div className="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-4 sm:p-6">
+    <div className={matchupCard}>
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-4 gap-2">
         <h3 className="font-semibold flex items-center gap-3">
           <span className="flex items-center gap-2">

--- a/llms.txt
+++ b/llms.txt
@@ -273,3 +273,12 @@ Files:
 - components/UpcomingGamesPanel.tsx (+14/-6)
 - pages/matchups/public.tsx (+38/-2)
 
+Timestamp: 2025-08-06T22:02:59.752Z
+Commit: 2fc7496dd0e4b13a1f8c0bc831a7b994dd35dcb7
+Author: Codex
+Message: refactor: centralize card styles
+Files:
+- components/AgentCard.tsx (+3/-2)
+- components/MatchupCard.tsx (+2/-1)
+- styles/cardStyles.ts (+3/-0)
+

--- a/styles/cardStyles.ts
+++ b/styles/cardStyles.ts
@@ -1,0 +1,3 @@
+export const matchupCard = "bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-4 sm:p-6";
+export const agentCard = "relative p-4 bg-gray-50 rounded-xl border flex flex-col gap-2 transition-all duration-500 ease-out";
+export const agentCardSkeleton = "p-4 rounded-xl border bg-gray-100 animate-pulse";


### PR DESCRIPTION
## Summary
- add `styles/cardStyles.ts` with shared card style constants
- update `MatchupCard` and `AgentCard` to use centralized class names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d03d83b483239f211b127a9345a1