### PR TITLE
Wrap AgentCard in dashboard link when authenticated

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useSession } from 'next-auth/react';
 import {
   Activity,
   LineChart,
@@ -43,6 +45,7 @@ const AgentCard: React.FC<Props> = ({
   loading = false,
 }) => {
   const [visible, setVisible] = useState(false);
+  const { data: session } = useSession();
   useEffect(() => {
     setVisible(true);
   }, []);
@@ -68,8 +71,7 @@ const AgentCard: React.FC<Props> = ({
       ? 'rgba(250,204,21,0.6)'
       : 'rgba(239,68,68,0.6)';
   const Icon = (agentIcons[name] || Info) as LucideIcon;
-
-  return (
+  const content = (
     <div
       className={`${agentCard} ${
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
@@ -120,6 +122,14 @@ const AgentCard: React.FC<Props> = ({
         </ul>
       )}
     </div>
+  );
+
+  return session?.user ? (
+    <Link href="/dashboard" aria-label="View agent dashboard">
+      {content}
+    </Link>
+  ) : (
+    content
   );
 };
 

--- a/llms.txt
+++ b/llms.txt
@@ -406,3 +406,10 @@ Files:
 - pages/_app.tsx (+11/-4)
 - supabase/schema.sql (+9/-0)
 
+Timestamp: 2025-08-06T23:10:29.798Z
+Commit: 423bccade410cdb4feb4cfedaf40c999a05a3406
+Author: Codex
+Message: Wrap AgentCard in dashboard link when authenticated
+Files:
+- components/AgentCard.tsx (+12/-2)
+


### PR DESCRIPTION
## Summary
- Use `useSession` to check authentication in `AgentCard`
- Wrap card in dashboard link when authenticated, with accessible aria-label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893dfedb21c832397478760b3a758a4