### PR TITLE
fix: ensure .env.local only used in development

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,3 +1,7 @@
+if (process.env.NODE_ENV === 'development') {
+  require('dotenv').config({ path: '.env.local' });
+}
+
 interface GetEnvOptions {
   required?: boolean;
   fallback?: string;

--- a/llms.txt
+++ b/llms.txt
@@ -594,3 +594,11 @@ Files:
 - scripts/hasDiagramChanged.ts (+31/-0)
 - scripts/syncSystemDiagram.ts (+21/-0)
 
+Timestamp: 2025-08-07T04:00:19.811Z
+Commit: bac3620ed348a8068a8ec13727237a394c3e5c14
+Author: Codex
+Message: fix: ensure .env.local only used in development
+Files:
+- lib/env.ts (+4/-0)
+- scripts/validateEnv.ts (+3/-0)
+

--- a/scripts/validateEnv.ts
+++ b/scripts/validateEnv.ts
@@ -1,5 +1,8 @@
 import fs from 'fs';
 import dotenv from 'dotenv';
+if (process.env.NODE_ENV === 'development') {
+  require('dotenv').config({ path: '.env.local' });
+}
 import { REQUIRED_ENV_KEYS } from '../lib/envKeys';
 
 const files = ['.env.local.example', '.env.development', '.env.production'];


### PR DESCRIPTION
## Summary
- guard dotenv loading so .env.local is only loaded in development
- ensure env validation script respects production environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894240b95c08323a6936ae77b07b291