### PR TITLE
feat: render live agent graph, enable dynamic flows, and expose agent errors

### DIFF
--- a/components/AgentNodeGraph.tsx
+++ b/components/AgentNodeGraph.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import { registry as agentRegistry } from '../lib/agents/registry';
 import type { AgentName, AgentLifecycle } from '../lib/types';
 
 interface Props {
@@ -7,7 +8,7 @@ interface Props {
 }
 
 const AgentNodeGraph: React.FC<Props> = ({ statuses }) => {
-  const agents = Object.keys(statuses) as AgentName[];
+  const agents = agentRegistry.map((a) => a.name as AgentName);
   if (agents.length === 0) {
     return <div className="text-center text-sm text-gray-400">No agent activity yet</div>;
   }

--- a/components/EnvDashboard.tsx
+++ b/components/EnvDashboard.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { ENV } from '../lib/env';
+import { REQUIRED_ENV_KEYS } from '../lib/envKeys';
 
 export default function EnvDashboard() {
   if (process.env.NODE_ENV !== 'development') return null;
   return (
     <div className="p-4 text-sm bg-black text-white rounded">
-      {Object.entries(ENV).map(([key, val]) => (
+      {REQUIRED_ENV_KEYS.map((key) => (
         <div key={key}>
-          {key}: <span className="font-mono">{val ? '✅' : '❌ MISSING'}</span>
+          {key}: <span className="font-mono">{process.env[key] ? '✅' : '❌ MISSING'}</span>
         </div>
       ))}
     </div>

--- a/components/LiveGameLogsPanel.tsx
+++ b/components/LiveGameLogsPanel.tsx
@@ -23,18 +23,19 @@ const LiveGameLogsPanel: React.FC<Props> = ({ logs }) => {
           <h3 className="font-semibold mb-2">Matchup {idx + 1}</h3>
           {matchLogs && matchLogs.length > 0 ? (
             <ul className="space-y-1">
-              {matchLogs
-                .filter((log) => log.result)
-                .map(({ name, result }) => (
-                  <li key={name} className="text-sm">
-                    <span className="font-medium">{formatAgentName(name)}: </span>
+              {matchLogs.map((log) => (
+                <li key={log.name} className="text-sm">
+                  <span className="font-medium">{formatAgentName(log.name)}: </span>
+                  {log.result ? (
                     <span>
-                      {result?.team} ({Math.round((result?.score || 0) * 100)}%) -
-                      {' '}
-                      {result?.reason}
+                      {log.result.team} ({Math.round((log.result.score || 0) * 100)}%) -{' '}
+                      {log.result.reason}
                     </span>
-                  </li>
-                ))}
+                  ) : (
+                    <span className="text-red-600">Error</span>
+                  )}
+                </li>
+              ))}
             </ul>
           ) : (
             <p className="text-sm text-gray-600">No agent logs.</p>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
-import { ENV } from './lib/env';
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
@@ -9,7 +8,7 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  const token = await getToken({ req, secret: ENV.NEXTAUTH_SECRET });
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
   if (!token) {
     const signInUrl = new URL('/auth/signin', req.url);
     return NextResponse.redirect(signInUrl);

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -7,7 +7,6 @@ import AgentStatusPanel from '../components/AgentStatusPanel';
 import MatchupInputForm from '../components/MatchupInputForm';
 import LiveGameLogsPanel from '../components/LiveGameLogsPanel';
 import type { AgentExecution } from '../lib/flow/runFlow';
-import type { AgentResult } from '../lib/types';
 
 const DashboardPage: React.FC = () => {
   const { nodes, startTime, handleLifecycleEvent, reset, statuses } = useFlowVisualizer();
@@ -18,11 +17,11 @@ const DashboardPage: React.FC = () => {
     setLogs((prev) => [...prev, []]);
   };
 
-  const handleAgent = (name: string, result: AgentResult) => {
+  const handleAgent = (exec: AgentExecution) => {
     setLogs((prev) => {
       const updated = [...prev];
       const current = updated[updated.length - 1] || [];
-      current.push({ name, result });
+      current.push(exec);
       updated[updated.length - 1] = current;
       return updated;
     });

--- a/pages/predictions.tsx
+++ b/pages/predictions.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import MatchupInputForm from '../components/MatchupInputForm';
 import PredictionsPanel from '../components/PredictionsPanel';
 import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
-import type { AgentOutputs, AgentResult, PickSummary } from '../lib/types';
+import type { AgentOutputs, PickSummary } from '../lib/types';
+import type { AgentExecution } from '../lib/flow/runFlow';
 
 const PredictionsPage: React.FC = () => {
   const [agents, setAgents] = useState<AgentOutputs>({});
@@ -17,9 +18,11 @@ const PredictionsPage: React.FC = () => {
           setPick(null);
           reset();
         }}
-        onAgent={(name: string, result: AgentResult) =>
-          setAgents((prev) => ({ ...prev, [name]: result }))
-        }
+        onAgent={(exec: AgentExecution) => {
+          if (exec.result) {
+            setAgents((prev) => ({ ...prev, [exec.name]: exec.result }));
+          }
+        }}
         onComplete={(data: { pick: PickSummary }) => setPick(data.pick)}
         onLifecycle={handleLifecycleEvent}
       />


### PR DESCRIPTION
## Summary
- integrate MatchupInputForm with EventSource to stream agent results and errors
- surface live logs and status updates on the landing page with AgentNodeGraph and AgentStatusPanel
- remove client-side dotenv usage to avoid Edge runtime warnings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68946784ebb483238ca23da73ed62921