### PR TITLE
feat: surface dynamic agent logs and statuses in dashboard

### DIFF
--- a/components/PredictionsPanel.tsx
+++ b/components/PredictionsPanel.tsx
@@ -37,6 +37,8 @@ const PredictionsPanel: React.FC<Props> = ({ session }) => {
         console.error('Error fetching upcoming games', err);
         setGames([]);
         setLoadingGames(false);
+        setToast({ message: 'Failed to load upcoming games.', type: 'error' });
+        setTimeout(() => setToast(null), 3000);
       });
   }, [league]);
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,7 +3,7 @@ export const getUpcomingGames = async (league: string = 'NFL') => {
   if (!res.ok) throw new Error('Failed to fetch upcoming games');
   const data = await res.json();
   if (Array.isArray(data) && data.some((g) => g.useFallback || g.source === 'fallback')) {
-    console.warn('Mock data is being used for predictions.');
+    throw new Error('Upcoming games data unavailable');
   }
   return data;
 };

--- a/llms.txt
+++ b/llms.txt
@@ -758,3 +758,12 @@ Message: fix: correct reset function in PredictionsPanel
 Files:
 - components/PredictionsPanel.tsx (+2/-2)
 
+Timestamp: 2025-08-07T08:14:06.596Z
+Commit: c177aef237386dea0065dfe16eb1f3ac37242d29
+Author: Codex
+Message: feat: surface dynamic agent logs and statuses in dashboard
+Files:
+- components/PredictionsPanel.tsx (+2/-0)
+- lib/api.ts (+1/-1)
+- pages/dashboard.tsx (+28/-3)
+

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,23 +1,48 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import AgentTimeline from '../lib/dashboard/AgentTimeline';
 import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
 import AgentStatusPanel from '../components/AgentStatusPanel';
 import MatchupInputForm from '../components/MatchupInputForm';
+import LiveGameLogsPanel from '../components/LiveGameLogsPanel';
+import type { AgentExecution } from '../lib/flow/runFlow';
+import type { AgentResult } from '../lib/types';
 
 const DashboardPage: React.FC = () => {
   const { nodes, startTime, handleLifecycleEvent, reset, statuses } = useFlowVisualizer();
+  const [logs, setLogs] = useState<AgentExecution[][]>([]);
+
+  const handleStart = () => {
+    reset();
+    setLogs((prev) => [...prev, []]);
+  };
+
+  const handleAgent = (name: string, result: AgentResult) => {
+    setLogs((prev) => {
+      const updated = [...prev];
+      const current = updated[updated.length - 1] || [];
+      current.push({ name, result });
+      updated[updated.length - 1] = current;
+      return updated;
+    });
+  };
 
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Agent Dashboard</h1>
       <MatchupInputForm
-        onStart={() => reset()}
-        onAgent={() => {}}
+        onStart={handleStart}
+        onAgent={handleAgent}
         onComplete={() => {}}
         onLifecycle={handleLifecycleEvent}
       />
+      {logs.length > 0 && (
+        <section className="my-4">
+          <h2 className="text-lg font-semibold mb-2">Agent Logs</h2>
+          <LiveGameLogsPanel logs={logs} />
+        </section>
+      )}
       <AgentTimeline nodes={nodes} startTime={startTime} />
       <AgentStatusPanel statuses={statuses} />
     </div>


### PR DESCRIPTION
## Summary
- display live agent execution logs and lifecycle status updates on dashboard
- expose upcoming game fetch failures instead of silently using fallback data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68945f3d712c8323bf8cf17ea87d0feb