### PR TITLE
style: enlarge header buttons

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -273,3 +273,10 @@ Files:
 - components/UpcomingGamesPanel.tsx (+14/-6)
 - pages/matchups/public.tsx (+38/-2)
 
+Timestamp: 2025-08-06T22:06:01.459Z
+Commit: 3f1cf29f6b69396ef8e1ab8ab6436ba5428b1b6d
+Author: Codex
+Message: style: enlarge header buttons
+Files:
+- pages/_app.tsx (+3/-3)
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,7 +34,7 @@ function Header() {
       )}
       <header className={`p-4 flex justify-end gap-4 items-center ${!dismissed ? 'mt-12' : ''}`}>
         <ThemeToggle />
-        <Link href="/predictions" className="px-2 py-1 border rounded">
+        <Link href="/predictions" className="min-h-[44px] px-4 py-2 border rounded">
           Predictions
         </Link>
         {status === 'loading' ? (
@@ -57,7 +57,7 @@ function Header() {
             <span>{session.user?.name || 'Anonymous'}</span>
             <button
               onClick={() => signOut()}
-              className="px-2 py-1 border rounded"
+              className="min-h-[44px] px-4 py-2 border rounded"
             >
               Sign out
             </button>
@@ -65,7 +65,7 @@ function Header() {
         ) : (
           <button
             onClick={() => signIn('google')}
-            className="px-2 py-1 border rounded"
+            className="min-h-[44px] px-4 py-2 border rounded"
           >
             Sign in with Google
           </button>


### PR DESCRIPTION
## Summary
- enlarge header nav buttons and links with `min-h-[44px] px-4 py-2`

## Testing
- `npm test`
- Verified in Chromium mobile emulation that nav link and sign-in button have 44px min-height and 8px vertical / 16px horizontal padding


------
https://chatgpt.com/codex/tasks/task_e_6893d050bc1483238d09a61409114848