### PR TITLE
feat: add docsync agent

### DIFF
--- a/__tests__/docsync-agent.test.ts
+++ b/__tests__/docsync-agent.test.ts
@@ -1,0 +1,70 @@
+import { formatMarkdown, updateWikiPage, syncLogRecord, CodexLog } from "../scripts/docsync-agent";
+
+describe("formatMarkdown", () => {
+  it("formats markdown with commit link and tags", () => {
+    const log: CodexLog = {
+      id: "1",
+      prompt: "Add feature",
+      completion: "Implements new feature",
+      commit_id: "abc123",
+      wiki_target: "Roadmap",
+      components_modified: ["ui/Button.tsx", "infra/setup.ts"],
+      timestamp: "2025-01-01T00:00:00Z",
+    };
+    const md = formatMarkdown(log, { owner: "me", repo: "repo", wikiBranch: "main" });
+    expect(md).toContain("https://github.com/me/repo/commit/abc123");
+    expect(md).toContain("#ui");
+    expect(md).toContain("#infra");
+  });
+});
+
+describe("updateWikiPage", () => {
+  it("inserts content after anchor", async () => {
+    const getContent = jest.fn().mockResolvedValue({
+      data: { content: Buffer.from("Heading\n<!-- DOCSYNC INSERTS BELOW -->\nOld\n").toString("base64"), sha: "1" },
+    });
+    const createOrUpdateFileContents = jest.fn().mockResolvedValue({});
+    const octokit: any = { repos: { getContent, createOrUpdateFileContents } };
+    await updateWikiPage(
+      octokit,
+      { owner: "me", repo: "repo", wikiBranch: "main" },
+      "Test",
+      "New Section",
+      "msg"
+    );
+    const encoded = createOrUpdateFileContents.mock.calls[0][0].content;
+    const decoded = Buffer.from(encoded, "base64").toString("utf8");
+    expect(decoded).toContain("Old\nNew Section");
+    expect(createOrUpdateFileContents).toHaveBeenCalled();
+  });
+});
+
+describe("syncLogRecord", () => {
+  it("updates wiki and marks log as synced", async () => {
+    const getContent = jest.fn().mockResolvedValue({ data: { content: Buffer.from("<!-- DOCSYNC INSERTS BELOW -->\n").toString("base64"), sha: "1" } });
+    const createOrUpdateFileContents = jest.fn().mockResolvedValue({});
+    const octokit: any = { repos: { getContent, createOrUpdateFileContents } };
+    const eq = jest.fn();
+    const update = jest.fn(() => ({ eq }));
+    const from = jest.fn(() => ({ update }));
+    const supabase: any = { from };
+    const log: CodexLog = {
+      id: "2",
+      prompt: "UI change",
+      completion: "Adds button",
+      commit_id: "def456",
+      wiki_target: null,
+      components_modified: ["Button.tsx"],
+      timestamp: "2025-01-02T00:00:00Z",
+    };
+    await syncLogRecord(
+      octokit,
+      supabase,
+      { owner: "me", repo: "repo", wikiBranch: "main" },
+      log
+    );
+    expect(createOrUpdateFileContents).toHaveBeenCalled();
+    expect(from).toHaveBeenCalledWith("codex_logs");
+    expect(eq).toHaveBeenCalledWith("id", "2");
+  });
+});

--- a/llms.txt
+++ b/llms.txt
@@ -852,3 +852,14 @@ Files:
 - pages/dashboard.tsx (+8/-2)
 - pages/index.tsx (+8/-2)
 
+Timestamp: 2025-08-07T09:57:16.468Z
+Commit: 0c9d8eb5fd5bf0269d4cbdd6adb158054a8d32d1
+Author: Codex
+Message: feat: add docsync agent
+Files:
+- __tests__/docsync-agent.test.ts (+70/-0)
+- package-lock.json (+174/-2)
+- package.json (+2/-1)
+- scripts/deploy-docsync-cron.sh (+9/-0)
+- scripts/docsync-agent.ts (+135/-0)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@octokit/rest": "^20.1.0",
         "@supabase/supabase-js": "^2.39.5",
         "framer-motion": "^11.18.2",
         "lucide-react": "^0.536.0",
@@ -1570,6 +1571,161 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.4.4-cjs.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+      "integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.3.2-cjs.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+      "integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.8.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+      "integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@panva/asn1.js": {
@@ -3297,6 +3453,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4262,6 +4424,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -8695,7 +8863,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -11052,6 +11219,12 @@
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
     "node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -11475,7 +11648,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "swr": "^2.3.4",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "@octokit/rest": "^20.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/scripts/deploy-docsync-cron.sh
+++ b/scripts/deploy-docsync-cron.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Deploy a cron job that runs the docsync agent every 12 hours
+set -e
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
+PROJECT_ROOT="$SCRIPT_DIR/.."
+CMD="cd $PROJECT_ROOT && npx ts-node scripts/docsync-agent.ts >> docsync.log 2>&1"
+SCHEDULE="0 */12 * * *"
+( crontab -l 2>/dev/null | grep -v 'docsync-agent'; echo "$SCHEDULE $CMD # docsync-agent" ) | crontab -
+echo "Cron job installed: $SCHEDULE $CMD"

--- a/scripts/docsync-agent.ts
+++ b/scripts/docsync-agent.ts
@@ -1,0 +1,135 @@
+import { Octokit } from "@octokit/rest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface CodexLog {
+  id: string;
+  prompt: string;
+  completion: string;
+  commit_id: string;
+  wiki_target?: string | null;
+  components_modified: string[];
+  timestamp: string;
+}
+
+interface RepoMeta {
+  owner: string;
+  repo: string;
+  wikiBranch: string;
+}
+
+const TAG_PATTERNS: { regex: RegExp; tag: string }[] = [
+  { regex: /\.tsx$/, tag: "#ui" },
+  { regex: /infra\//, tag: "#infra" },
+  { regex: /agent/i, tag: "#agent" },
+  { regex: /\.ts$/, tag: "#runtime" },
+];
+
+export function extractTags(components: string[]): string[] {
+  const tags = new Set<string>();
+  for (const c of components) {
+    for (const { regex, tag } of TAG_PATTERNS) {
+      if (regex.test(c)) {
+        tags.add(tag);
+      }
+    }
+  }
+  return Array.from(tags);
+}
+
+export function formatMarkdown(log: CodexLog, repo: RepoMeta): string {
+  const commitUrl = `https://github.com/${repo.owner}/${repo.repo}/commit/${log.commit_id}`;
+  const date = new Date(log.timestamp).toISOString().split("T")[0];
+  const components = log.components_modified?.map((c) => `\`${c}\``).join(", ") || "";
+  const tags = extractTags(log.components_modified).join(", ");
+  return `### 🔧 [${log.prompt}](${commitUrl})\n\n${log.completion}\n\n**Modified Components:** ${components}\n**Tags:** ${tags}\n🕒 Committed: ${date}`;
+}
+
+export async function updateWikiPage(
+  octokit: Octokit,
+  repo: RepoMeta,
+  page: string,
+  content: string,
+  commitMessage: string
+): Promise<void> {
+  const path = `${page}.md`;
+  const { data } = await octokit.repos.getContent({
+    owner: repo.owner,
+    repo: `${repo.repo}.wiki`,
+    path,
+    ref: repo.wikiBranch,
+  });
+  const sha = (data as any).sha as string | undefined;
+  const current = Buffer.from((data as any).content || "", "base64").toString("utf8");
+  const anchor = "<!-- DOCSYNC INSERTS BELOW -->";
+  let newContent: string;
+  if (current.includes(anchor)) {
+    const [head, tail] = current.split(anchor);
+    const existing = tail.trim();
+    newContent = `${head}${anchor}\n${existing}${existing ? "\n" : ""}${content}\n`;
+  } else {
+    newContent = `${current}\n${anchor}\n${content}\n`;
+  }
+  await octokit.repos.createOrUpdateFileContents({
+    owner: repo.owner,
+    repo: `${repo.repo}.wiki`,
+    path,
+    message: commitMessage,
+    content: Buffer.from(newContent).toString("base64"),
+    branch: repo.wikiBranch,
+    sha,
+  });
+}
+
+export async function syncLogRecord(
+  octokit: Octokit,
+  supabase: SupabaseClient,
+  repo: RepoMeta,
+  log: CodexLog
+): Promise<void> {
+  const page = log.wiki_target || "Unsorted Codex Logs";
+  const section = formatMarkdown(log, repo);
+  await updateWikiPage(
+    octokit,
+    repo,
+    page,
+    section,
+    `Update ${page} from Codex log #${log.id}`
+  );
+  if (log.components_modified?.some((c) => c.endsWith(".tsx"))) {
+    await updateWikiPage(
+      octokit,
+      repo,
+      "UI Components Guide",
+      section,
+      `Update UI Components Guide from Codex log #${log.id}`
+    );
+  }
+  await supabase.from("codex_logs").update({ synced: true }).eq("id", log.id);
+}
+
+export async function run() {
+  const { createClient } = await import("@supabase/supabase-js");
+  const supabase = createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+  const octokit = new Octokit({ auth: process.env.GH_PAT });
+  const repo: RepoMeta = {
+    owner: process.env.GH_OWNER!,
+    repo: process.env.GH_REPO!,
+    wikiBranch: process.env.WIKI_BRANCH || "main",
+  };
+  const { data: logs } = await supabase
+    .from("codex_logs")
+    .select("*")
+    .eq("synced", false);
+  if (logs) {
+    for (const log of logs as CodexLog[]) {
+      await syncLogRecord(octokit, supabase, repo, log);
+    }
+  }
+}
+
+if (require.main === module) {
+  run();
+}


### PR DESCRIPTION
## Summary
- add docsync agent to sync Codex logs into the GitHub wiki
- create cron deployment script for scheduled syncs
- test coverage for markdown formatting, wiki updates, and log syncing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894776c695c83239c64027b1c681232