### PR TITLE
docs: add agent lifecycle overview

### DIFF
--- a/agentLogsStore.json
+++ b/agentLogsStore.json
@@ -6,6 +6,7 @@
     "synced": false,
     "syncAttemptedAt": "2025-08-07T10:25:55.847Z",
     "syncError": "supabase env missing",
-    "architectureDocumented": true
+    "architectureDocumented": true,
+    "lifecycleDocumented": true
   }
 ]

--- a/docs/agent-lifecycle-overview.md
+++ b/docs/agent-lifecycle-overview.md
@@ -1,0 +1,46 @@
+# Agent Lifecycle Overview
+
+## Lifecycle States
+- **idle** – default state before `runFlow` begins.
+- **started** – emitted when `runFlow` invokes an agent.
+- **completed** – agent returns a result without error.
+- **errored** – agent throws or rejects.
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle
+    idle --> started: runFlow dispatch
+    started --> completed: success
+    started --> errored: exception
+    errored --> started: retry
+```
+
+Within `runFlow`, agents begin in `idle` until the orchestrator fires a `started` event, then transition to `completed` or `errored` based on execution outcome. Reruns re-enter `started` from `errored`.
+
+## Backend Execution
+- `/api/run-agents` launches agents for a given session and forwards lifecycle events.
+- Each lifecycle event writes to `agentLogsStore` and Supabase via `lifecycleAgent` and `logToSupabase`.
+- On completion or error, scores, durations, and stack traces persist alongside `sessionId` and `agentId`.
+
+## Frontend Integration
+- `AgentNodeGraph.tsx` animates nodes: pulsing on `started`, dimming on `errored`, and hiding when all agents remain `idle`.
+- `AgentStatusPanel.tsx` lists agents with status text, error badges, and **Re-run Agent** buttons for recovery.
+- Panels collapse when inactive, providing a fallback when no lifecycle state is active.
+
+## Log Emission
+- Server‑Sent Events stream `status`, `score`, `error`, and `duration` per agent.
+- `AgentLogsModal` fetches logs with these identifiers to display raw output, score breakdown, or error traces.
+
+## Codex & Observability
+- `DocSyncAgent` scans lifecycle logs to flag unsynced or abnormal sessions for documentation.
+- Clear states help Codex target prompts, debug failures, and auto‑generate docs.
+
+## Testing
+- `runAgentsApi.test.ts` verifies streaming and summary logging for lifecycle events.
+- After each run, status changes appear in logs and UI, confirming state propagation.
+
+---
+**Summary**
+- Timestamp: 2025-08-07T10:42:11Z
+- File: agent-lifecycle-overview.md
+- Lifecycle states referenced: 4

--- a/llms.txt
+++ b/llms.txt
@@ -918,3 +918,19 @@ Files:
 - docs/prediction-flow-architecture.md (+82/-0)
 - llms.txt (+13/-0)
 
+Timestamp: 2025-08-07T10:42:11Z
+Prompt B: Agent Lifecycle Overview
+Summary:
+- Added agent-lifecycle-overview.md documenting lifecycle states and transitions with mermaid diagrams.
+- Marked agentLogsStore.json entries with "lifecycleDocumented": true.
+Testing:
+- npm test — passed
+Timestamp: 2025-08-07T10:43:37.921Z
+Commit: ebbd18dc82315e503da46cd14f44e53fbc1432f8
+Author: Codex
+Message: docs: overview agent lifecycle
+Files:
+- agentLogsStore.json (+2/-1)
+- docs/agent-lifecycle-overview.md (+46/-0)
+- llms.txt (+7/-0)
+


### PR DESCRIPTION
## Summary
- document idle, started, completed, and errored lifecycle states and transitions
- explain backend logging, SSE emissions, and frontend visualization
- mark agent logs as lifecycle documented and update llms log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894826a8ea88323b42070af7c1f9b44