### PR TITLE
feat: enable live prediction flow on landing

### DIFF
--- a/__tests__/runAgentsApi.test.ts
+++ b/__tests__/runAgentsApi.test.ts
@@ -23,7 +23,7 @@ describe('run-agents API', () => {
       ],
     });
 
-    const req: any = { query: { teamA: 'A', teamB: 'B', matchDay: '1' } };
+    const req: any = { query: { homeTeam: 'A', awayTeam: 'B', week: '1' } };
     const chunks: string[] = [];
     const res: any = {
       setHeader: jest.fn(),
@@ -54,7 +54,7 @@ describe('run-agents API', () => {
       ],
     });
 
-    const req: any = { query: { teamA: 'A', teamB: 'B', matchDay: '1' } };
+    const req: any = { query: { homeTeam: 'A', awayTeam: 'B', week: '1' } };
     const chunks: string[] = [];
     const res: any = {
       setHeader: jest.fn(),

--- a/components/AgentNodeGraph.tsx
+++ b/components/AgentNodeGraph.tsx
@@ -9,22 +9,34 @@ interface Props {
 
 const AgentNodeGraph: React.FC<Props> = ({ statuses }) => {
   const agents = agentRegistry.map((a) => a.name as AgentName);
-  if (agents.length === 0) {
-    return <div className="text-center text-sm text-gray-400">No agent activity yet</div>;
+  const hasActivity = Object.values(statuses).some(
+    (s) => s.status && s.status !== 'idle'
+  );
+  if (!hasActivity) {
+    return (
+      <div className="text-center text-sm text-gray-400">No agent activity yet</div>
+    );
   }
   return (
     <div className="flex justify-center flex-wrap gap-4 py-4">
       {agents.map((name) => {
         const state = statuses[name]?.status || 'idle';
+        let bg = 'bg-blue-600';
+        if (state === 'completed') bg = 'bg-green-600';
+        else if (state === 'errored') bg = 'bg-red-600';
         return (
           <motion.div
             key={name}
             animate={{
-              scale: state === 'completed' ? 1 : 1.1,
+              scale: state === 'started' ? 1.1 : 1,
               opacity: state === 'errored' ? 0.4 : 1,
             }}
-            transition={{ repeat: state === 'started' ? Infinity : 0, duration: 0.8, yoyo: true }}
-            className="w-16 h-16 rounded-full bg-blue-600 flex items-center justify-center text-xs"
+            transition={{
+              repeat: state === 'started' ? Infinity : 0,
+              repeatType: 'reverse',
+              duration: 0.8,
+            }}
+            className={`w-16 h-16 rounded-full ${bg} flex items-center justify-center text-xs`}
           >
             {name}
           </motion.div>

--- a/components/MatchupInputForm.tsx
+++ b/components/MatchupInputForm.tsx
@@ -15,13 +15,13 @@ interface SummaryPayload {
 }
 
 export type Props = {
-  onStart: (info: { teamA: string; teamB: string; matchDay: number }) => void;
+  onStart: (info: { homeTeam: string; awayTeam: string; week: number }) => void;
   onAgent: (exec: AgentExecution) => void;
   onComplete: (data: SummaryPayload) => void;
   onLifecycle: (event: { name: string } & AgentLifecycle) => void;
-  defaultTeamA?: string;
-  defaultTeamB?: string;
-  defaultMatchDay?: number;
+  defaultHomeTeam?: string;
+  defaultAwayTeam?: string;
+  defaultWeek?: number;
   autostart?: boolean;
 };
 
@@ -30,29 +30,33 @@ const MatchupInputForm: React.FC<Props> = ({
   onAgent,
   onComplete,
   onLifecycle,
-  defaultTeamA,
-  defaultTeamB,
-  defaultMatchDay,
+  defaultHomeTeam,
+  defaultAwayTeam,
+  defaultWeek,
   autostart,
 }) => {
-  const [teamA, setTeamA] = useState(defaultTeamA || '');
-  const [teamB, setTeamB] = useState(defaultTeamB || '');
-  const [matchDay, setMatchDay] = useState(
-    defaultMatchDay !== undefined ? String(defaultMatchDay) : ''
+  const [homeTeam, setHomeTeam] = useState(defaultHomeTeam || '');
+  const [awayTeam, setAwayTeam] = useState(defaultAwayTeam || '');
+  const [week, setWeek] = useState(
+    defaultWeek !== undefined ? String(defaultWeek) : ''
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const runPrediction = (teamAVal: string, teamBVal: string, md: number) => {
+  const runPrediction = (
+    home: string,
+    away: string,
+    wk: number
+  ) => {
     setError(null);
     setLoading(true);
-    onStart({ teamA: teamAVal, teamB: teamBVal, matchDay: md });
+    onStart({ homeTeam: home, awayTeam: away, week: wk });
 
     try {
       const es = new EventSource(
-        `/api/run-agents?teamA=${encodeURIComponent(teamAVal)}&teamB=${encodeURIComponent(
-          teamBVal
-        )}&matchDay=${md}`
+        `/api/run-agents?homeTeam=${encodeURIComponent(
+          home
+        )}&awayTeam=${encodeURIComponent(away)}&week=${wk}`
       );
 
       es.onmessage = (event) => {
@@ -85,25 +89,25 @@ const MatchupInputForm: React.FC<Props> = ({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!teamA || !teamB || !matchDay) {
+    if (!homeTeam || !awayTeam || !week) {
       setError('All fields are required');
       return;
     }
-    const matchDayNum = parseInt(matchDay, 10);
-    if (isNaN(matchDayNum)) {
-      setError('Match day must be a number');
+    const weekNum = parseInt(week, 10);
+    if (isNaN(weekNum)) {
+      setError('Week must be a number');
       return;
     }
-    runPrediction(teamA, teamB, matchDayNum);
+    runPrediction(homeTeam, awayTeam, weekNum);
   };
 
   useEffect(() => {
-    if (autostart && defaultTeamA && defaultTeamB) {
-      const md = defaultMatchDay ?? 1;
-      runPrediction(defaultTeamA, defaultTeamB, md);
+    if (autostart && defaultHomeTeam && defaultAwayTeam) {
+      const wk = defaultWeek ?? 1;
+      runPrediction(defaultHomeTeam, defaultAwayTeam, wk);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autostart, defaultTeamA, defaultTeamB, defaultMatchDay]);
+  }, [autostart, defaultHomeTeam, defaultAwayTeam, defaultWeek]);
 
   return (
     <form
@@ -111,43 +115,43 @@ const MatchupInputForm: React.FC<Props> = ({
       className="bg-white rounded-lg shadow p-4 sm:p-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4"
     >
       <div className="flex flex-col">
-        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="teamA">
-          Team/Player A
+        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="homeTeam">
+          Home Team
         </label>
         <input
-          id="teamA"
+          id="homeTeam"
           type="text"
           className="w-full border rounded px-3 py-2"
-          value={teamA}
-          onChange={(e) => setTeamA(e.target.value)}
+          value={homeTeam}
+          onChange={(e) => setHomeTeam(e.target.value)}
           disabled={loading}
           placeholder="e.g., BOS or Federer"
         />
       </div>
       <div className="flex flex-col">
-        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="teamB">
-          Team/Player B
+        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="awayTeam">
+          Away Team
         </label>
         <input
-          id="teamB"
+          id="awayTeam"
           type="text"
           className="w-full border rounded px-3 py-2"
-          value={teamB}
-          onChange={(e) => setTeamB(e.target.value)}
+          value={awayTeam}
+          onChange={(e) => setAwayTeam(e.target.value)}
           disabled={loading}
           placeholder="e.g., LAL or Nadal"
         />
       </div>
       <div className="flex flex-col">
-        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="matchDay">
-          Match Day
+        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="week">
+          Week
         </label>
         <input
-          id="matchDay"
+          id="week"
           type="number"
           className="w-full border rounded px-3 py-2"
-          value={matchDay}
-          onChange={(e) => setMatchDay(e.target.value)}
+          value={week}
+          onChange={(e) => setWeek(e.target.value)}
           disabled={loading}
           placeholder="e.g., 1"
         />

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,8 +1,8 @@
-import dotenv from 'dotenv';
 import { z } from 'zod';
 
-if (process.env.NODE_ENV === 'development') {
-  dotenv.config({ path: '.env.local' });
+if (typeof window === 'undefined' && process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line global-require
+  require('dotenv').config({ path: '.env.local' });
 }
 
 const envSchema = z.object({

--- a/llms.txt
+++ b/llms.txt
@@ -790,3 +790,17 @@ Files:
 - components/TeamBadge.tsx (+12/-8)
 - pages/index.tsx (+1/-1)
 
+Timestamp: 2025-08-07T09:07:43.252Z
+Commit: d7733bcd130a5cb7b7dbc8972adc5501bb47082a
+Author: Codex
+Message: feat: enable live prediction flow on landing
+Files:
+- __tests__/runAgentsApi.test.ts (+2/-2)
+- components/AgentNodeGraph.tsx (+17/-5)
+- components/MatchupInputForm.tsx (+44/-40)
+- lib/env.ts (+3/-3)
+- pages/api/run-agents.ts (+17/-13)
+- pages/dashboard.tsx (+3/-1)
+- pages/index.tsx (+6/-2)
+- pages/predictions.tsx (+3/-1)
+

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -12,7 +12,9 @@ const DashboardPage: React.FC = () => {
   const { nodes, startTime, handleLifecycleEvent, reset, statuses } = useFlowVisualizer();
   const [logs, setLogs] = useState<AgentExecution[][]>([]);
 
-  const handleStart = () => {
+  const handleStart = (
+    _info: { homeTeam: string; awayTeam: string; week: number }
+  ) => {
     reset();
     setLogs((prev) => [...prev, []]);
   };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,9 +13,13 @@ export default function Home() {
   const [agents, setAgents] = useState<AgentOutputs>({});
   const [pick, setPick] = useState<PickSummary | null>(null);
   const [logs, setLogs] = useState<AgentExecution[][]>([]);
+  const [flowStarted, setFlowStarted] = useState(false);
   const { statuses, handleLifecycleEvent, reset } = useFlowVisualizer();
 
-  const handleStart = () => {
+  const handleStart = (
+    _info: { homeTeam: string; awayTeam: string; week: number }
+  ) => {
+    setFlowStarted(true);
     setAgents({});
     setPick(null);
     reset();
@@ -62,7 +66,7 @@ export default function Home() {
         <h2 className="text-center text-2xl font-semibold mb-4">Agent Leaderboard Snapshot</h2>
         <Leaderboard />
       </section>
-      <AgentStatusPanel statuses={statuses} />
+      {flowStarted && <AgentStatusPanel statuses={statuses} />}
     </main>
   );
 }

--- a/pages/predictions.tsx
+++ b/pages/predictions.tsx
@@ -13,7 +13,9 @@ const PredictionsPage: React.FC = () => {
   return (
     <main className="min-h-screen bg-gray-50 p-6 space-y-6">
       <MatchupInputForm
-        onStart={() => {
+        onStart={(
+          _info: { homeTeam: string; awayTeam: string; week: number }
+        ) => {
           setAgents({});
           setPick(null);
           reset();


### PR DESCRIPTION
## Summary
- wire MatchupInputForm to stream predictions using homeTeam/awayTeam/week
- animate AgentNodeGraph on lifecycle events and expose status panel after flow start
- guard dotenv usage to server runtime

## Testing
- `npm test`
- `GOOGLE_CLIENT_ID=1 GOOGLE_CLIENT_SECRET=1 SUPABASE_KEY=1 SUPABASE_URL=http://localhost NEXTAUTH_SECRET=1 NEXTAUTH_URL=http://localhost SPORTS_API_KEY=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68946ad8032c8323866233ab23f1f010