### PR TITLE
fix(env): include NEXTAUTH_URL in validation

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,26 +1,23 @@
 import dotenv from 'dotenv';
-import { REQUIRED_ENV_KEYS } from './envKeys';
+import { z } from 'zod';
 
 if (process.env.NODE_ENV === 'development') {
   dotenv.config({ path: '.env.local' });
 }
 
-for (const key of REQUIRED_ENV_KEYS) {
-  if (!process.env[key]) {
-    throw new Error(`❌ Missing required key: ${key}`);
-  }
-}
+const envSchema = z.object({
+  GOOGLE_CLIENT_ID: z.string().nonempty(),
+  GOOGLE_CLIENT_SECRET: z.string().nonempty(),
+  SUPABASE_KEY: z.string().nonempty(),
+  SUPABASE_URL: z.string().url(),
+  NEXTAUTH_SECRET: z.string().nonempty(),
+  NEXTAUTH_URL: z.string().url(),
+  SPORTS_API_KEY: z.string().nonempty(),
+  SPORTS_DB_NFL_ID: z.string().optional(),
+  SPORTS_DB_MLB_ID: z.string().optional(),
+  SPORTS_DB_NBA_ID: z.string().optional(),
+  SPORTS_DB_NHL_ID: z.string().optional(),
+  ODDS_API_KEY: z.string().optional(),
+});
 
-export const ENV = {
-  GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID!,
-  GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET!,
-  SUPABASE_KEY: process.env.SUPABASE_KEY!,
-  SUPABASE_URL: process.env.SUPABASE_URL!,
-  NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET!,
-  SPORTS_API_KEY: process.env.SPORTS_API_KEY!,
-  SPORTS_DB_NFL_ID: process.env.SPORTS_DB_NFL_ID,
-  SPORTS_DB_MLB_ID: process.env.SPORTS_DB_MLB_ID,
-  SPORTS_DB_NBA_ID: process.env.SPORTS_DB_NBA_ID,
-  SPORTS_DB_NHL_ID: process.env.SPORTS_DB_NHL_ID,
-  ODDS_API_KEY: process.env.ODDS_API_KEY,
-} as const;
+export const ENV = envSchema.parse(process.env);

--- a/llms.txt
+++ b/llms.txt
@@ -672,3 +672,15 @@ Files:
 - codex-prompts/validateEnv-prompt.md (+2/-0)
 - llms.txt (+2/-0)
 
+Timestamp: 2025-08-07T05:09:00Z
+Codex injected NEXTAUTH_URL into environment validation
+Timestamp: 2025-08-07T05:13:20.775Z
+Commit: 2e606c32dccad8c5c6b9cd8b7ed45fcb9f3db3d3
+Author: Codex
+Message: fix(env): include NEXTAUTH_URL in validation
+Files:
+- lib/env.ts (+16/-19)
+- llms.txt (+2/-0)
+- package-lock.json (+11/-1)
+- package.json (+3/-2)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "next-auth": "^4.24.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "swr": "^2.3.4"
+        "swr": "^2.3.4",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -11715,6 +11716,15 @@
       "dependencies": {
         "@types/zen-observable": "0.8.3",
         "zen-observable": "0.8.15"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "next-auth": "^4.24.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "swr": "^2.3.4"
+    "swr": "^2.3.4",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",


### PR DESCRIPTION
## Summary
- add `NEXTAUTH_URL` to typed env schema
- log addition to `llms.txt`
- add `zod` dependency

## Testing
- `npm test`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68943415dd508323aa70431121df4a96