### PR TITLE
feat: log UI events for navigation and auth

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -379,3 +379,11 @@ Files:
 - pages/index.tsx (+3/-1)
 - styles/typography.css (+3/-0)
 
+Timestamp: 2025-08-06T22:59:53.707Z
+Commit: 1007e0b801bfe123a0ef8aa1c70e757237e303cf
+Author: Codex
+Message: feat: log UI events for navigation and auth
+Files:
+- pages/_app.tsx (+8/-1)
+- pages/index.tsx (+14/-2)
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import '../styles/typography.css';
 import Navbar from '../components/Navbar';
 import ThemeToggle from '../components/ThemeToggle';
 import { ToastProvider } from '../lib/useToast';
+import { logUiEvent } from '../lib/logUiEvent';
 
 function Header() {
   const { data: session, status } = useSession();
@@ -67,7 +68,13 @@ function Header() {
           </>
         ) : (
           <button
-            onClick={() => signIn('google')}
+            onClick={() => {
+              logUiEvent(
+                'sign_in_click',
+                session?.user?.id ? { user_id: session.user.id } : {},
+              );
+              signIn('google');
+            }}
             className="min-h-[44px] px-4 py-2 border rounded"
           >
             Sign in with Google

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,13 @@
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { useSession } from 'next-auth/react';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
 import { TypographyH1, TypographyMuted } from '../components/ui/typography';
 import dynamic from 'next/dynamic';
 import type { AgentOutputs } from '../lib/types';
 import { FADE_DURATION, EASE } from '../lib/animations';
+import { logUiEvent } from '../lib/logUiEvent';
 
 const MatchupCard = dynamic(() => import('../components/MatchupCard'), { ssr: false });
 
@@ -25,7 +27,7 @@ const dummyResult = {
 };
 
 export default function Home() {
-
+  const { data: session } = useSession();
   return (
     <main className="min-h-screen bg-gradient-to-br from-zinc-900 to-neutral-950 text-white">
       <div className="max-w-3xl mx-auto py-16 space-y-6 text-center">
@@ -47,7 +49,17 @@ export default function Home() {
           whileHover={{ scale: 1.05 }}
         >
           <Link href="/matchups/public">
-            <Button variant="primaryCTA">Explore Matchups</Button>
+            <Button
+              variant="primaryCTA"
+              onClick={() =>
+                logUiEvent(
+                  'explore_matchups_click',
+                  session?.user?.id ? { user_id: session.user.id } : {},
+                )
+              }
+            >
+              Explore Matchups
+            </Button>
           </Link>
         </motion.div>
         <div className="pt-8 space-y-4">


### PR DESCRIPTION
## Summary
- track Explore Matchups clicks with logUiEvent and include user id when available
- log sign-in button clicks and capture user id extras

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893dd8566d48323bf8d7b6aa39bb7ab