### PR TITLE
feat: add agent logs modal and error insights

### DIFF
--- a/components/AgentLogsModal.tsx
+++ b/components/AgentLogsModal.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from './ui/button';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  sessionId: string;
+  agentId: string;
+}
+
+interface LogData {
+  output: any;
+  reasoning?: string;
+  duration?: number;
+  error?: string;
+  weightedScore?: number;
+}
+
+const AgentLogsModal: React.FC<Props> = ({ isOpen, onClose, sessionId, agentId }) => {
+  const [tab, setTab] = useState<'raw' | 'score' | 'error'>('raw');
+  const [data, setData] = useState<LogData | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setLoading(true);
+      fetch(`/api/logs?sessionId=${encodeURIComponent(sessionId)}&agentId=${encodeURIComponent(agentId)}`)
+        .then((res) => res.json())
+        .then((d) => setData(d))
+        .finally(() => setLoading(false));
+    }
+  }, [isOpen, sessionId, agentId]);
+
+  if (!isOpen) return null;
+
+  const handleCopy = () => {
+    if (data) {
+      navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+    }
+  };
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex justify-center py-10">
+          <div className="h-6 w-6 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+        </div>
+      );
+    }
+    if (!data) {
+      return <p className="text-center">No logs found.</p>;
+    }
+    if (tab === 'raw') {
+      return (
+        <pre className="text-xs overflow-auto max-h-96 bg-gray-100 p-2 rounded text-gray-800">{JSON.stringify(data.output, null, 2)}</pre>
+      );
+    }
+    if (tab === 'score') {
+      return (
+        <div className="space-y-2 text-sm">
+          <p><span className="font-semibold">Weighted Score:</span> {data.weightedScore ?? 'N/A'}</p>
+          <p><span className="font-semibold">Rationale:</span> {data.reasoning ?? 'N/A'}</p>
+          <p><span className="font-semibold">Duration:</span> {data.duration ?? 0}ms</p>
+        </div>
+      );
+    }
+    return (
+      <pre className="text-xs overflow-auto max-h-96 bg-gray-100 p-2 rounded text-red-700">{data.error}</pre>
+    );
+  };
+
+  const handleOverlay = () => onClose();
+  const handleContentClick = (e: React.MouseEvent) => e.stopPropagation();
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={handleOverlay}
+    >
+      <div
+        className="bg-white text-gray-900 w-full max-w-lg rounded shadow-md p-4"
+        onClick={handleContentClick}
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">{agentId} Logs</h2>
+          <Button onClick={handleCopy}>Copy Logs</Button>
+        </div>
+        <div className="flex space-x-4 mb-4 border-b">
+          <button
+            className={`pb-2 text-sm ${tab === 'raw' ? 'border-b-2 border-blue-500' : ''}`}
+            onClick={() => setTab('raw')}
+          >
+            Raw Output
+          </button>
+          <button
+            className={`pb-2 text-sm ${tab === 'score' ? 'border-b-2 border-blue-500' : ''}`}
+            onClick={() => setTab('score')}
+          >
+            Score Breakdown
+          </button>
+          <button
+            className={`pb-2 text-sm ${tab === 'error' ? 'border-b-2 border-blue-500' : ''}`}
+            onClick={() => setTab('error')}
+          >
+            Error Trace
+          </button>
+        </div>
+        {renderContent()}
+      </div>
+    </div>
+  );
+};
+
+export default AgentLogsModal;

--- a/components/AgentStatusPanel.tsx
+++ b/components/AgentStatusPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { agents as agentRegistry } from '../lib/agents/registry';
 import { formatAgentName } from '../lib/utils';
 import type { AgentLifecycle, AgentName } from '../lib/types';
+import AgentLogsModal from './AgentLogsModal';
 
 export type AgentStatusMap = Record<
   AgentName,
@@ -11,10 +12,12 @@ export type AgentStatusMap = Record<
 interface Props {
   statuses: Partial<AgentStatusMap>;
   onRetry?: (agent: AgentName) => void;
+  sessionId: string;
 }
 
-const AgentStatusPanel: React.FC<Props> = ({ statuses, onRetry }) => {
+const AgentStatusPanel: React.FC<Props> = ({ statuses, onRetry, sessionId }) => {
   const [open, setOpen] = useState(false);
+  const [selectedAgent, setSelectedAgent] = useState<AgentName | null>(null);
 
   return (
     <div className="fixed left-0 right-0 bottom-16 mx-auto max-w-md">
@@ -39,12 +42,21 @@ const AgentStatusPanel: React.FC<Props> = ({ statuses, onRetry }) => {
                   key={name}
                   className="flex items-center justify-between px-4 py-2 text-sm"
                 >
-                  <span className="flex-1">{formatAgentName(name)}</span>
+                  <span
+                    className="flex-1 cursor-pointer"
+                    onClick={() => setSelectedAgent(name)}
+                  >
+                    {formatAgentName(name)}
+                  </span>
                   {errored ? (
                     <span className="flex items-center space-x-2">
-                      <span className="px-2 py-0.5 text-xs rounded bg-red-100 text-red-700">
+                      <button
+                        type="button"
+                        onClick={() => setSelectedAgent(name)}
+                        className="px-2 py-0.5 text-xs rounded bg-red-100 text-red-700"
+                      >
                         Error
-                      </span>
+                      </button>
                       {onRetry && (
                         <button
                           type="button"
@@ -64,6 +76,14 @@ const AgentStatusPanel: React.FC<Props> = ({ statuses, onRetry }) => {
           </ul>
         )}
       </div>
+      {selectedAgent && (
+        <AgentLogsModal
+          isOpen={true}
+          agentId={selectedAgent}
+          sessionId={sessionId}
+          onClose={() => setSelectedAgent(null)}
+        />
+      )}
     </div>
   );
 };

--- a/lib/agentLogsStore.ts
+++ b/lib/agentLogsStore.ts
@@ -1,0 +1,19 @@
+export interface AgentLog {
+  output?: any;
+  durationMs?: number;
+  error?: string;
+}
+
+const agentLogs: Record<string, AgentLog> = {};
+
+export function writeAgentLog(
+  sessionId: string,
+  agentId: string,
+  data: AgentLog
+) {
+  agentLogs[`${sessionId}:${agentId}`] = data;
+}
+
+export function readAgentLog(sessionId: string, agentId: string): AgentLog | undefined {
+  return agentLogs[`${sessionId}:${agentId}`];
+}

--- a/lib/flow/runFlow.ts
+++ b/lib/flow/runFlow.ts
@@ -12,6 +12,7 @@ export interface AgentExecution {
   name: AgentName;
   result?: AgentResult;
   error?: true;
+  errorInfo?: { message?: string; stack?: string };
   scoreTotal?: number;
   confidenceEstimate?: number;
   agentDurationMs?: number;
@@ -63,11 +64,15 @@ export async function runFlow(
         endedAt: end,
         durationMs: duration,
       });
-    } catch (err) {
+    } catch (err: any) {
       const end = Date.now();
       const duration = end - start;
       console.error(`[runFlow] ${name} error:`, err);
-      const exec: AgentExecution = { name, error: true };
+      const errorInfo = {
+        message: err?.message || 'Unknown error',
+        stack: err?.stack,
+      };
+      const exec: AgentExecution = { name, error: true, errorInfo };
       executions.push(exec);
       onAgent?.(exec);
       onLifecycle?.({
@@ -76,6 +81,7 @@ export async function runFlow(
         startedAt: start,
         endedAt: end,
         durationMs: duration,
+        error: errorInfo,
       });
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,4 +64,5 @@ export interface AgentLifecycle {
   startedAt: number;
   endedAt?: number;
   durationMs?: number;
+  error?: { message?: string; stack?: string };
 }

--- a/llms.txt
+++ b/llms.txt
@@ -837,3 +837,18 @@ Files:
 - pages/index.tsx (+87/-7)
 - scripts/validateEnv.ts (+1/-7)
 
+Timestamp: 2025-08-07T09:46:05.782Z
+Commit: 5b1a28eedfd1a1733051f8132d3f3b40bd5f9efa
+Author: Codex
+Message: feat: add agent logs modal and error insights
+Files:
+- components/AgentLogsModal.tsx (+114/-0)
+- components/AgentStatusPanel.tsx (+24/-4)
+- lib/agentLogsStore.ts (+19/-0)
+- lib/flow/runFlow.ts (+8/-2)
+- lib/types.ts (+1/-0)
+- pages/api/logs.ts (+25/-0)
+- pages/api/run-agents.ts (+22/-1)
+- pages/dashboard.tsx (+8/-2)
+- pages/index.tsx (+8/-2)
+

--- a/pages/api/logs.ts
+++ b/pages/api/logs.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { readAgentLog } from '../../lib/agentLogsStore';
+import { agents } from '../../lib/agents/registry';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { sessionId, agentId } = req.query;
+  if (typeof sessionId !== 'string' || typeof agentId !== 'string') {
+    res.status(400).json({ error: 'sessionId and agentId are required' });
+    return;
+  }
+  const data = readAgentLog(sessionId, agentId);
+  if (!data) {
+    res.status(404).json({ error: 'Log not found' });
+    return;
+  }
+  const meta = agents.find((a) => a.name === agentId);
+  const weightedScore = data.output?.score * (meta?.weight ?? 1);
+  res.status(200).json({
+    output: data.output || null,
+    reasoning: data.output?.reason,
+    duration: data.durationMs,
+    error: data.error,
+    weightedScore,
+  });
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
 import AgentTimeline from '../lib/dashboard/AgentTimeline';
@@ -13,6 +13,7 @@ const DashboardPage: React.FC = () => {
     useFlowVisualizer();
   const [logs, setLogs] = useState<AgentExecution[][]>([]);
   const [flowStarted, setFlowStarted] = useState(false);
+  const [sessionId, setSessionId] = useState('');
 
   const handleStart = (
     _info: { homeTeam: string; awayTeam: string; week: number }
@@ -32,6 +33,11 @@ const DashboardPage: React.FC = () => {
     });
   };
 
+  useEffect(() => {
+    const sid = typeof window !== 'undefined' ? localStorage.getItem('sessionId') || '' : '';
+    setSessionId(sid);
+  }, []);
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Agent Dashboard</h1>
@@ -48,7 +54,7 @@ const DashboardPage: React.FC = () => {
         </section>
       )}
       <AgentTimeline nodes={nodes} startTime={startTime} />
-      {flowStarted && <AgentStatusPanel statuses={statuses} />}
+      {flowStarted && <AgentStatusPanel statuses={statuses} sessionId={sessionId} />}
     </div>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,10 +17,12 @@ export default function Home() {
   const [leaderboard, setLeaderboard] = useState<Record<string, { totalConfidence: number; totalScore: number; count: number }>>({});
   const [currentParams, setCurrentParams] = useState<{ homeTeam: string; awayTeam: string; week: number } | null>(null);
   const { statuses, handleLifecycleEvent, reset } = useFlowVisualizer();
+  const [sessionId, setSessionId] = useState('');
 
   useEffect(() => {
     const sid = typeof window !== 'undefined' ? localStorage.getItem('sessionId') : null;
     if (sid) {
+      setSessionId(sid);
       const stored = localStorage.getItem(`leaderboard:${sid}`);
       if (stored) {
         try {
@@ -142,10 +144,14 @@ export default function Home() {
 
       <section className="pt-8">
         <h2 className="text-center text-2xl font-semibold mb-4">Agent Leaderboard Snapshot</h2>
-        <AgentLeaderboardPanel stats={leaderboard} />
+      <AgentLeaderboardPanel stats={leaderboard} />
       </section>
       {flowStarted && (
-        <AgentStatusPanel statuses={statuses} onRetry={handleRetryAgent} />
+        <AgentStatusPanel
+          statuses={statuses}
+          onRetry={handleRetryAgent}
+          sessionId={sessionId}
+        />
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- add AgentLogsModal for raw output, score breakdown and error trace with copy logs
- extend AgentStatusPanel to open logs modal and pass sessionId
- log agent outputs/errors with run-agents and expose via /api/logs

## Testing
- `npm test`
- `GOOGLE_CLIENT_ID=1 GOOGLE_CLIENT_SECRET=1 SUPABASE_KEY=1 SUPABASE_URL=http://localhost NEXTAUTH_SECRET=1 NEXTAUTH_URL=http://localhost SPORTS_API_KEY=1 npm run build`
- `vercel --prebuilt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894744636cc8323b63231054f1ad143