### PR TITLE
style: add confidence text utility

### DIFF
--- a/components/AgentRationalePanel.tsx
+++ b/components/AgentRationalePanel.tsx
@@ -45,7 +45,7 @@ const AgentRationalePanel: React.FC<Props> = ({ executions, winner }) => {
               <span className="flex items-center gap-2">
                 <Icon className="w-4 h-4" /> {formatAgentName(name)}
               </span>
-              <span>{Math.round(result.score * 100)}%</span>
+              <span className="confidenceText">{Math.round(result.score * 100)}%</span>
             </div>
             <p className="text-xs text-gray-600 mt-1">{result.reason}</p>
             {disagree && (

--- a/components/ConfidenceMeter.tsx
+++ b/components/ConfidenceMeter.tsx
@@ -58,7 +58,7 @@ const ConfidenceMeter: React.FC<ConfidenceMeterProps> = ({
         className={`flex items-center mb-1 ${showTeams ? 'justify-between' : 'justify-end'}`}
       >
         {showTeams && <span className="font-semibold">{teamALabel}</span>}
-        <span className="font-bold">{hideValues ? '??' : `${display}%`}</span>
+        <span className="confidenceText">{hideValues ? '??' : `${display}%`}</span>
         {showTeams && <span className="font-semibold">{teamBLabel}</span>}
       </div>
       <div

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -133,14 +133,14 @@ const MatchupCard: React.FC<MatchupProps> = ({
           confidence={confidencePct}
           history={accuracyHistory}
         />
-        <DisagreementBadge confidence={confidencePct} />
+        <DisagreementBadge confidence={confidencePct} className="confidenceText" />
         {confidencePct > 80 && (
-          <span className="mt-2 inline-block px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs">
+          <span className="confidenceText mt-2 inline-block px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs">
             🟢 High Confidence
           </span>
         )}
         {confidencePct < 55 && (
-          <span className="mt-2 inline-block px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded text-xs">
+          <span className="confidenceText mt-2 inline-block px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded text-xs">
             🟡 Toss-Up
           </span>
         )}

--- a/llms.txt
+++ b/llms.txt
@@ -273,3 +273,14 @@ Files:
 - components/UpcomingGamesPanel.tsx (+14/-6)
 - pages/matchups/public.tsx (+38/-2)
 
+Timestamp: 2025-08-06T22:04:48.157Z
+Commit: 8f2a506d22c9c912e8ddc933de1dd11a693ccb7d
+Author: Codex
+Message: style: add confidence text utility
+Files:
+- components/AgentRationalePanel.tsx (+1/-1)
+- components/ConfidenceMeter.tsx (+1/-1)
+- components/MatchupCard.tsx (+3/-3)
+- pages/_app.tsx (+1/-0)
+- styles/typography.css (+5/-0)
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import '../styles/globals.css';
+import '../styles/typography.css';
 import ThemeToggle from '../components/ThemeToggle';
 
 function Header() {

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -1,0 +1,5 @@
+@layer components {
+  .confidenceText {
+    @apply font-semibold;
+  }
+}


### PR DESCRIPTION
## Summary
- add `confidenceText` utility class for consistent confidence styling
- apply `confidenceText` across confidence displays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d0459d588323a74bbd5ed1d69d86