### PR TITLE
fix: patch JSX apostrophe lint failure in landing page

### DIFF
--- a/components/AgentNodeGraph.tsx
+++ b/components/AgentNodeGraph.tsx
@@ -22,7 +22,7 @@ const AgentNodeGraph: React.FC<Props> = ({ statuses }) => {
               scale: state === 'completed' ? 1 : 1.1,
               opacity: state === 'errored' ? 0.4 : 1,
             }}
-            transition={{ repeat: state === 'running' ? Infinity : 0, duration: 0.8, yoyo: true }}
+            transition={{ repeat: state === 'started' ? Infinity : 0, duration: 0.8, yoyo: true }}
             className="w-16 h-16 rounded-full bg-blue-600 flex items-center justify-center text-xs"
           >
             {name}

--- a/components/TeamBadge.tsx
+++ b/components/TeamBadge.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Image from 'next/image';
 
 const teamFallbacks: Record<string, string> = {
   "49ers": "🟥 SF",
@@ -18,7 +19,7 @@ export type TeamBadgeProps = {
 const TeamBadge: React.FC<TeamBadgeProps> = ({ team, logoUrl, isWinner }) => {
   const [useFallback, setUseFallback] = useState(false);
 
-  const badgeClasses = `w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center overflow-hidden ${
+  const badgeClasses = `relative w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center overflow-hidden ${
     isWinner ? 'ring-2 ring-green-400 transition-transform hover:scale-105' : ''
   }`;
 
@@ -26,13 +27,16 @@ const TeamBadge: React.FC<TeamBadgeProps> = ({ team, logoUrl, isWinner }) => {
 
   if (!useFallback && src) {
     return (
-      <img
-        src={src}
-        alt={`${team} logo`}
-        className={badgeClasses}
-        onError={() => setUseFallback(true)}
-        loading="lazy"
-      />
+      <div className={badgeClasses}>
+        <Image
+          src={src}
+          alt={`${team} logo`}
+          fill
+          sizes="(min-width: 640px) 2.5rem, 2rem"
+          className="object-cover"
+          onError={() => setUseFallback(true)}
+        />
+      </div>
     );
   }
 

--- a/llms.txt
+++ b/llms.txt
@@ -781,3 +781,12 @@ Files:
 - pages/index.tsx (+47/-120)
 - pages/predictions.tsx (+26/-32)
 
+Timestamp: 2025-08-07T08:41:47.559Z
+Commit: d56da5913a2efe5cf64b12a07486e185350a7217
+Author: Codex
+Message: fix: escape apostrophe and optimize badge component
+Files:
+- components/AgentNodeGraph.tsx (+1/-1)
+- components/TeamBadge.tsx (+12/-8)
+- pages/index.tsx (+1/-1)
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,7 +28,7 @@ export default function Home() {
   return (
     <main className="min-h-screen bg-gradient-to-br from-zinc-900 to-neutral-950 text-white p-6 space-y-8">
       <section className="text-center space-y-4 max-w-3xl mx-auto">
-        <h1 className="text-4xl font-bold">Win more pick'em contests with live AI predictions</h1>
+        <h1 className="text-4xl font-bold">Win more pick&apos;em contests with live AI predictions</h1>
         <p className="text-gray-300">Agents scour news, lines and stats in real time so you lock the sharp side first.</p>
       </section>
 


### PR DESCRIPTION
## Summary
- escape landing page apostrophe to satisfy JSX lint rules
- replace TeamBadge <img> with Next.js Image component and make badge container relative
- check AgentNodeGraph status with "started" to avoid build-time type error

## Testing
- `npm test`
- `GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy SUPABASE_KEY=dummy SUPABASE_URL=https://example.com NEXTAUTH_SECRET=dummy SPORTS_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894654a07b88323ac7ffb67efe1e0d6