### PR TITLE
feat: surface live agent status

### DIFF
--- a/lib/dashboard/useFlowVisualizer.ts
+++ b/lib/dashboard/useFlowVisualizer.ts
@@ -18,6 +18,11 @@ export interface FlowEdge {
   target: AgentName;
 }
 
+export interface AgentStatus {
+  status: AgentLifecycle['status'] | 'idle';
+  durationMs?: number;
+}
+
 /**
  * Hook that translates agent lifecycle events from the SSE stream into
  * structures that are easier to visualize (nodes, edges, timestamps).
@@ -25,6 +30,7 @@ export interface FlowEdge {
 export default function useFlowVisualizer() {
   const [nodes, setNodes] = useState<Record<AgentName, FlowNode>>({});
   const [edges, setEdges] = useState<FlowEdge[]>([]);
+  const [statuses, setStatuses] = useState<Record<AgentName, AgentStatus>>({});
   const flowStartRef = useRef<number | null>(null);
   const lastNodeRef = useRef<AgentName | null>(null);
 
@@ -70,6 +76,20 @@ export default function useFlowVisualizer() {
 
         return { ...prev, [event.name]: updated };
       });
+
+      setStatuses((prev) => {
+        if (event.status === 'started') {
+          return { ...prev, [event.name]: { status: 'started' } };
+        }
+
+        return {
+          ...prev,
+          [event.name]: {
+            status: event.status,
+            durationMs: event.durationMs,
+          },
+        };
+      });
     },
     []
   );
@@ -83,6 +103,7 @@ export default function useFlowVisualizer() {
     edges,
     startTime: flowStartRef.current,
     handleLifecycleEvent,
+    statuses,
   };
 }
 

--- a/llms.txt
+++ b/llms.txt
@@ -723,3 +723,12 @@ Message: chore: log EOD summary
 Files:
 - llms.txt (+15/-0)
 
+Timestamp: 2025-08-07T07:26:48.336Z
+Commit: f1a7c33e25854363ccb7d0e60486f5beb301511e
+Author: Codex
+Message: feat: surface live agent status
+Files:
+- components/PredictionsPanel.tsx (+19/-0)
+- lib/dashboard/useFlowVisualizer.ts (+21/-0)
+- pages/dashboard.tsx (+3/-1)
+

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -3,9 +3,10 @@ import type { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import AgentTimeline from '../lib/dashboard/AgentTimeline';
 import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
+import AgentStatusPanel from '../components/AgentStatusPanel';
 
 const DashboardPage: React.FC = () => {
-  const { nodes, startTime, handleLifecycleEvent } = useFlowVisualizer();
+  const { nodes, startTime, handleLifecycleEvent, statuses } = useFlowVisualizer();
 
   useEffect(() => {
     const es = new EventSource('/api/run-agents?teamA=LAL&teamB=BOS&matchDay=1');
@@ -22,6 +23,7 @@ const DashboardPage: React.FC = () => {
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Agent Dashboard</h1>
       <AgentTimeline nodes={nodes} startTime={startTime} />
+      <AgentStatusPanel statuses={statuses} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- extend flow visualizer hook to track agent lifecycle statuses
- display real-time agent status panel on dashboard
- expose optional agent status panel while running predictions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894542281788323a48dfdc10e1368dd