### PR TITLE
Display agent logs for live predictions

### DIFF
--- a/components/LiveGameLogsPanel.tsx
+++ b/components/LiveGameLogsPanel.tsx
@@ -1,11 +1,48 @@
 import React from 'react';
+import { AgentExecution } from '../lib/flow/runFlow';
+import { formatAgentName } from '../lib/utils';
 
 interface Props {
-  logs: any;
+  logs: AgentExecution[][];
 }
 
-const LiveGameLogsPanel: React.FC<Props> = () => {
-  return null;
+/**
+ * Display agent execution logs for each matchup.
+ * Logs are grouped by matchup and list each agent's
+ * selected team, score, and reasoning.
+ */
+const LiveGameLogsPanel: React.FC<Props> = ({ logs }) => {
+  if (!logs || logs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      {logs.map((matchLogs, idx) => (
+        <div key={idx} className="border rounded p-4">
+          <h3 className="font-semibold mb-2">Matchup {idx + 1}</h3>
+          {matchLogs && matchLogs.length > 0 ? (
+            <ul className="space-y-1">
+              {matchLogs
+                .filter((log) => log.result)
+                .map(({ name, result }) => (
+                  <li key={name} className="text-sm">
+                    <span className="font-medium">{formatAgentName(name)}: </span>
+                    <span>
+                      {result?.team} ({Math.round((result?.score || 0) * 100)}%) -
+                      {' '}
+                      {result?.reason}
+                    </span>
+                  </li>
+                ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-600">No agent logs.</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
 };
 
 export default LiveGameLogsPanel;

--- a/components/PredictionsPanel.tsx
+++ b/components/PredictionsPanel.tsx
@@ -127,6 +127,12 @@ const PredictionsPanel: React.FC<Props> = ({ session }) => {
       {!loadingPred && !predictions.length && (
         <EmptyState message="Pick a league and hit Run Predictions to get started!" />
       )}
+      {agentLogs.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">Agent Logs</h2>
+          <LiveGameLogsPanel logs={agentLogs} />
+        </section>
+      )}
       {toast && (
         <div
           role="alert"
@@ -137,7 +143,6 @@ const PredictionsPanel: React.FC<Props> = ({ session }) => {
           {toast.message}
         </div>
       )}
-      <LiveGameLogsPanel logs={agentLogs} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Show per-matchup agent outputs in new `LiveGameLogsPanel`
- Render agent logs from predictions run within a dedicated section for readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689454204f6c83239edb4cf9e1538020