### PR TITLE
feat: add env helper and supabase client

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ GOOGLE_CLIENT_SECRET=<your-client-secret>
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=<secure-generated-secret>
 ODDS_API_KEY=<your-oddsapi-key>
-SPORTS_DB_API_KEY=<your-thesportsdb-api-key>
+SPORTS_API_KEY=<your-thesportsdb-api-key>
 SPORTS_DB_NFL_ID=<thesportsdb-nfl-league-id>
 SPORTS_DB_MLB_ID=<thesportsdb-mlb-league-id>
 SPORTS_DB_NBA_ID=<thesportsdb-nba-league-id>
@@ -175,7 +175,7 @@ SPORTS_DB_NHL_ID=<thesportsdb-nhl-league-id>
 
 You can find the Supabase values in your dashboard under **Project Settings → API**.
 The NextAuth variables enable Google sign-in for protected routes.
-`SPORTS_DB_API_KEY` is required for live schedule fetching from TheSportsDB.
+`SPORTS_API_KEY` is required for live schedule fetching from TheSportsDB.
 `SPORTS_DB_NFL_ID` sets the TheSportsDB league ID for NFL (default `4391`). Use `SPORTS_DB_MLB_ID`, `SPORTS_DB_NBA_ID`, and `SPORTS_DB_NHL_ID` to configure other leagues. These values populate the `SPORTS_DB_LEAGUE_IDS` map in `lib/data/liveSports.ts`.
 
 ### Development Setup

--- a/lib/accuracy.ts
+++ b/lib/accuracy.ts
@@ -1,4 +1,4 @@
-import { getSupabaseClient } from './supabaseClient';
+import { supabase } from './supabaseClient';
 import { agents as agentRegistry } from './agents/registry';
 import type { AgentName, AgentOutputs } from './types';
 
@@ -17,8 +17,7 @@ export interface AccuracyStat {
 }
 
 export async function recomputeAccuracy() {
-  const client = getSupabaseClient();
-  const { data, error } = await client
+  const { data, error } = await supabase
     .from('matchups')
     .select('agents, pick, actual_winner, flow');
   if (error || !data) {
@@ -73,8 +72,8 @@ export async function recomputeAccuracy() {
     accuracy: t.wins + t.losses > 0 ? t.wins / (t.wins + t.losses) : 0,
   }));
 
-  await client.from('agent_stats').upsert(agentStats, { onConflict: 'agent' });
-  await client.from('flow_stats').upsert(flowStats, { onConflict: 'flow' });
+  await supabase.from('agent_stats').upsert(agentStats, { onConflict: 'agent' });
+  await supabase.from('flow_stats').upsert(flowStats, { onConflict: 'flow' });
 
   return { agentStats, flowStats };
 }

--- a/lib/agents/trendsAgent.ts
+++ b/lib/agents/trendsAgent.ts
@@ -1,5 +1,5 @@
 import { AgentResult, Matchup } from '../types';
-import { getSupabaseClient } from '../supabaseClient';
+import { supabase } from '../supabaseClient';
 
 export interface TrendsResult extends AgentResult {
   flowPopularity: { flow: string; count: number }[];
@@ -13,8 +13,7 @@ interface MatchupRow {
 }
 
 export const trendsAgent = async (_: Matchup): Promise<TrendsResult> => {
-  const client = getSupabaseClient();
-  const { data, error } = await client
+  const { data, error } = await supabase
     .from<'matchups', MatchupRow>('matchups')
     .select('flow, agents, actual_winner')
     .order('created_at', { ascending: false })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,7 +2,7 @@ export const getUpcomingGames = async (league: string = 'NFL') => {
   const res = await fetch(`/api/upcoming-games?league=${league}`);
   if (!res.ok) throw new Error('Failed to fetch upcoming games');
   if (res.headers.get('x-missing-api-key')) {
-    console.warn('No SPORTS_DB_API_KEY is set. Using mock data for games.');
+    console.warn('No SPORTS_API_KEY is set. Using mock data for games.');
   }
   const data = await res.json();
   if (Array.isArray(data) && data.some((g) => g.useFallback || g.source === 'fallback')) {

--- a/lib/data/liveSports.ts
+++ b/lib/data/liveSports.ts
@@ -1,12 +1,13 @@
 import { Matchup } from '../types';
+import { ENV } from '../env';
 
 // Supported league identifiers.  We expose these so callers can reference the
 // specific league types when needed but the public API of this module is via
 // the dedicated fetch helpers defined at the bottom of the file.
 export type League = 'NFL' | 'MLB' | 'NBA' | 'NHL';
 
-const SPORTS_DB_API_KEY = process.env.SPORTS_DB_API_KEY ?? '1';
-const SPORTSDB_TEAM_URL = `https://www.thesportsdb.com/api/v1/json/${SPORTS_DB_API_KEY}/lookupteam.php?id=`;
+const SPORTS_API_KEY = ENV.SPORTS_API_KEY;
+const SPORTSDB_TEAM_URL = `https://www.thesportsdb.com/api/v1/json/${SPORTS_API_KEY}/lookupteam.php?id=`;
 
 const SPORTS_DB_LEAGUE_IDS: Record<League, string | undefined> = {
   NFL: process.env.SPORTS_DB_NFL_ID,
@@ -50,7 +51,7 @@ async function fetchUpcomingGames(league: League): Promise<Matchup[]> {
   const isDev = process.env.NODE_ENV === 'development';
   const leagueId = SPORTS_DB_LEAGUE_IDS[league];
   if (!leagueId) return [];
-  const eventsUrl = `https://www.thesportsdb.com/api/v1/json/${SPORTS_DB_API_KEY}/eventsnextleague.php?id=${leagueId}`;
+  const eventsUrl = `https://www.thesportsdb.com/api/v1/json/${SPORTS_API_KEY}/eventsnextleague.php?id=${leagueId}`;
   const oddsSport = ODDS_API_SPORT_MAP[league];
   const oddsApiUrl = `https://api.the-odds-api.com/v4/sports/${oddsSport}/odds/`;
   try {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,12 +1,19 @@
-const required = ['NEXTAUTH_SECRET', 'NEXTAUTH_URL', 'SUPABASE_ANON_KEY'];
-const missing = required.filter((key) => !process.env[key]);
-if (missing.length) {
-  throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
-}
+export const getEnv = (key: string, fallback?: string): string => {
+  const value = process.env[key];
+  if (!value) {
+    if (fallback !== undefined) {
+      console.warn(`[env] Warning: Missing ${key}, using fallback: ${fallback}`);
+      return fallback;
+    }
+    throw new Error(`[env] Missing required environment variable: ${key}`);
+  }
+  return value;
+};
 
-export const hasSportsDbKey =
-  !!process.env.SPORTS_DB_API_KEY && process.env.SPORTS_DB_API_KEY !== '1';
+export const ENV = {
+  SUPABASE_URL: getEnv('SUPABASE_URL', 'https://fallback.supabase.co'),
+  SUPABASE_ANON_KEY: getEnv('SUPABASE_ANON_KEY', 'anon-fallback'),
+  NEXTAUTH_URL: getEnv('NEXTAUTH_URL', 'http://localhost:3000'),
+  SPORTS_API_KEY: getEnv('SPORTS_API_KEY', 'sports-fallback-key'),
+};
 
-if (!hasSportsDbKey) {
-  console.warn('Sports API key missing. Add it to `.env.local` to enable live games.');
-}

--- a/lib/logToSupabase.ts
+++ b/lib/logToSupabase.ts
@@ -1,4 +1,4 @@
-import { getSupabaseClient } from './supabaseClient';
+import { supabase } from './supabaseClient';
 import { AgentOutputs, Matchup, PickSummary } from './types';
 import { recomputeAccuracy } from './accuracy';
 
@@ -28,8 +28,7 @@ async function processQueue() {
   const entry = queue.shift()!;
   let retryDelay: number | null = null;
   try {
-    const client = getSupabaseClient();
-    const { error } = await client.from('matchups').insert({
+    const { error } = await supabase.from('matchups').insert({
       team_a: entry.matchup.homeTeam,
       team_b: entry.matchup.awayTeam,
       match_day: entry.matchup.matchDay,

--- a/lib/logUiEvent.test.js
+++ b/lib/logUiEvent.test.js
@@ -10,11 +10,11 @@ toast.triggerToast = (t) => {
   assert.strictEqual(t.message, 'Unable to log event; please sign in again');
 };
 
-supabase.getSupabaseClient = () => ({
+supabase.supabase = {
   from: () => ({
     insert: () => Promise.reject(new Error('fail')),
   }),
-});
+};
 
 (async () => {
   await logUiEvent('test', { session_type: 'unauthenticated' });

--- a/lib/logUiEvent.ts
+++ b/lib/logUiEvent.ts
@@ -1,4 +1,4 @@
-import { getSupabaseClient } from './supabaseClient';
+import { supabase } from './supabaseClient';
 import { triggerToast } from './useToast';
 
 export async function logUiEvent(
@@ -8,8 +8,7 @@ export async function logUiEvent(
   try {
     const meta = metadata ?? {};
     console.log(`[UI EVENT] ${uiEvent}`, Object.keys(meta).length ? meta : '');
-    const client = getSupabaseClient();
-    await client.from('ui_events').insert({
+    await supabase.from('ui_events').insert({
       event: uiEvent,
       metadata: meta,
       created_at: new Date().toISOString(),

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,20 +1,5 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import './env';
+import { createClient } from '@supabase/supabase-js';
+import { ENV } from './env';
 
-let client: SupabaseClient | null = null;
+export const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_ANON_KEY);
 
-export const getSupabaseClient = (): SupabaseClient => {
-  if (!client) {
-    const url = process.env.SUPABASE_URL;
-    const anonKey = process.env.SUPABASE_ANON_KEY;
-
-    if (!url || !anonKey) {
-      throw new Error(
-        'Supabase environment variables SUPABASE_URL and SUPABASE_ANON_KEY must be set.'
-      );
-    }
-
-    client = createClient(url, anonKey);
-  }
-  return client;
-};

--- a/llms.txt
+++ b/llms.txt
@@ -503,3 +503,23 @@ Files:
 - pages/index.tsx (+83/-32)
 - pages/matchups/public.tsx (+10/-1)
 
+Timestamp: 2025-08-07T01:18:44.402Z
+Commit: b19cecc7c0139123e4680fc6a853984d177c70d8
+Author: Codex
+Message: feat: add env helper and supabase client
+Files:
+- README.md (+2/-2)
+- lib/accuracy.ts (+4/-5)
+- lib/agents/trendsAgent.ts (+2/-3)
+- lib/api.ts (+1/-1)
+- lib/data/liveSports.ts (+4/-3)
+- lib/env.ts (+17/-10)
+- lib/logToSupabase.ts (+2/-3)
+- lib/logUiEvent.test.js (+2/-2)
+- lib/logUiEvent.ts (+2/-3)
+- lib/supabaseClient.ts (+3/-18)
+- pages/api/accuracy.ts (+4/-6)
+- pages/api/run-predictions.ts (+4/-3)
+- pages/api/upcoming-games.ts (+8/-5)
+- pages/history.tsx (+2/-3)
+

--- a/pages/api/accuracy.ts
+++ b/pages/api/accuracy.ts
@@ -1,10 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getSupabaseClient } from '../../lib/supabaseClient';
+import { supabase } from '../../lib/supabaseClient';
 import { recomputeAccuracy } from '../../lib/accuracy';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const client = getSupabaseClient();
-
   if (req.method === 'POST') {
     const { matchupId, actualWinner } = req.body as {
       matchupId?: string;
@@ -15,7 +13,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return;
     }
 
-    const { error } = await client
+    const { error } = await supabase
       .from('matchups')
       .update({ actual_winner: actualWinner })
       .eq('id', matchupId);
@@ -35,11 +33,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (req.method === 'GET') {
-    const { data: agentRows, error: agentError } = await client
+    const { data: agentRows, error: agentError } = await supabase
       .from('agent_stats')
       .select('*')
       .order('accuracy', { ascending: false });
-    const { data: flowRows, error: flowError } = await client
+    const { data: flowRows, error: flowError } = await supabase
       .from('flow_stats')
       .select('*')
       .order('accuracy', { ascending: false });

--- a/pages/api/run-predictions.ts
+++ b/pages/api/run-predictions.ts
@@ -7,6 +7,7 @@ import { loadFlow } from '../../lib/flow/loadFlow';
 import { runFlow } from '../../lib/flow/runFlow';
 import { agents } from '../../lib/agents/registry';
 import type { Matchup } from '../../lib/types';
+import { ENV } from '../../lib/env';
 
 interface Game {
   homeTeam: { name: string };
@@ -34,12 +35,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const missingEnv = ['SPORTS_DB_API_KEY'].filter((key) => !process.env[key]);
+  const missingEnv = ['SPORTS_API_KEY'].filter((key) => !process.env[key]);
   if (missingEnv.length) {
     console.warn(`Missing required env vars: ${missingEnv.join(', ')}`);
   }
-  if (!process.env.SPORTS_DB_API_KEY && process.env.NODE_ENV === 'development') {
-    console.warn('[Dev Warning] Using mock data. Add SPORTS_DB_API_KEY to .env.local');
+  if (ENV.SPORTS_API_KEY === 'sports-fallback-key' && process.env.NODE_ENV === 'development') {
+    console.warn('[Dev Warning] Using mock data. Add SPORTS_API_KEY to .env.local');
   }
 
   const { league, games } = req.body || {};

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -12,17 +12,20 @@ import { agents as registry } from '../../lib/agents/registry';
 import type { AgentOutputs, PickSummary } from '../../lib/types';
 import { logToSupabase } from '../../lib/logToSupabase';
 import { getFallbackMatchups } from '../../lib/utils/fallbackMatchups';
-import { hasSportsDbKey } from '../../lib/env';
+import { ENV } from '../../lib/env';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const missingEnv = ['SPORTS_DB_API_KEY'].filter((key) => !process.env[key]);
+  const missingEnv = ['SPORTS_API_KEY'].filter((key) => !process.env[key]);
   if (missingEnv.length) {
     console.warn(`Missing required env vars: ${missingEnv.join(', ')}`);
   }
-  if (!process.env.SPORTS_DB_API_KEY && process.env.NODE_ENV === 'development') {
-    console.warn('[Dev Warning] Using mock data. Add SPORTS_DB_API_KEY to .env.local');
+  if (
+    ENV.SPORTS_API_KEY === 'sports-fallback-key' &&
+    process.env.NODE_ENV === 'development'
+  ) {
+    console.warn('[Dev Warning] Using mock data. Add SPORTS_API_KEY to .env.local');
   }
-  if (!hasSportsDbKey) {
+  if (ENV.SPORTS_API_KEY === 'sports-fallback-key') {
     console.warn('Sports API key missing. Add it to `.env.local` to enable live games.');
     try {
       const mockPath = path.join(process.cwd(), 'mock', 'upcoming-games.json');

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { AgentName, AgentOutputs } from '../lib/types';
 import { formatAgentName } from '../lib/utils';
-import { getSupabaseClient } from '../lib/supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 
 interface MatchupRow {
   id: string;
@@ -21,8 +21,7 @@ const HistoryPage: React.FC = () => {
 
   useEffect(() => {
     const fetchMatchups = async () => {
-      const client = getSupabaseClient();
-      const { data, error } = await client
+      const { data, error } = await supabase
         .from('matchups')
         .select('id, team_a, team_b, agents, pick, actual_winner')
         .order('created_at', { ascending: false });


### PR DESCRIPTION
## Summary
- add typed env helper with fallbacks and warnings
- expose supabase client via single instance and update callers
- standardize SPORTS_API_KEY handling in APIs and data layer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893fd25ce2083239fb859152cb072c1