### PR TITLE
docs: add AIML_OVERVIEW.md [constitutional-injection]

### DIFF
--- a/AIML_OVERVIEW.md
+++ b/AIML_OVERVIEW.md
@@ -1,0 +1,100 @@
+# 🧠 AIML_OVERVIEW.md – EdgePicks AI/ML Constitution
+_Last Updated: August 6, 2025_
+
+## 🔍 Purpose
+
+This file serves as the source of truth for all AI/ML logic in EdgePicks, including:
+
+- Agent design and responsibilities
+- Flow orchestration patterns
+- Feature-to-agent mappings
+- Environment requirements for AI inference
+- Governance protocol for safe, explainable ML
+
+---
+
+## 🤖 Agents
+
+Each AI agent contributes domain-specific insights to NFL matchup predictions. Current agents:
+
+- `InjuryScout`: Scrapes injury reports, flags absences and return-to-play indicators
+- `LineWatcher`: Monitors betting lines for sharp movement or reverse trends
+- `StatCruncher`: Computes stats like yards per play, QB pressure rate, turnover margin
+- `CoachWhisperer`: Applies heuristics on coaching style, decisions, and aggression
+- `WeatherEye`: Flags games with precipitation, heat index, or wind speed anomalies
+
+All agents output structured JSON to the `AgentDebugPanel` and propagate to `MatchupInsightsPanel`.
+
+---
+
+## 🔁 Flow Orchestration
+
+- `FlowOrchestrator` manages agent invocation in sequence or parallel, with optional weighting logic.
+- User input via `MatchupInputForm` triggers flows like `defaultNFLFlow`, which load all agents.
+- Agent outputs are merged into a composite prediction result, rendered in the UI with transparency.
+
+---
+
+## 🧪 ML & Heuristics
+
+While no deep learning models are currently deployed, agents use ML-adjacent logic:
+
+- Rule-based scoring (StatCruncher, CoachWhisperer)
+- Real-time signals and weighting (LineWatcher)
+- Environmental heuristics (WeatherEye)
+- Future expansion may include:
+  - GNNs for player interaction modeling
+  - LLM-based playbook similarity
+  - Reinforcement learning for betting scenarios
+
+All logic must remain explainable, sandboxed, and inspectable.
+
+---
+
+## 🛡️ Environment
+
+Agents rely on:
+- `SUPABASE_URL`, `SUPABASE_KEY` – for logs, auth, user context
+- `SPORTSDATAIO_API_KEY`, `GOOGLE_CLIENT_ID` – for sports data + auth
+- `.env.local` – only used during local development
+- `lib/env.ts` – exports a centralized `ENV` object and throws on missing keys
+- `scripts/validateEnv.ts` – build-time enforcement
+
+---
+
+## Governance
+
+This document is **constitutional**. All future Codex prompts involving agents, flows, prediction methods, or model changes must:
+
+- Reference `AIML_OVERVIEW.md`
+- Append any change to `## Amendments` below with a rationale and signature
+- Log entries in `llms.txt` as `[codex] Amend AIML_OVERVIEW.md: ...`
+- Tag PRs with `docs: amend AIML_OVERVIEW.md [codex-governance]`
+
+Changes without documented amendment may be rejected.
+
+---
+
+## 🧾 Amendments
+
+> None yet. You will be the first. 🤝
+
+---
+
+## 📌 Location
+
+- Path: `/AIML_OVERVIEW.md`
+- Linked from: `README.md → 📘 AI/ML Constitution`
+
+---
+
+## 🧠 Author(s)
+
+Created by the Codex system and Csp-Ai on August 6, 2025. All contributors must leave signatures under each amendment.
+
+✅ Testing Instructions
+```bash
+npm run validate-env   # Confirms ENV logic works
+npm test               # Full suite (ensure no breakage)
+npx vercel --prod      # Will fail if GOOGLE_CLIENT_ID is not set
+```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This file serves as the **Codex constitution** and **single source of truth** fo
 **All future agents and developers must reference `llms.txt` before executing changes.**  
 The README reflects system-level intent. The `llms.txt` file reflects execution history, behavior shifts, and rationale.
 
+## 📘 AI/ML Constitution
+
+See [AIML_OVERVIEW.md](AIML_OVERVIEW.md) for the constitutional AI/ML architecture and governance.
+
 ## Git Hooks
 
 This project uses [Husky](https://typicode.github.io/husky) to manage Git hooks. A pre-push hook runs `npm run postpush`, which executes `scripts/log-llms-entry.ts` and appends the latest commit details to `llms.txt`.

--- a/codex-prompts/inject-aiml-constitution.md
+++ b/codex-prompts/inject-aiml-constitution.md
@@ -1,0 +1,136 @@
+# Codex Prompt – Inject AI/ML Constitution & Governance Protocol
+
+## Objective
+
+Inject a foundational governance document (`AIML_OVERVIEW.md`) that defines the current AI/ML architecture, agent roles, flow orchestration, and amendment protocol for all future Codex-driven merges. Treat this as a living constitution for EdgePicks' modular intelligence system.
+
+## Tasks
+
+1. ✅ **Create `AIML_OVERVIEW.md`** in the root directory with the full content below.
+2. ✅ **Link it in `README.md`**, under a new section titled `📘 AI/ML Constitution` with a markdown link.
+3. ✅ **Log this in `llms.txt`** with an entry:
+[codex] Injected AIML_OVERVIEW.md as AI/ML Constitution for all agent-based governance
+
+4. ✅ **Update `codex-prompts/validateEnv-prompt.md`** to add a line under “Summary”:
+> Note: This prompt interoperates with `AIML_OVERVIEW.md`, the constitutional file for agent structure and environment governance.
+
+5. ✅ Add a `## Governance` section to `AIML_OVERVIEW.md` that defines amendment rules:
+- All future Codex prompts involving agents, flows, prediction methods, or model changes must:
+  - Reference `AIML_OVERVIEW.md`
+  - Append to the `## Amendments` section in that file
+  - Include a rationale and signature
+  - Tag PRs with `docs: amend AIML_OVERVIEW.md [codex-governance]`
+
+6. ✅ Confirm the Markdown renders correctly and commit using:
+docs: add AIML_OVERVIEW.md [constitutional-injection]
+
+---
+
+## ✅ AIML_OVERVIEW.md (Content)
+
+```md
+# 🧠 AIML_OVERVIEW.md – EdgePicks AI/ML Constitution
+_Last Updated: August 6, 2025_
+
+## 🔍 Purpose
+
+This file serves as the source of truth for all AI/ML logic in EdgePicks, including:
+
+- Agent design and responsibilities
+- Flow orchestration patterns
+- Feature-to-agent mappings
+- Environment requirements for AI inference
+- Governance protocol for safe, explainable ML
+
+---
+
+## 🤖 Agents
+
+Each AI agent contributes domain-specific insights to NFL matchup predictions. Current agents:
+
+- `InjuryScout`: Scrapes injury reports, flags absences and return-to-play indicators
+- `LineWatcher`: Monitors betting lines for sharp movement or reverse trends
+- `StatCruncher`: Computes stats like yards per play, QB pressure rate, turnover margin
+- `CoachWhisperer`: Applies heuristics on coaching style, decisions, and aggression
+- `WeatherEye`: Flags games with precipitation, heat index, or wind speed anomalies
+
+All agents output structured JSON to the `AgentDebugPanel` and propagate to `MatchupInsightsPanel`.
+
+---
+
+## 🔁 Flow Orchestration
+
+- `FlowOrchestrator` manages agent invocation in sequence or parallel, with optional weighting logic.
+- User input via `MatchupInputForm` triggers flows like `defaultNFLFlow`, which load all agents.
+- Agent outputs are merged into a composite prediction result, rendered in the UI with transparency.
+
+---
+
+## 🧪 ML & Heuristics
+
+While no deep learning models are currently deployed, agents use ML-adjacent logic:
+
+- Rule-based scoring (StatCruncher, CoachWhisperer)
+- Real-time signals and weighting (LineWatcher)
+- Environmental heuristics (WeatherEye)
+- Future expansion may include:
+- GNNs for player interaction modeling
+- LLM-based playbook similarity
+- Reinforcement learning for betting scenarios
+
+All logic must remain explainable, sandboxed, and inspectable.
+
+---
+
+## 🛡️ Environment
+
+Agents rely on:
+- `SUPABASE_URL`, `SUPABASE_KEY` – for logs, auth, user context
+- `SPORTSDATAIO_API_KEY`, `GOOGLE_CLIENT_ID` – for sports data + auth
+- `.env.local` – only used during local development
+- `lib/env.ts` – exports a centralized `ENV` object and throws on missing keys
+- `scripts/validateEnv.ts` – build-time enforcement
+
+---
+
+## 🔐 Governance
+
+This document is **constitutional**. All future Codex prompts must:
+
+- Reference `AIML_OVERVIEW.md` directly
+- Append any change to `## Amendments` below
+- Log entries in `llms.txt` as `[codex] Amend AIML_OVERVIEW.md: ...`
+- Commit with message:
+docs: amend AIML_OVERVIEW.md [codex-governance]
+
+Changes without documented amendment may be rejected.
+
+---
+
+## 🧾 Amendments
+
+> None yet. You will be the first. 🤝
+
+---
+
+## 📌 Location
+
+- Path: `/AIML_OVERVIEW.md`
+- Linked from: `README.md → 📘 AI/ML Constitution`
+
+---
+
+## 🧠 Author(s)
+
+Created by the Codex system and Csp-Ai on August 6, 2025. All contributors must leave signatures under each amendment.
+
+✅ Testing Instructions
+```bash
+npm run validate-env   # Confirms ENV logic works
+npm test               # Full suite (ensure no breakage)
+npx vercel --prod      # Will fail if GOOGLE_CLIENT_ID is not set
+```
+```
+
+🟢 Prompt complete. Standing by.
+Let me know when you're ready to commit or scaffold the first amendment.

--- a/codex-prompts/validateEnv-prompt.md
+++ b/codex-prompts/validateEnv-prompt.md
@@ -1,5 +1,7 @@
 ## Codex Prompt Summary
 
+> Note: This prompt interoperates with `AIML_OVERVIEW.md`, the constitutional file for agent structure and environment governance.
+
 Create a strict environment variable enforcement system:
 
 - Only load `.env.local` in development

--- a/llms.txt
+++ b/llms.txt
@@ -659,3 +659,16 @@ Files:
 - package.json (+1/-1)
 - scripts/validateEnv.ts (+9/-3)
 
+Timestamp: 2025-08-07T04:49:17Z
+[codex] Injected AIML_OVERVIEW.md as AI/ML Constitution for all agent-based governance
+Timestamp: 2025-08-07T04:55:15.897Z
+Commit: 02529ab2952c8577ff06f3fb3896d3f870bded5b
+Author: Codex
+Message: docs: add AIML_OVERVIEW.md [constitutional-injection]
+Files:
+- AIML_OVERVIEW.md (+100/-0)
+- README.md (+4/-0)
+- codex-prompts/inject-aiml-constitution.md (+136/-0)
+- codex-prompts/validateEnv-prompt.md (+2/-0)
+- llms.txt (+2/-0)
+


### PR DESCRIPTION
## Summary
- add AIML_OVERVIEW.md to codify AI/ML agents, orchestration, environment, and governance
- link constitution in README and note interoperability in validateEnv prompt
- log constitution injection in llms history and add supporting Codex prompt

## Testing
- `npm run validate-env` *(fails: Missing required key: GOOGLE_CLIENT_ID)*
- `npm test`
- `npx vercel --prod` *(prompted to install vercel; no deployment performed)*

------
https://chatgpt.com/codex/tasks/task_e_68942fb4f024832387d611efbbeb7642