### PR TITLE
feat: integrate flow into predictions

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -467,3 +467,10 @@ Message: docs: document flows and sse examples
 Files:
 - README.md (+22/-0)
 
+Timestamp: 2025-08-07T00:22:01.562Z
+Commit: c9399439ed07cdc3c39d3ad8dbf652263f6694db
+Author: Codex
+Message: feat: integrate flow into predictions
+Files:
+- pages/api/run-predictions.ts (+52/-15)
+


### PR DESCRIPTION
## Summary
- use runFlow to evaluate agent outputs for each game
- compute winner and confidence from weighted agent scores
- aggregate agent scores across predictions for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893f0642944832397d12f3e19fd1e72