### PR TITLE
Use dynamic MatchupCard and lazy TeamBadge images

### DIFF
--- a/components/TeamBadge.tsx
+++ b/components/TeamBadge.tsx
@@ -31,6 +31,7 @@ const TeamBadge: React.FC<TeamBadgeProps> = ({ team, logoUrl, isWinner }) => {
         alt={`${team} logo`}
         className={badgeClasses}
         onError={() => setUseFallback(true)}
+        loading="lazy"
       />
     );
   }

--- a/llms.txt
+++ b/llms.txt
@@ -370,3 +370,12 @@ Files:
 - components/UpcomingGamesPanel.tsx (+2/-1)
 main
 
+Timestamp: 2025-08-06T22:54:21.567Z
+Commit: d6bb1dbd9a6b20baaaa4f2adcac8c352dc513bdb
+Author: Codex
+Message: Use dynamic MatchupCard and lazy TeamBadge images
+Files:
+- components/TeamBadge.tsx (+1/-0)
+- pages/index.tsx (+3/-1)
+- styles/typography.css (+3/-0)
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,9 +3,11 @@ import { motion } from 'framer-motion';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
 import { TypographyH1, TypographyMuted } from '../components/ui/typography';
-import MatchupCard from '../components/MatchupCard';
+import dynamic from 'next/dynamic';
 import type { AgentOutputs } from '../lib/types';
 import { FADE_DURATION, EASE } from '../lib/animations';
+
+const MatchupCard = dynamic(() => import('../components/MatchupCard'), { ssr: false });
 
 const dummyAgents: AgentOutputs = {
   injuryScout: { team: 'Team A', score: 0.2, reason: 'Fewer injuries' },

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -1,5 +1,8 @@
+@tailwind components;
+
 @layer components {
   .confidenceText {
     @apply font-semibold;
   }
 }
+


### PR DESCRIPTION
## Summary
- lazy-load MatchupCard on the home page via Next.js dynamic import (SSR disabled)
- defer TeamBadge logo loading with `loading="lazy"`
- include Tailwind components layer so typography styles compile

## Testing
- `npm test`
- `NEXTAUTH_SECRET=abc NEXTAUTH_URL=http://localhost npm run build`
- `CHROME_PATH=/usr/bin/chromium-browser npx -y lighthouse http://localhost:3000 --only-categories=performance --output=json --quiet --chrome-flags="--headless --no-sandbox" --output-path=lh-after.json` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6893d92be9ac83239bd812322d01bf98