### PR TITLE
Show agent rationale on name hover

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -12,7 +12,6 @@ import { AgentName, AgentResult } from '../lib/types';
 import { formatAgentName } from '../lib/utils';
 import Tooltip from './Tooltip';
 import ConfidenceMeter from './ConfidenceMeter';
-import AgentTooltip from './AgentTooltip';
 import { agentCard, agentCardSkeleton } from '../styles/cardStyles';
 
 interface Props {
@@ -77,9 +76,10 @@ const AgentCard: React.FC<Props> = ({
       style={{ boxShadow: `0 0 8px ${glowColor}` }}
     >
       <div className="flex items-center justify-between">
-        <AgentTooltip name={name}>
+        <Tooltip content={result.reason}>
           <span
-            className="flex items-center gap-2 font-medium"
+            className="flex items-center gap-2 font-medium cursor-help"
+            tabIndex={0}
             onMouseEnter={() =>
               window.dispatchEvent(
                 new CustomEvent('glossary-hover', { detail: name })
@@ -90,11 +90,21 @@ const AgentCard: React.FC<Props> = ({
                 new CustomEvent('glossary-hover', { detail: null })
               )
             }
+            onFocus={() =>
+              window.dispatchEvent(
+                new CustomEvent('glossary-hover', { detail: name })
+              )
+            }
+            onBlur={() =>
+              window.dispatchEvent(
+                new CustomEvent('glossary-hover', { detail: null })
+              )
+            }
           >
             <Icon className="w-4 h-4" />
             {formatAgentName(name)}
           </span>
-        </AgentTooltip>
+        </Tooltip>
         {showWeight && (
           <span className="text-xs text-gray-500">{weightPct}% weight</span>
         )}
@@ -107,11 +117,6 @@ const AgentCard: React.FC<Props> = ({
         teamB={{ name: '' }}
         confidence={scorePct}
       />
-      <div className="text-xs text-gray-600 flex items-center">
-        <Tooltip content={result.reason}>
-          <Info className="w-4 h-4 cursor-help" />
-        </Tooltip>
-      </div>
       {result.warnings && result.warnings.length > 0 && (
         <ul className="text-xs text-yellow-700 list-disc pl-4">
           {result.warnings.map((w, i) => (

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -14,6 +14,9 @@ const Tooltip: React.FC<TooltipProps> = ({ content, children, className }) => {
       className={`relative inline-block ${className || ''}`}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
+      tabIndex={0}
     >
       {children}
       {open && (

--- a/llms.txt
+++ b/llms.txt
@@ -406,3 +406,12 @@ Files:
 - pages/_app.tsx (+11/-4)
 - supabase/schema.sql (+9/-0)
 
+Timestamp: 2025-08-06T23:09:44.509Z
+Commit: ef69ff4b6c52bb8ea28c9399b7cb9befc77d082c
+Author: Codex
+Message: Show agent rationale on name hover
+Files:
+- components/AgentCard.tsx (+14/-9)
+- components/Tooltip.tsx (+3/-0)
+- manual-qa.md (+7/-0)
+

--- a/manual-qa.md
+++ b/manual-qa.md
@@ -1,0 +1,7 @@
+# Manual QA - AgentCard Tooltip Accessibility
+
+Steps to validate:
+1. Render an `AgentCard` with a populated `result`.
+2. Hover over the agent name – the rationale from `result.reason` should appear in a tooltip.
+3. Tab to the agent name and observe that the same rationale tooltip appears on focus.
+4. Move the mouse away or tab out – the tooltip should disappear.


### PR DESCRIPTION
## Summary
- display agent reasoning when hovering or focusing agent name
- make Tooltip component focusable and keyboard accessible
- document manual QA for rationale tooltip

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893dfecf37483239c2bdc278239330d