### PR TITLE
Use dynamic matchups for dashboard timeline

### DIFF
--- a/lib/dashboard/useFlowVisualizer.ts
+++ b/lib/dashboard/useFlowVisualizer.ts
@@ -28,6 +28,13 @@ export default function useFlowVisualizer() {
   const flowStartRef = useRef<number | null>(null);
   const lastNodeRef = useRef<AgentName | null>(null);
 
+  const reset = useCallback(() => {
+    setNodes({});
+    setEdges([]);
+    flowStartRef.current = null;
+    lastNodeRef.current = null;
+  }, []);
+
   const handleLifecycleEvent = useCallback(
     (event: { name: AgentName } & AgentLifecycle) => {
       setNodes((prev) => {
@@ -83,6 +90,7 @@ export default function useFlowVisualizer() {
     edges,
     startTime: flowStartRef.current,
     handleLifecycleEvent,
+    reset,
   };
 }
 

--- a/llms.txt
+++ b/llms.txt
@@ -723,3 +723,11 @@ Message: chore: log EOD summary
 Files:
 - llms.txt (+15/-0)
 
+Timestamp: 2025-08-07T07:26:34.227Z
+Commit: 957c3b626778eddd1f5a5270703c3ffc5bb0031e
+Author: Codex
+Message: Use dynamic matchups in dashboard timeline
+Files:
+- lib/dashboard/useFlowVisualizer.ts (+8/-0)
+- pages/dashboard.tsx (+9/-13)
+

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,26 +1,22 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import type { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import AgentTimeline from '../lib/dashboard/AgentTimeline';
 import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
+import MatchupInputForm from '../components/MatchupInputForm';
 
 const DashboardPage: React.FC = () => {
-  const { nodes, startTime, handleLifecycleEvent } = useFlowVisualizer();
-
-  useEffect(() => {
-    const es = new EventSource('/api/run-agents?teamA=LAL&teamB=BOS&matchDay=1');
-    es.onmessage = (event) => {
-      const data = JSON.parse(event.data);
-      if (data.type === 'lifecycle') {
-        handleLifecycleEvent(data);
-      }
-    };
-    return () => es.close();
-  }, [handleLifecycleEvent]);
+  const { nodes, startTime, handleLifecycleEvent, reset } = useFlowVisualizer();
 
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Agent Dashboard</h1>
+      <MatchupInputForm
+        onStart={(_info) => reset()}
+        onAgent={(_name, _result) => {}}
+        onComplete={(_data) => {}}
+        onLifecycle={handleLifecycleEvent}
+      />
       <AgentTimeline nodes={nodes} startTime={startTime} />
     </div>
   );


### PR DESCRIPTION
## Summary
- replace static EventSource in dashboard with MatchupInputForm for user-selected matchups
- add reset to flow visualizer so timeline restarts each run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894542136648323b058f8a8ddd2a250