### PR TITLE
fix: correct reset function in PredictionsPanel

### DIFF
--- a/components/PredictionsPanel.tsx
+++ b/components/PredictionsPanel.tsx
@@ -22,7 +22,7 @@ const PredictionsPanel: React.FC<Props> = ({ session }) => {
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
   const [lastRun, setLastRun] = useState<string | null>(null);
   const [agentLogs, setAgentLogs] = useState<any[]>([]);
-  const { statuses, handleLifecycleEvent, resetTimeline } = useFlowVisualizer();
+  const { statuses, handleLifecycleEvent, reset } = useFlowVisualizer();
 
   useEffect(() => {
     setLoadingGames(true);
@@ -51,7 +51,7 @@ const PredictionsPanel: React.FC<Props> = ({ session }) => {
     }
 
     setLoadingPred(true);
-    resetTimeline();
+    reset();
     let es: EventSource | null = null;
 
     try {

--- a/llms.txt
+++ b/llms.txt
@@ -751,3 +751,10 @@ Files:
  main
  main
 
+Timestamp: 2025-08-07T07:42:26.340Z
+Commit: 26ef5fe471e664b39c699201984c16b04b15df55
+Author: Codex
+Message: fix: correct reset function in PredictionsPanel
+Files:
+- components/PredictionsPanel.tsx (+2/-2)
+


### PR DESCRIPTION
## Summary
- fix incorrect destructuring of `resetTimeline` from `useFlowVisualizer`
- call `reset` before running prediction flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689457fefb7083238f84fcd343fa56aa