### PR TITLE
refactor: add prediction reveal hook

### DIFF
--- a/components/hooks/usePredictionReveal.test.js
+++ b/components/hooks/usePredictionReveal.test.js
@@ -1,0 +1,37 @@
+require('ts-node').register({ transpileOnly: true, compilerOptions: { module: 'CommonJS' } });
+const assert = require('assert');
+const React = require('react');
+const renderer = require('react-test-renderer');
+const { act } = renderer;
+const nextAuth = require('next-auth/react');
+
+function renderHookWithSession(session) {
+  nextAuth.useSession = () => ({ data: session });
+  const result = {};
+  function TestComponent() {
+    result.current = require('./usePredictionReveal').default();
+    return null;
+  }
+  act(() => {
+    renderer.create(React.createElement(TestComponent));
+  });
+  return result;
+}
+
+// Test unauthenticated: should show modal
+let result = renderHookWithSession(null);
+assert.deepStrictEqual(result.current.revealed, {});
+act(() => {
+  result.current.handleReveal(1);
+});
+assert.strictEqual(result.current.showModal, true);
+
+// Test authenticated: should reveal index
+result = renderHookWithSession({ user: { name: 'Test' } });
+act(() => {
+  result.current.handleReveal(2);
+});
+assert.strictEqual(result.current.revealed[2], true);
+assert.strictEqual(result.current.showModal, false);
+
+console.log('usePredictionReveal tests passed');

--- a/components/hooks/usePredictionReveal.ts
+++ b/components/hooks/usePredictionReveal.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { useSession } from 'next-auth/react';
+
+export default function usePredictionReveal() {
+  const { data: session } = useSession();
+  const [revealed, setRevealed] = useState<Record<number, boolean>>({});
+  const [showModal, setShowModal] = useState(false);
+
+  const handleReveal = (idx: number) => {
+    if (session) {
+      setRevealed((prev) => ({ ...prev, [idx]: true }));
+    } else {
+      setShowModal(true);
+    }
+  };
+
+  return { revealed, handleReveal, showModal, setShowModal };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "autoprefixer": "^10.4.14",
         "husky": "^9.1.7",
         "postcss": "^8.4.31",
+        "react-test-renderer": "^18.2.0",
         "tailwindcss": "^3.3.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
@@ -2754,6 +2755,42 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node scripts/update-llms-log.test.js && node lib/logUiEvent.test.js",
+    "test": "node scripts/update-llms-log.test.js && node lib/logUiEvent.test.js && node components/hooks/usePredictionReveal.test.js",
     "dev:local": "next dev --port 3000",
     "test:local": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/testLocal.ts",
     "postinstall": "node -e \"try{require.resolve('@types/react')}catch(e){console.warn('@types/react not found')}\"",
@@ -34,6 +34,7 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "react-test-renderer": "^18.2.0"
   }
 }

--- a/pages/matchups/public.tsx
+++ b/pages/matchups/public.tsx
@@ -1,23 +1,16 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSession } from 'next-auth/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import UpcomingGamesPanel from '../../components/UpcomingGamesPanel';
 import PredictionTracker from '../../components/PredictionTracker';
 import SignInModal from '../../components/SignInModal';
 import { FADE_DURATION, EASE } from '../../lib/animations';
+import usePredictionReveal from '../../components/hooks/usePredictionReveal';
 
 const PublicMatchupsPage: React.FC = () => {
   const { data: session } = useSession();
-  const [revealed, setRevealed] = useState<Record<number, boolean>>({});
-  const [showModal, setShowModal] = useState(false);
-
-  const handleReveal = (idx: number) => {
-    if (session) {
-      setRevealed((prev) => ({ ...prev, [idx]: true }));
-    } else {
-      setShowModal(true);
-    }
-  };
+  const { revealed, handleReveal, showModal, setShowModal } =
+    usePredictionReveal();
 
   return (
     <main className="min-h-screen bg-gray-50 p-6 space-y-4">


### PR DESCRIPTION
## Summary
- add `usePredictionReveal` hook to manage reveal state and sign-in modal
- refactor PublicMatchupsPage to use the new hook
- test hook behavior for authenticated and unauthenticated users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e1da46c48323b7681c44917ad0df