### PR TITLE
ci: add GitHub Actions pipeline for lint, test, and deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: EdgePicks CI Pipeline
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: ⚙️ Lint, Type Check, Test, Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🟢 Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🧹 Lint
+        run: npm run lint
+
+      - name: 🔎 Type check
+        run: npx tsc --noEmit
+
+      - name: 🧪 Run tests
+        run: npm test
+
+      - name: 🏗 Build app (optional for Vercel)
+        run: npm run build
+
+  deploy:
+    name: 🚀 Deploy to Vercel
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && success()
+
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🔐 Setup Vercel CLI
+        run: npm install -g vercel
+
+      - name: 🚀 Deploy to Vercel (Production)
+        run: vercel --prod --confirm --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for lint, type check, tests, build, and Vercel deploy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893fbf2370483238f819a04042d1ea5