### PR TITLE
Use EmptyState for empty upcoming games

### DIFF
--- a/components/UpcomingGamesPanel.tsx
+++ b/components/UpcomingGamesPanel.tsx
@@ -3,6 +3,7 @@ import TeamBadge from './TeamBadge';
 import ConfidenceMeter, { ConfidenceMeterProps } from './ConfidenceMeter';
 import { AgentExecution } from '../lib/flow/runFlow';
 import AgentRationalePanel from './AgentRationalePanel';
+import EmptyState from './EmptyState';
 
 interface UpcomingGame {
   homeTeam: ConfidenceMeterProps['teamA'];
@@ -103,7 +104,7 @@ const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({
         {warning && (
           <p className="text-center text-yellow-600 mb-2">{warning}</p>
         )}
-        <p className="text-center">No upcoming games found.</p>
+        <EmptyState message="No matchups available right now. Check back later." />
       </>
     );
   }

--- a/llms.txt
+++ b/llms.txt
@@ -343,3 +343,10 @@ Files:
 main
  main
 
+Timestamp: 2025-08-06T22:29:16.958Z
+Commit: 6bbd67491c9aca1eec5860dad30fd4216a3a12c2
+Author: Codex
+Message: Use EmptyState for empty upcoming games
+Files:
+- components/UpcomingGamesPanel.tsx (+2/-1)
+


### PR DESCRIPTION
## Summary
- import `EmptyState` into `UpcomingGamesPanel`
- show EmptyState message when no matchups are available

## Testing
- `npx ts-node upcomingGamesPanel.test.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d60a6f5083238d5baab6c254570b