### PR TITLE
Merge tests for PublicMatchupsPage and usePredictionReveal

### DIFF
--- a/__tests__/PublicMatchupsPage.test.tsx
+++ b/__tests__/PublicMatchupsPage.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useSession } from 'next-auth/react';
+import PublicMatchupsPage from '../pages/matchups/public';
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}));
+
+jest.mock('../components/UpcomingGamesPanel', () => ({
+  cardWrapper,
+}: any) => cardWrapper({ index: 0, children: <div data-testid="game">Game</div> }));
+
+jest.mock('../components/PredictionTracker', () => ({ onReveal }: any) => (
+  <button onClick={onReveal}>Reveal</button>
+));
+
+jest.mock('../components/SignInModal', () => ({ isOpen }: any) =>
+  isOpen ? <div data-testid="sign-in-modal" /> : null
+);
+
+describe('PublicMatchupsPage', () => {
+  afterEach(() => {
+    (useSession as jest.Mock).mockReset();
+  });
+
+  it('shows sign-in modal when revealing without session', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: null });
+    render(<PublicMatchupsPage />);
+    fireEvent.click(screen.getByText('Reveal'));
+    expect(screen.getByTestId('sign-in-modal')).toBeInTheDocument();
+  });
+
+  it('reveals predictions when session exists', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: {} });
+    render(<PublicMatchupsPage />);
+    fireEvent.click(screen.getByText('Reveal'));
+    expect(screen.getByTestId('game')).toBeInTheDocument();
+    expect(screen.queryByTestId('sign-in-modal')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/hooks/usePredictionReveal.test.ts
+++ b/__tests__/hooks/usePredictionReveal.test.ts
@@ -1,0 +1,31 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSession } from 'next-auth/react';
+import usePredictionReveal from '../../lib/hooks/usePredictionReveal';
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}));
+
+describe('usePredictionReveal', () => {
+  afterEach(() => {
+    (useSession as jest.Mock).mockReset();
+  });
+
+  it('reveals index when session exists', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: {} });
+    const { result } = renderHook(() => usePredictionReveal());
+    act(() => result.current.handleReveal(1));
+    expect(result.current.revealed[1]).toBe(true);
+    expect(result.current.showModal).toBe(false);
+  });
+
+  it('shows modal when no session', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: null });
+    const { result } = renderHook(() => usePredictionReveal());
+    act(() => result.current.handleReveal(2));
+    expect(result.current.revealed[2]).toBeUndefined();
+    expect(result.current.showModal).toBe(true);
+    act(() => result.current.closeModal());
+    expect(result.current.showModal).toBe(false);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ const customJestConfig = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: ['<rootDir>/__tests__/**/*.test.(ts|tsx)'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/lib/hooks/usePredictionReveal.ts
+++ b/lib/hooks/usePredictionReveal.ts
@@ -1,0 +1,22 @@
+import { useSession } from 'next-auth/react';
+import { useState } from 'react';
+
+const usePredictionReveal = () => {
+  const { data: session } = useSession();
+  const [revealed, setRevealed] = useState<Record<number, boolean>>({});
+  const [showModal, setShowModal] = useState(false);
+
+  const handleReveal = (idx: number) => {
+    if (session) {
+      setRevealed((prev) => ({ ...prev, [idx]: true }));
+    } else {
+      setShowModal(true);
+    }
+  };
+
+  const closeModal = () => setShowModal(false);
+
+  return { revealed, showModal, handleReveal, closeModal, session };
+};
+
+export default usePredictionReveal;

--- a/llms.txt
+++ b/llms.txt
@@ -435,3 +435,14 @@ Files:
 - package-lock.json (+5544/-1290)
 - package.json (+7/-2)
 
+Timestamp: 2025-08-06T23:39:07.226Z
+Commit: df4f3b2eebd30360b39591b5ffc70dd64f3faf5d
+Author: Codex
+Message: Merge tests for PublicMatchupsPage and usePredictionReveal
+Files:
+- __tests__/PublicMatchupsPage.test.tsx (+40/-0)
+- __tests__/hooks/usePredictionReveal.test.ts (+31/-0)
+- jest.config.js (+3/-0)
+- lib/hooks/usePredictionReveal.ts (+22/-0)
+- pages/matchups/public.tsx (+5/-14)
+

--- a/pages/matchups/public.tsx
+++ b/pages/matchups/public.tsx
@@ -1,23 +1,14 @@
-import React, { useState } from 'react';
-import { useSession } from 'next-auth/react';
+import React from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import UpcomingGamesPanel from '../../components/UpcomingGamesPanel';
 import PredictionTracker from '../../components/PredictionTracker';
 import SignInModal from '../../components/SignInModal';
 import { FADE_DURATION, EASE } from '../../lib/animations';
+import usePredictionReveal from '../../lib/hooks/usePredictionReveal';
 
 const PublicMatchupsPage: React.FC = () => {
-  const { data: session } = useSession();
-  const [revealed, setRevealed] = useState<Record<number, boolean>>({});
-  const [showModal, setShowModal] = useState(false);
-
-  const handleReveal = (idx: number) => {
-    if (session) {
-      setRevealed((prev) => ({ ...prev, [idx]: true }));
-    } else {
-      setShowModal(true);
-    }
-  };
+  const { revealed, showModal, handleReveal, closeModal, session } =
+    usePredictionReveal();
 
   return (
     <main className="min-h-screen bg-gray-50 p-6 space-y-4">
@@ -49,7 +40,7 @@ const PublicMatchupsPage: React.FC = () => {
           </div>
         )}
       />
-      <SignInModal isOpen={showModal} onClose={() => setShowModal(false)} />
+      <SignInModal isOpen={showModal} onClose={closeModal} />
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- add hook for handling prediction reveal logic
- consolidate PublicMatchupsPage tests
- add tests for usePredictionReveal hook

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: Argument of type '{ revealedIndex: number; }' is not assignable to parameter of type 'string'.)*

------
https://chatgpt.com/codex/tasks/task_e_6893e673f5a48323b48680ed64aed5ad