### PR TITLE
feat: allow structured metadata in logUiEvent

### DIFF
--- a/components/PredictionTracker.tsx
+++ b/components/PredictionTracker.tsx
@@ -41,8 +41,10 @@ const PredictionTracker: React.FC<Props> = ({
 
   useEffect(() => {
     if (isFinal) {
-      const extras = revealedIndex !== undefined ? { revealedIndex } : undefined;
-      logUiEvent('prediction_tracker_complete', extras);
+      logUiEvent(
+        'prediction_tracker_complete',
+        revealedIndex !== undefined ? { revealedIndex } : undefined,
+      );
     }
   }, [isFinal, revealedIndex]);
 

--- a/lib/logUiEvent.test.js
+++ b/lib/logUiEvent.test.js
@@ -17,7 +17,7 @@ supabase.getSupabaseClient = () => ({
 });
 
 (async () => {
-  await logUiEvent('test', 'unauthenticated', undefined);
+  await logUiEvent('test', { session_type: 'unauthenticated' });
   assert(called, 'toast should be triggered on error');
   console.log('logUiEvent error toast test passed');
 })();

--- a/lib/logUiEvent.ts
+++ b/lib/logUiEvent.ts
@@ -3,17 +3,15 @@ import { triggerToast } from './useToast';
 
 export async function logUiEvent(
   uiEvent: string,
-  sessionType: string,
-  userId?: string,
-  extras: Record<string, any> = {}
+  metadata?: Record<string, any>,
 ): Promise<void> {
   try {
+    const meta = metadata ?? {};
+    console.log(`[UI EVENT] ${uiEvent}`, Object.keys(meta).length ? meta : '');
     const client = getSupabaseClient();
     await client.from('ui_events').insert({
       event: uiEvent,
-      session_type: sessionType,
-      user_id: userId,
-      extras,
+      metadata: meta,
       created_at: new Date().toISOString(),
     });
   } catch (err) {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -61,7 +61,10 @@ function Header() {
             <span>{session.user?.name || 'Anonymous'}</span>
             <button
               onClick={() => {
-                void logUiEvent('sign_out', sessionType, session?.user?.id);
+                void logUiEvent('sign_out', {
+                  session_type: sessionType,
+                  user_id: (session?.user as any)?.id,
+                });
                 signOut();
               }}
               className="min-h-[44px] px-4 py-2 border rounded"
@@ -74,7 +77,7 @@ function Header() {
             onClick={() => {
               logUiEvent('sign_in_click', {
                 session_type: sessionType,
-                user_id: session?.user?.id ?? 'unknown',
+                user_id: (session?.user as any)?.id ?? 'unknown',
               });
               signIn('google');
             }}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -54,7 +54,9 @@ export default function Home() {
               onClick={() =>
                 logUiEvent(
                   'explore_matchups_click',
-                  session?.user?.id ? { user_id: session.user.id } : {},
+                  (session?.user as any)?.id
+                    ? { user_id: (session.user as any).id }
+                    : undefined,
                 )
               }
             >


### PR DESCRIPTION
## Summary
- expand `logUiEvent` to take optional metadata objects
- log prediction tracker completion with structured metadata
- update app pages and tests for new logging signature

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: Missing required environment variables: NEXTAUTH_SECRET, NEXTAUTH_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6893f4ec16a48323b7c438a54d491265