### PR TITLE
Finalize UI Wiki Sync & Documentation Logs

### DIFF
--- a/.github/ui-components-review.md
+++ b/.github/ui-components-review.md
@@ -1,0 +1,9 @@
+# Fallback Issue: UI Components Visual Review
+
+The following items require follow-up:
+
+- Verify mobile spacing in `AgentDebugPanel`.
+- Check color contrast for `ScoreBar` labels.
+- Ensure `AgentStatusPanel` transitions are consistent across browsers.
+
+Generated automatically because no corresponding GitHub issue was detected.

--- a/__tests__/docsync-agent.test.ts
+++ b/__tests__/docsync-agent.test.ts
@@ -66,5 +66,7 @@ describe("syncLogRecord", () => {
     expect(createOrUpdateFileContents).toHaveBeenCalled();
     expect(from).toHaveBeenCalledWith("codex_logs");
     expect(eq).toHaveBeenCalledWith("id", "2");
+    const paths = createOrUpdateFileContents.mock.calls.map((c) => c[0].path);
+    expect(paths).toContain("ui-components-guide.md");
   });
 });

--- a/agentLogsStore.json
+++ b/agentLogsStore.json
@@ -1,0 +1,5 @@
+{
+  "timestamp": "2025-08-07T10:17:20Z",
+  "command": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/docsync-agent.ts",
+  "output": "Error: supabaseUrl is required."
+}

--- a/llms.txt
+++ b/llms.txt
@@ -870,3 +870,18 @@ Message: docs: add UI components guide
 Files:
 - docs/ui-components-guide.md (+24/-0)
 
+
+Timestamp: 2025-08-07T10:17:20Z
+codex:finalize-ui-wiki-sync
+codex:ui-components-docsync-update
+Timestamp: 2025-08-07T10:18:51.107Z
+Commit: c7c8b0c173166a939fcd1876d7593f34f872ad33
+Author: Codex
+Message: Finalize UI Wiki Sync & Documentation Logs
+Files:
+- .github/ui-components-review.md (+9/-0)
+- __tests__/docsync-agent.test.ts (+2/-0)
+- agentLogsStore.json (+5/-0)
+- llms.txt (+4/-0)
+- scripts/docsync-agent.ts (+2/-2)
+

--- a/scripts/docsync-agent.ts
+++ b/scripts/docsync-agent.ts
@@ -99,9 +99,9 @@ export async function syncLogRecord(
     await updateWikiPage(
       octokit,
       repo,
-      "UI Components Guide",
+      "ui-components-guide",
       section,
-      `Update UI Components Guide from Codex log #${log.id}`
+      `Update ui-components-guide from Codex log #${log.id}`
     );
   }
   await supabase.from("codex_logs").update({ synced: true }).eq("id", log.id);


### PR DESCRIPTION
## Summary
- point docsync agent to `ui-components-guide.md` when syncing UI updates
- log DocSyncAgent execution and record fallback UI component review issue
- append llms entry with final Codex prompt references

## Testing
- `npm test`
- `bash scripts/deploy-docsync-cron.sh` *(fails: crontab: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947bf2354c8323808cdf380bf83d55