### PR TITLE
docs: document flows and sse examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ GET /api/log-status
 
 This returns the number of pending log entries and the last error encountered (if any).
 
+## Flow Configurations
+
+Flow presets live in the `flows/` directory as simple JSON files that list which agents should run for a request. Each config includes a human-friendly name and an ordered array of agent IDs:
+
+```json
+{
+  "name": "Default NFL Flow",
+  "agents": ["injuryScout", "statCruncher", "lineWatcher", "guardianAgent"]
+}
+```
+
+Streaming endpoints accept a `flow` query parameter so you can select one of these configs. If omitted, `/api/run-agents` defaults to `football-pick` and `/api/trends` defaults to `trends`.
+
+### SSE Examples
+
+Use `curl` with `-N` to watch Server-Sent Events as they arrive:
+
+```sh
+curl -N -H "Accept: text/event-stream" "http://localhost:3000/api/run-agents?teamA=KC&teamB=DEN&matchDay=1&flow=football-pick"
+curl -N -H "Accept: text/event-stream" "http://localhost:3000/api/trends?flow=trends"
+```
+
 ## Environment Variables
 
 Create a `.env.local` file in the project root for local development. The app

--- a/llms.txt
+++ b/llms.txt
@@ -460,3 +460,10 @@ Message: docs: update sports db league env vars
 Files:
 - README.md (+5/-2)
 
+Timestamp: 2025-08-07T00:10:56.863Z
+Commit: 1d91af3fdb3cfc8be43777e641e5497b06caefe9
+Author: Codex
+Message: docs: document flows and sse examples
+Files:
+- README.md (+22/-0)
+


### PR DESCRIPTION
## Summary
- explain how flow JSON configs in `flows/` define agent sets and can be selected via a `flow` query parameter
- show how to stream results from `/api/run-agents` and `/api/trends` using Server-Sent Events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893edeb83c08323b82cb795f371c3a4