### PR TITLE
Use LoadingShimmer during upcoming games load

### DIFF
--- a/components/UpcomingGamesPanel.tsx
+++ b/components/UpcomingGamesPanel.tsx
@@ -3,6 +3,7 @@ import TeamBadge from './TeamBadge';
 import ConfidenceMeter, { ConfidenceMeterProps } from './ConfidenceMeter';
 import { AgentExecution } from '../lib/flow/runFlow';
 import AgentRationalePanel from './AgentRationalePanel';
+import LoadingShimmer from './LoadingShimmer';
 
 interface UpcomingGame {
   homeTeam: ConfidenceMeterProps['teamA'];
@@ -90,7 +91,7 @@ const UpcomingGamesPanel: React.FC<UpcomingGamesPanelProps> = ({
   }, []);
 
   if (loading) {
-    return <p className="text-center">Loading upcoming games...</p>;
+    return <LoadingShimmer lineClassName="h-20" />;
   }
 
   if (error) {

--- a/llms.txt
+++ b/llms.txt
@@ -343,3 +343,10 @@ Files:
 main
  main
 
+Timestamp: 2025-08-06T22:29:43.682Z
+Commit: 7456d593868aead2aeb6abb634990f27fa21b88a
+Author: Codex
+Message: Use LoadingShimmer in upcoming games panel
+Files:
+- components/UpcomingGamesPanel.tsx (+2/-1)
+


### PR DESCRIPTION
## Summary
- display `LoadingShimmer` while upcoming games are loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d6114d9483239ff4b726ffd95a3d