### PR TITLE
Wire up agent predictions and env validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ missing-env-report.txt
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Test artifacts
+a.txt

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Returns:
 - Overall winner and confidence
 - Logs the outcome to Supabase (if configured)
 
+Example stream snippet:
+
+```text
+data: {"type":"agent","name":"injuryScout","result":{"team":"KC","score":0.72,"reason":"Mahomes cleared"}}
+data: {"type":"summary","matchup":{"homeTeam":"KC","awayTeam":"DEN","matchDay":1,"time":"","league":""},"agents":{"injuryScout":{"team":"KC","score":0.72,"reason":"Mahomes cleared"}},"pick":{"winner":"KC","confidence":0.72,"topReasons":["Mahomes cleared"]}}
+```
+
 ### Log Status Endpoint
 
 Monitor the in-memory log queue via:
@@ -171,9 +178,14 @@ SPORTS_DB_NBA_ID=<thesportsdb-nba-league-id>
 SPORTS_DB_NHL_ID=<thesportsdb-nhl-league-id>
 ```
 
-Environment-specific files like `.env.development` and `.env.production` follow the same keys. Run `npm run validate-env` to
-verify example files contain required variables. During `npm run dev`, a `missing-env-report.txt` file lists any required keys
-that are unset in your current environment.
+Common TheSportsDB league IDs:
+
+- NFL: `4391`
+- MLB: `4424`
+- NBA: `4387`
+- NHL: `4380`
+
+Use `.env.local` for local development and `.env.production` for deployments. Both files share the same keys, but missing values in production will cause the app to throw at startup to avoid silent failures. Run `npm run validate-env` to verify example files contain required variables. During `npm run dev`, a `missing-env-report.txt` file lists any required keys that are unset in your current environment.
 
 You can find the Supabase values in your dashboard under **Project Settings → API**.
 The NextAuth variables enable Google sign-in for protected routes.

--- a/__tests__/runAgentsApi.test.ts
+++ b/__tests__/runAgentsApi.test.ts
@@ -1,0 +1,43 @@
+/** @jest-environment node */
+import handler from '../pages/api/run-agents';
+import { runFlow } from '../lib/flow/runFlow';
+import { logToSupabase } from '../lib/logToSupabase';
+
+jest.mock('../lib/flow/runFlow');
+jest.mock('../lib/logToSupabase');
+
+const mockedRunFlow = runFlow as jest.Mock;
+const mockedLog = logToSupabase as jest.Mock;
+
+describe('run-agents API', () => {
+  it('streams agent results and logs summary', async () => {
+    mockedRunFlow.mockResolvedValue({
+      outputs: {
+        injuryScout: { team: 'A', score: 0.7, reason: 'healthy' },
+      },
+      executions: [
+        {
+          name: 'injuryScout',
+          result: { team: 'A', score: 0.7, reason: 'healthy' },
+        },
+      ],
+    });
+
+    const req: any = { query: { teamA: 'A', teamB: 'B', matchDay: '1' } };
+    const chunks: string[] = [];
+    const res: any = {
+      setHeader: jest.fn(),
+      write: (c: string) => chunks.push(c),
+      end: jest.fn(),
+      flush: jest.fn(),
+      flushHeaders: jest.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(mockedRunFlow).toHaveBeenCalled();
+    expect(mockedLog).toHaveBeenCalled();
+    const summary = chunks.find((c) => c.includes('summary'));
+    expect(summary).toBeDefined();
+  });
+});

--- a/__tests__/validateEnv.test.ts
+++ b/__tests__/validateEnv.test.ts
@@ -1,0 +1,29 @@
+/** @jest-environment node */
+import { readFileSync, writeFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+
+describe('validate-env script', () => {
+  const file = '.env.local.example';
+  const original = readFileSync(file, 'utf8');
+
+  afterAll(() => {
+    writeFileSync(file, original);
+  });
+
+  it('fails when required keys are missing', () => {
+    // remove SUPABASE_URL line
+    const modified = original
+      .split('\n')
+      .filter((line) => !line.startsWith('SUPABASE_URL'))
+      .join('\n');
+    writeFileSync(file, modified);
+    const result = spawnSync('npm', ['run', '--silent', 'validate-env']);
+    expect(result.status).not.toBe(0);
+  });
+
+  it('passes when all required keys exist', () => {
+    writeFileSync(file, original);
+    const result = spawnSync('npm', ['run', '--silent', 'validate-env']);
+    expect(result.status).toBe(0);
+  });
+});

--- a/components/LiveGamesList.tsx
+++ b/components/LiveGamesList.tsx
@@ -55,8 +55,21 @@ const LiveGamesList: React.FC<Props> = ({
             <LoadingShimmer lines={1} />
           ) : (
             predictions[idx] && (
-              <div className="text-sm text-gray-600">
-                Predicted winner: {predictions[idx].winner}
+              <div className="text-sm text-gray-600 space-y-1">
+                <div>
+                  Predicted winner: {predictions[idx].winner} (
+                  {predictions[idx].confidence}% confidence)
+                </div>
+                <ul className="list-disc pl-5">
+                  {Object.entries(predictions[idx].agents || {}).map(
+                    ([name, result]: any) => (
+                      <li key={name}>
+                        <strong>{name}</strong>: {result.team} (
+                        {Math.round(result.score * 100)}%) – {result.reason}
+                      </li>
+                    )
+                  )}
+                </ul>
               </div>
             )
           )}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom';
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_ANON_KEY = 'test-anon';
+process.env.NEXTAUTH_URL = 'http://localhost';
+process.env.NEXTAUTH_SECRET = 'secret';
+process.env.GOOGLE_CLIENT_ID = 'google-id';
+process.env.GOOGLE_CLIENT_SECRET = 'google-secret';

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -5,11 +5,12 @@ interface GetEnvOptions {
 
 export const getEnv = (
   key: string,
-  { required = true, fallback }: GetEnvOptions = {}
+  { required = true, fallback }: GetEnvOptions = {},
 ): string => {
   const value = process.env[key];
+  const isProduction = process.env.NODE_ENV === 'production';
   if (!value) {
-    if (fallback !== undefined) {
+    if (fallback !== undefined && !isProduction) {
       console.warn(`[env] ${key} is missing, using fallback: ${fallback}`);
       return fallback;
     }
@@ -39,4 +40,3 @@ export const ENV = {
   SPORTS_DB_NHL_ID: getEnv('SPORTS_DB_NHL_ID', { required: false }),
   ODDS_API_KEY: getEnv('ODDS_API_KEY', { required: false }),
 } as const;
-

--- a/lib/logUiEvent.test.js
+++ b/lib/logUiEvent.test.js
@@ -1,3 +1,10 @@
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_ANON_KEY = 'anon';
+process.env.NEXTAUTH_URL = 'http://localhost';
+process.env.NEXTAUTH_SECRET = 'secret';
+process.env.GOOGLE_CLIENT_ID = 'gid';
+process.env.GOOGLE_CLIENT_SECRET = 'gsecret';
+
 require('ts-node').register({ transpileOnly: true, compilerOptions: { module: 'CommonJS' } });
 const assert = require('assert');
 const { logUiEvent } = require('./logUiEvent');

--- a/llms.txt
+++ b/llms.txt
@@ -546,3 +546,18 @@ Files:
 - scripts/missingEnvReport.ts (+11/-0)
 - scripts/validateEnv.ts (+22/-0)
 
+Timestamp: 2025-08-07T02:15:07.755Z
+Commit: d0b907c5d3cf8dac88cde807868a2e208fd61924
+Author: Codex
+Message: feat: integrate agent flows and env validation
+Files:
+- .gitignore (+3/-0)
+- README.md (+15/-3)
+- __tests__/runAgentsApi.test.ts (+43/-0)
+- __tests__/validateEnv.test.ts (+29/-0)
+- components/LiveGamesList.tsx (+15/-2)
+- jest.setup.ts (+7/-0)
+- lib/env.ts (+3/-3)
+- lib/logUiEvent.test.js (+7/-0)
+- pages/api/run-predictions.ts (+21/-2)
+


### PR DESCRIPTION
## Summary
- centralize env access with production-safe `getEnv` and ignore stray `a.txt`
- run `/api/run-predictions` through real agent flows and log to Supabase
- show per-agent confidence and reasoning in predictions list
- document `/run-agents` output, league IDs, and env file usage

## Testing
- `npm test`
- `npm run validate-env`
- `npx vercel build --yes` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689406515f5c832385899ca641674f5f