### PR TITLE
feat: transform landing page into AI-powered prediction hub

### DIFF
--- a/components/AgentNodeGraph.tsx
+++ b/components/AgentNodeGraph.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { AgentName, AgentLifecycle } from '../lib/types';
+
+interface Props {
+  statuses: Record<AgentName, { status: AgentLifecycle['status'] | 'idle' }>;
+}
+
+const AgentNodeGraph: React.FC<Props> = ({ statuses }) => {
+  const agents = Object.keys(statuses) as AgentName[];
+  if (agents.length === 0) {
+    return <div className="text-center text-sm text-gray-400">No agent activity yet</div>;
+  }
+  return (
+    <div className="flex justify-center flex-wrap gap-4 py-4">
+      {agents.map((name) => {
+        const state = statuses[name]?.status || 'idle';
+        return (
+          <motion.div
+            key={name}
+            animate={{
+              scale: state === 'completed' ? 1 : 1.1,
+              opacity: state === 'errored' ? 0.4 : 1,
+            }}
+            transition={{ repeat: state === 'running' ? Infinity : 0, duration: 0.8, yoyo: true }}
+            className="w-16 h-16 rounded-full bg-blue-600 flex items-center justify-center text-xs"
+          >
+            {name}
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AgentNodeGraph;

--- a/components/PredictionsPanel.tsx
+++ b/components/PredictionsPanel.tsx
@@ -1,180 +1,50 @@
-import React, { useEffect, useState } from 'react';
-import type { Session } from 'next-auth';
-import LiveGamesList from './LiveGamesList';
-import EmptyState from './EmptyState';
-import LiveGameLogsPanel from './LiveGameLogsPanel';
-import AgentStatusPanel from './AgentStatusPanel';
-import { getUpcomingGames, runPredictions } from '../lib/api';
-import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
+import React from 'react';
+import type { AgentOutputs, AgentLifecycle, PickSummary, AgentName } from '../lib/types';
 
 interface Props {
-  session: Session | null;
+  agents: AgentOutputs;
+  pick: PickSummary | null;
+  statuses: Record<AgentName, { status: AgentLifecycle['status'] | 'idle'; durationMs?: number }>;
 }
 
-const leagues = ['NFL', 'NBA', 'MLB', 'NHL'];
-
-const PredictionsPanel: React.FC<Props> = ({ session }) => {
-  const [league, setLeague] = useState('NFL');
-  const [games, setGames] = useState<any[]>([]);
-  const [loadingGames, setLoadingGames] = useState(true);
-  const [predictions, setPredictions] = useState<any[]>([]);
-  const [loadingPred, setLoadingPred] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
-  const [lastRun, setLastRun] = useState<string | null>(null);
-  const [agentLogs, setAgentLogs] = useState<any[]>([]);
-  const { statuses, handleLifecycleEvent, reset } = useFlowVisualizer();
-
-  useEffect(() => {
-    setLoadingGames(true);
-    getUpcomingGames(league)
-      .then((data) => {
-        setGames(data);
-        setLoadingGames(false);
-        setPredictions([]);
-        setAgentLogs([]);
-      })
-      .catch((err) => {
-        console.error('Error fetching upcoming games', err);
-        setGames([]);
-        setLoadingGames(false);
-        setToast({ message: 'Failed to load upcoming games.', type: 'error' });
-        setTimeout(() => setToast(null), 3000);
-      });
-  }, [league]);
-
-  const handleRun = async () => {
-    if (!session) {
-      setToast({ message: 'Please sign in to run predictions.', type: 'error' });
-      return;
-    }
-    if (!games.length) {
-      setToast({ message: `No games found for ${league}.`, type: 'error' });
-      return;
-    }
-
-    setLoadingPred(true);
-    reset();
-    let es: EventSource | null = null;
-
-    try {
-      const g = games[0];
-      es = new EventSource(
-        `/api/run-agents?teamA=${encodeURIComponent(g.homeTeam.name)}&teamB=${encodeURIComponent(
-          g.awayTeam.name
-        )}&matchDay=1`
-      );
-
-      es.onmessage = (event) => {
-        const data = JSON.parse(event.data);
-        if (data.type === 'lifecycle') {
-          handleLifecycleEvent(data);
-        }
-      };
-
-      const res = await runPredictions(league, games);
-      if (res.error) {
-        throw new Error(res.error);
-      }
-
-      const fetched = res.predictions || [];
-      setPredictions(fetched);
-      setAgentLogs(fetched.flatMap((p: any) => p.executions || []));
-      setLastRun(res.timestamp);
-      setToast({
-        message: `Predictions generated successfully for ${league}.`,
-        type: 'success',
-      });
-    } catch (err) {
-      console.error(err);
-      setPredictions([]);
-      setAgentLogs([]);
-      setToast({
-        message: 'Prediction flow failed. Please try again.',
-        type: 'error',
-      });
-    } finally {
-      setLoadingPred(false);
-      es?.close();
-      setTimeout(() => setToast(null), 3000);
-    }
-  };
-
+const PredictionsPanel: React.FC<Props> = ({ agents, pick, statuses }) => {
+  const agentNames = Object.keys(agents) as AgentName[];
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">Welcome, {session?.user?.name || 'Anonymous'}</h1>
-      <div className="flex flex-wrap items-center gap-4">
-        <label htmlFor="league">League:</label>
-        <select
-          id="league"
-          value={league}
-          onChange={(e) => setLeague(e.target.value)}
-          className="border p-1 rounded"
-        >
-          {leagues.map((l) => (
-            <option key={l} value={l}>
-              {l}
-            </option>
-          ))}
-        </select>
-        {session ? (
-          <button
-            onClick={handleRun}
-            className="px-3 py-1 bg-blue-600 text-white rounded"
-            disabled={loadingPred || loadingGames}
-          >
-            Run Predictions
-          </button>
-        ) : (
-          <span className="text-sm text-gray-600">Sign in to run personalized predictions</span>
-        )}
-      </div>
-
-      {lastRun && (
-        <p className="text-sm text-gray-600" aria-live="polite">
-          {league} predictions generated at{' '}
-          {new Date(lastRun).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
-        </p>
-      )}
-
-      <LiveGamesList
-        league={league}
-        games={games}
-        predictions={predictions}
-        loadingGames={loadingGames}
-        loadingPredictions={loadingPred}
-      />
-
-      {!loadingPred && !predictions.length && (
-        <EmptyState message="Pick a league and hit Run Predictions to get started!" />
-      )}
-
-      {agentLogs.length > 0 && (
-        <section className="space-y-2">
-          <h2 className="text-xl font-semibold">Agent Logs</h2>
-          <LiveGameLogsPanel logs={agentLogs} />
-        </section>
-      )}
-
-      {statuses && Object.keys(statuses).length > 0 && (
-        <section className="space-y-2">
-          <h2 className="text-xl font-semibold">Agent Status</h2>
-          <AgentStatusPanel statuses={statuses} />
-        </section>
-      )}
-
-      {toast && (
-        <div
-          role="alert"
-          className={`fixed bottom-4 right-4 px-3 py-2 rounded shadow text-white ${
-            toast.type === 'success' ? 'bg-green-600' : 'bg-red-600'
-          }`}
-        >
-          {toast.message}
+      {pick && (
+        <div className="p-4 bg-white/10 rounded">
+          <h2 className="text-xl font-semibold">Prediction: {pick.winner}</h2>
+          <p className="text-sm text-gray-300">
+            Confidence: {(pick.confidence * 100).toFixed(0)}%
+          </p>
+          {pick.topReasons && pick.topReasons.length > 0 && (
+            <ul className="mt-2 list-disc list-inside text-sm text-gray-300">
+              {pick.topReasons.map((r, i) => (
+                <li key={i}>{r}</li>
+              ))}
+            </ul>
+          )}
         </div>
+      )}
+      {agentNames.length > 0 && (
+        <ul className="space-y-2">
+          {agentNames.map((name) => {
+            const result = agents[name];
+            const status = statuses[name]?.status || 'idle';
+            return (
+              <li key={name} className="p-3 bg-white/5 rounded">
+                <div className="flex justify-between mb-1">
+                  <span className="font-medium">{name}</span>
+                  <span className="text-xs text-gray-400">{status}</span>
+                </div>
+                <p className="text-sm text-gray-300">{result.reason}</p>
+              </li>
+            );
+          })}
+        </ul>
       )}
     </div>
   );
 };
 
 export default PredictionsPanel;
-

--- a/lib/logUiEvent.ts
+++ b/lib/logUiEvent.ts
@@ -1,4 +1,3 @@
-import { supabase } from './supabaseClient';
 import { triggerToast } from './useToast';
 
 export async function logUiEvent(
@@ -8,6 +7,17 @@ export async function logUiEvent(
   try {
     const meta = metadata ?? {};
     console.log(`[UI EVENT] ${uiEvent}`, Object.keys(meta).length ? meta : '');
+
+    if (typeof window !== 'undefined') {
+      await fetch('/api/log-status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event: uiEvent, metadata: meta }),
+      });
+      return;
+    }
+
+    const { supabase } = await import('./supabaseClient');
     await supabase.from('ui_events').insert({
       event: uiEvent,
       metadata: meta,

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,5 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
-import { ENV } from './env';
 
-export const supabase = createClient(ENV.SUPABASE_URL, ENV.SUPABASE_KEY);
+if (typeof window !== 'undefined') {
+  throw new Error('supabaseClient should only be used server-side');
+}
+
+const SUPABASE_URL = process.env.SUPABASE_URL as string;
+const SUPABASE_KEY = process.env.SUPABASE_KEY as string;
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 

--- a/llms.txt
+++ b/llms.txt
@@ -767,3 +767,17 @@ Files:
 - lib/api.ts (+1/-1)
 - pages/dashboard.tsx (+28/-3)
 
+Timestamp: 2025-08-07T08:29:11.155Z
+Commit: 0e101a9ffac726d4dcdd989ea826a11105ec24f7
+Author: Codex
+Message: feat: revamp landing page with live agent predictions
+Files:
+- components/AgentNodeGraph.tsx (+36/-0)
+- components/MatchupInputForm.tsx (+45/-20)
+- components/PredictionsPanel.tsx (+37/-167)
+- lib/logUiEvent.ts (+11/-1)
+- lib/supabaseClient.ts (+8/-2)
+- pages/api/run-agents.ts (+36/-28)
+- pages/index.tsx (+47/-120)
+- pages/predictions.tsx (+26/-32)
+


### PR DESCRIPTION
## Summary
- replace landing page hero with bettor-focused value prop
- stream agent predictions on load with animated node graph and live status panel
- ensure Supabase credentials stay server-side and emit run-agents errors for visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894621f1bd08323be389419ba1791a2