### PR TITLE
refactor: centralize animation constants

### DIFF
--- a/components/PredictionTracker.tsx
+++ b/components/PredictionTracker.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { FADE_DURATION, EASE } from '../lib/animations';
 
 interface Props {
   onReveal: () => void;
@@ -36,7 +37,7 @@ const PredictionTracker: React.FC<Props> = ({ onReveal, stepDuration = 1500 }) =
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -8 }}
-        transition={{ duration: 0.4 }}
+        transition={{ duration: FADE_DURATION, ease: EASE }}
         className={`p-4 text-center rounded ${
           isFinal ? 'bg-blue-600 text-white cursor-pointer' : 'bg-gray-100 text-gray-700'
         }`}

--- a/lib/animations.ts
+++ b/lib/animations.ts
@@ -1,0 +1,2 @@
+export const FADE_DURATION = 0.4;
+export const EASE = 'easeInOut';

--- a/llms.txt
+++ b/llms.txt
@@ -273,3 +273,13 @@ Files:
 - components/UpcomingGamesPanel.tsx (+14/-6)
 - pages/matchups/public.tsx (+38/-2)
 
+Timestamp: 2025-08-06T22:03:21.354Z
+Commit: 8dc99b37ab282e39b510372a41be59c6f467b18d
+Author: Codex
+Message: refactor: centralize animation constants
+Files:
+- components/PredictionTracker.tsx (+2/-1)
+- lib/animations.ts (+2/-0)
+- pages/index.tsx (+13/-2)
+- pages/matchups/public.tsx (+2/-1)
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import { Card } from '../components/ui/card';
 import { TypographyH1, TypographyMuted } from '../components/ui/typography';
 import MatchupCard from '../components/MatchupCard';
 import type { AgentOutputs } from '../lib/types';
+import { FADE_DURATION, EASE } from '../lib/animations';
 
 const dummyAgents: AgentOutputs = {
   injuryScout: { team: 'Team A', score: 0.2, reason: 'Fewer injuries' },
@@ -26,13 +27,23 @@ export default function Home() {
   return (
     <main className="min-h-screen bg-gradient-to-br from-zinc-900 to-neutral-950 text-white">
       <div className="max-w-3xl mx-auto py-16 space-y-6 text-center">
-        <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} className="space-y-2">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: FADE_DURATION, ease: EASE }}
+          className="space-y-2"
+        >
           <TypographyH1>Welcome to EdgePicks</TypographyH1>
           <TypographyMuted>
             AI-powered predictions. Transparent. Competitive. Built for Pick’em players.
           </TypographyMuted>
         </motion.div>
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} whileHover={{ scale: 1.05 }}>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: FADE_DURATION, ease: EASE }}
+          whileHover={{ scale: 1.05 }}
+        >
           <Link href="/matchups/public">
             <Button>Explore Matchups</Button>
           </Link>

--- a/pages/matchups/public.tsx
+++ b/pages/matchups/public.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import UpcomingGamesPanel from '../../components/UpcomingGamesPanel';
 import PredictionTracker from '../../components/PredictionTracker';
 import SignInModal from '../../components/SignInModal';
+import { FADE_DURATION, EASE } from '../../lib/animations';
 
 const PublicMatchupsPage: React.FC = () => {
   const { data: session } = useSession();
@@ -34,7 +35,7 @@ const PublicMatchupsPage: React.FC = () => {
                   initial={{ opacity: 0, y: 8 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -8 }}
-                  transition={{ duration: 0.4 }}
+                  transition={{ duration: FADE_DURATION, ease: EASE }}
                 >
                   {children}
                 </motion.div>


### PR DESCRIPTION
## Summary
- centralize fade timing and easing constants in `lib/animations`
- refactor motion components to consume shared animation constants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d04b5d448323ad21dcf7c3ee64c5