### PR TITLE
feat: log session data

### DIFF
--- a/lib/logUiEvent.test.js
+++ b/lib/logUiEvent.test.js
@@ -17,7 +17,7 @@ supabase.getSupabaseClient = () => ({
 });
 
 (async () => {
-  await logUiEvent('test');
+  await logUiEvent('test', 'unauthenticated', undefined);
   assert(called, 'toast should be triggered on error');
   console.log('logUiEvent error toast test passed');
 })();

--- a/lib/logUiEvent.ts
+++ b/lib/logUiEvent.ts
@@ -3,12 +3,16 @@ import { triggerToast } from './useToast';
 
 export async function logUiEvent(
   uiEvent: string,
+  sessionType: string,
+  userId?: string,
   extras: Record<string, any> = {}
 ): Promise<void> {
   try {
     const client = getSupabaseClient();
     await client.from('ui_events').insert({
       event: uiEvent,
+      session_type: sessionType,
+      user_id: userId,
       extras,
       created_at: new Date().toISOString(),
     });

--- a/llms.txt
+++ b/llms.txt
@@ -379,3 +379,13 @@ Files:
 - pages/index.tsx (+3/-1)
 - styles/typography.css (+3/-0)
 
+Timestamp: 2025-08-06T23:00:17.712Z
+Commit: 0ee0b2314e618cddc87c272314ed72973c0ed9f0
+Author: Codex
+Message: feat: log session data
+Files:
+- lib/logUiEvent.test.js (+1/-1)
+- lib/logUiEvent.ts (+4/-0)
+- pages/_app.tsx (+11/-4)
+- supabase/schema.sql (+9/-0)
+

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,9 +9,10 @@ import '../styles/typography.css';
 import Navbar from '../components/Navbar';
 import ThemeToggle from '../components/ThemeToggle';
 import { ToastProvider } from '../lib/useToast';
+import { logUiEvent } from '../lib/logUiEvent';
 
 function Header() {
-  const { data: session, status } = useSession();
+  const { data: session, status: sessionType } = useSession();
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
@@ -40,7 +41,7 @@ function Header() {
         <Link href="/predictions" className="min-h-[44px] px-4 py-2 border rounded">
           Predictions
         </Link>
-        {status === 'loading' ? (
+        {sessionType === 'loading' ? (
           <div className="w-8 h-8 rounded-full bg-gray-200 animate-pulse" />
         ) : session ? (
           <>
@@ -59,7 +60,10 @@ function Header() {
             )}
             <span>{session.user?.name || 'Anonymous'}</span>
             <button
-              onClick={() => signOut()}
+              onClick={() => {
+                void logUiEvent('sign_out', sessionType, session?.user?.id);
+                signOut();
+              }}
               className="min-h-[44px] px-4 py-2 border rounded"
             >
               Sign out
@@ -67,7 +71,10 @@ function Header() {
           </>
         ) : (
           <button
-            onClick={() => signIn('google')}
+            onClick={() => {
+              void logUiEvent('sign_in', sessionType, session?.user?.id);
+              signIn('google');
+            }}
             className="min-h-[44px] px-4 py-2 border rounded"
           >
             Sign in with Google

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -27,3 +27,12 @@ create table if not exists flow_stats (
   losses int default 0,
   accuracy float default 0
 );
+
+create table if not exists ui_events (
+  id uuid primary key default gen_random_uuid(),
+  event text not null,
+  session_type text,
+  user_id text,
+  extras jsonb,
+  created_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- record session type and user id with `logUiEvent`
- log sign-in and sign-out events with session data
- add `ui_events` table to supabase schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893dd873bf083238fab05e8f62bea05