### PR TITLE
feat: add toast hook and logging error handler

### DIFF
--- a/lib/logUiEvent.test.js
+++ b/lib/logUiEvent.test.js
@@ -1,0 +1,23 @@
+require('ts-node').register({ transpileOnly: true, compilerOptions: { module: 'CommonJS' } });
+const assert = require('assert');
+const { logUiEvent } = require('./logUiEvent');
+const supabase = require('./supabaseClient');
+const toast = require('./useToast');
+
+let called = false;
+toast.triggerToast = (t) => {
+  called = true;
+  assert.strictEqual(t.message, 'Unable to log event; please sign in again');
+};
+
+supabase.getSupabaseClient = () => ({
+  from: () => ({
+    insert: () => Promise.reject(new Error('fail')),
+  }),
+});
+
+(async () => {
+  await logUiEvent('test');
+  assert(called, 'toast should be triggered on error');
+  console.log('logUiEvent error toast test passed');
+})();

--- a/lib/logUiEvent.ts
+++ b/lib/logUiEvent.ts
@@ -1,4 +1,5 @@
 import { getSupabaseClient } from './supabaseClient';
+import { triggerToast } from './useToast';
 
 export async function logUiEvent(
   uiEvent: string,
@@ -13,5 +14,9 @@ export async function logUiEvent(
     });
   } catch (err) {
     console.error('Failed to log UI event', err);
+    triggerToast({
+      message: 'Unable to log event; please sign in again',
+      type: 'error',
+    });
   }
 }

--- a/lib/useToast.ts
+++ b/lib/useToast.ts
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+interface Toast {
+  id: number;
+  message: string;
+  type?: 'success' | 'error';
+}
+
+type AddToast = (toast: Omit<Toast, 'id'>) => void;
+
+const ToastContext = createContext<AddToast>(() => {});
+
+let trigger: AddToast = () => {};
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback<AddToast>((toast) => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { ...toast, id }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  trigger = addToast;
+
+  const portal =
+    typeof document !== 'undefined'
+      ? createPortal(
+          React.createElement(
+            'div',
+            { className: 'fixed bottom-4 right-4 space-y-2 z-50' },
+            toasts.map((t) =>
+              React.createElement(
+                'div',
+                {
+                  key: t.id,
+                  className: `px-3 py-2 rounded shadow text-white ${
+                    t.type === 'success' ? 'bg-green-600' : 'bg-red-600'
+                  }`,
+                },
+                t.message,
+              ),
+            ),
+          ),
+          document.body,
+        )
+      : null;
+
+  return React.createElement(
+    ToastContext.Provider,
+    { value: addToast },
+    children,
+    portal,
+  );
+};
+
+export const useToast = () => useContext(ToastContext);
+
+export const triggerToast: AddToast = (toast) => trigger(toast);

--- a/llms.txt
+++ b/llms.txt
@@ -343,3 +343,14 @@ Files:
 main
  main
 
+Timestamp: 2025-08-06T22:33:18.591Z
+Commit: bd2f94dc3a50bcc314b14965b5c08f75401ac529
+Author: Codex
+Message: feat: add toast hook and logging error handler
+Files:
+- lib/logUiEvent.test.js (+23/-0)
+- lib/logUiEvent.ts (+5/-0)
+- lib/useToast.ts (+62/-0)
+- package.json (+1/-1)
+- pages/_app.tsx (+8/-5)
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node scripts/update-llms-log.test.js",
+    "test": "node scripts/update-llms-log.test.js && node lib/logUiEvent.test.js",
     "dev:local": "next dev --port 3000",
     "test:local": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/testLocal.ts",
     "postinstall": "node -e \"try{require.resolve('@types/react')}catch(e){console.warn('@types/react not found')}\"",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import '../styles/globals.css';
 import '../styles/typography.css';
 import Navbar from '../components/Navbar';
 import ThemeToggle from '../components/ThemeToggle';
+import { ToastProvider } from '../lib/useToast';
 
 function Header() {
   const { data: session, status } = useSession();
@@ -83,11 +84,13 @@ export default function MyApp({
 }: AppProps) {
   return (
     <SessionProvider session={session}>
-      <Navbar />
-      <Header />
-      <div className="pt-16">
-        <Component {...pageProps} />
-      </div>
+      <ToastProvider>
+        <Navbar />
+        <Header />
+        <div className="pt-16">
+          <Component {...pageProps} />
+        </div>
+      </ToastProvider>
     </SessionProvider>
   );
 }


### PR DESCRIPTION
## Summary
- introduce reusable toast provider and trigger hook
- show error toast when UI event logging fails
- mount global toast provider and add failing insert unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d617d9e48323ad0c295c1f8b1d7b