### PR TITLE
docs: add UI components guide

### DIFF
--- a/docs/ui-components-guide.md
+++ b/docs/ui-components-guide.md
@@ -1,0 +1,24 @@
+# UI Components Guide
+
+This guide summarizes the main React components used to render prediction flows and agent insights in the EdgePicks UI.
+
+## AgentNodeGraph
+
+Displays a node for each registered agent and animates their status during execution. Active agents pulse and errored agents turn red, providing a quick visual of system activity.
+
+## MatchupInputForm
+
+Interactive form for entering home team, away team, and week. Submitting the form streams agent results via an EventSource connection and triggers lifecycle callbacks as data arrives.
+
+## AgentLeaderboardPanel
+
+Aggregates per‑agent performance stats. For each agent, the panel calculates average confidence, total score, and number of evaluations, presenting them in a sorted list.
+
+## AgentDebugPanel
+
+Developer‑focused view showing detailed agent outputs. It lists each agent with its raw and weighted scores, reason text, and any warnings. Mobile layouts use stacked cards while desktop displays a sortable table.
+
+## Additional Components
+
+The `components/` directory includes many other UI pieces such as `AgentCard`, `AgentStatusPanel`, `ScoreBar`, and more. These building blocks combine to deliver transparent predictions and rich debugging information.
+

--- a/llms.txt
+++ b/llms.txt
@@ -863,3 +863,10 @@ Files:
 - scripts/deploy-docsync-cron.sh (+9/-0)
 - scripts/docsync-agent.ts (+135/-0)
 
+Timestamp: 2025-08-07T10:04:28.292Z
+Commit: 120e885a5fad4fcb9e6db9e87ccf8736f695cb4e
+Author: Codex
+Message: docs: add UI components guide
+Files:
+- docs/ui-components-guide.md (+24/-0)
+


### PR DESCRIPTION
## Summary
- document key UI components such as AgentNodeGraph, MatchupInputForm, AgentLeaderboardPanel, and AgentDebugPanel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894792eb4188323b3cae1be72ee7785