### PR TITLE
chore: add script to inject sports API key

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -370,3 +370,10 @@ Files:
 - components/UpcomingGamesPanel.tsx (+2/-1)
 main
 
+Timestamp: 2025-08-06T22:54:10.476Z
+Commit: a3a17787d8d6554d47cbb41b9b602a4b6a8e0ebf
+Author: Codex
+Message: chore: add script to inject sports API key
+Files:
+- scripts/set-sports-api-key.js (+33/-0)
+

--- a/scripts/set-sports-api-key.js
+++ b/scripts/set-sports-api-key.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const envPath = path.resolve('.env.local');
+const apiKey = 'dac119a231fa4062abcadc7222e69889';
+const keyLine = `NEXT_PUBLIC_SPORTS_API_KEY=${apiKey}`;
+
+(async () => {
+  try {
+    let content = '';
+    if (fs.existsSync(envPath)) {
+      content = fs.readFileSync(envPath, 'utf8');
+
+      if (content.includes('NEXT_PUBLIC_SPORTS_API_KEY=')) {
+        // Replace existing line
+        content = content.replace(/NEXT_PUBLIC_SPORTS_API_KEY=.*/g, keyLine);
+      } else {
+        // Append if not present
+        content += `\n${keyLine}`;
+      }
+    } else {
+      content = keyLine;
+    }
+
+    fs.writeFileSync(envPath, content.trim() + '\n');
+    console.log('.env.local updated with SportsDataIO API key ✅');
+  } catch (err) {
+    console.error('❌ Failed to write .env.local:', err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a utility script to set or update `NEXT_PUBLIC_SPORTS_API_KEY` in `.env.local`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893dcad18a4832383ddab71b1cee1f0