### PR TITLE
docs: document agent design patterns

### DIFF
--- a/agentLogsStore.json
+++ b/agentLogsStore.json
@@ -7,6 +7,7 @@
     "syncAttemptedAt": "2025-08-07T10:25:55.847Z",
     "syncError": "supabase env missing",
     "architectureDocumented": true,
-    "lifecycleDocumented": true
+    "lifecycleDocumented": true,
+    "designPatternsDocumented": true
   }
 ]

--- a/docs/agent-design-patterns.md
+++ b/docs/agent-design-patterns.md
@@ -1,0 +1,82 @@
+# Agent Design Patterns
+
+## 1. Agent Types & Roles
+
+| Agent | Data Sources | Insights | Contribution | Registry Tag |
+|-------|--------------|----------|--------------|--------------|
+| **InjuryScout** | `espn`, team reports | Lineup availability and injury severity | Adjusts team strength based on player status | `{ name: "injuryScout", id: "injuryScout", category: "injury", league: "NFL" }` |
+| **LineWatcher** | market odds feeds | Line movement and sharp money | Flags market shifts influencing confidence | `{ name: "lineWatcher", id: "lineWatcher", category: "line", league: "NFL" }` |
+| **StatCruncher** | advanced stats APIs | Efficiency and matchup metrics | Quantifies historical performance trends | `{ name: "statCruncher", id: "statCruncher", category: "stat", league: "NFL" }` |
+| **TrendsAgent** | Supabase historical tables | Momentum, hit rates, flow popularity | Provides context beyond box scores | `{ name: "trendsAgent", id: "trendsAgent", category: "analytics", league: "NFL" }` |
+| **GuardianAgent** | — | Consistency and reasoning checks | Guards against inconsistent or low-confidence picks | `{ name: "guardianAgent", id: "guardianAgent", category: "guardian", league: "NFL" }` |
+
+## 2. Code Structure Template
+
+```ts
+// AgentName.ts
+import { fetchData } from './data';
+import { AgentOutput } from './types';
+
+export async function run(input: AgentInput): Promise<AgentOutput> {
+  try {
+    const parsed = parseInput(input);        // Input parsing
+    const raw = await fetchData(parsed);     // Data fetch
+    const score = scoreMatchup(raw);         // Scoring function
+    return {                                 // Output shape
+      agent: 'agentName',
+      score,
+      reasoning: buildReasoning(raw, score)
+    };
+  } catch (error) {
+    logError(error, input);                  // Error handling
+    throw error;
+  }
+}
+```
+
+## 3. Error Handling & Logging
+
+- Wrap scoring logic in `try/catch` blocks.
+- Log `error.message`, `error.stack`, and original `input`.
+- Persist results and errors:
+  - **Supabase**: insert into `agent_logs` table for centralized analysis.
+  - **agentLogsStore**: append lightweight JSON entries for local debugging.
+
+## 4. Metadata & Registry
+
+Agents register in `lib/agents/agents.json` with:
+
+```json
+{
+  "name": "injuryScout",
+  "id": "injuryScout",
+  "description": "Tracks player injuries and availability.",
+  "category": "injury",
+  "league": "NFL"
+}
+```
+
+Required fields:
+- `name` and `id`: unique identifiers.
+- `description`: short summary.
+- `category`: domain classification.
+- `league`: supported league(s).
+
+## 5. Testing & Debugging
+
+- Provide unit tests for scoring logic with representative matchups.
+- Mock external API calls to keep tests deterministic.
+- Treat logs as first-class observability; view them in the dashboard's Agent Logs modal.
+
+## 6. Codex Integration
+
+- Codex parses top-level `//` comments for agent name and purpose.
+- Use descriptive headers to enable automated prompt generation.
+- Agents may opt into lifecycle auditing and doc sync by exporting `audit: true` in metadata.
+
+## 7. Extensibility Best Practices
+
+- Design for multiple leagues with pluggable data adapters.
+- Implement fallback paths and feature toggles for experimental logic.
+- Avoid tight coupling with UI components; instead emit lifecycle events and `confidence` scores for downstream display.
+

--- a/llms.txt
+++ b/llms.txt
@@ -934,3 +934,22 @@ Files:
 - docs/agent-lifecycle-overview.md (+46/-0)
 - llms.txt (+7/-0)
 
+Timestamp: 2025-08-07T10:49:16Z
+Summary:
+- Documented agent design patterns to guide modular, reliable agent development.
+Files:
+- docs/agent-design-patterns.md
+- agentLogsStore.json
+- llms.txt
+Patterns documented: 7
+Testing:
+- npm test — passed
+Timestamp: 2025-08-07T10:50:20.777Z
+Commit: d35e717415290dd2c89ca7aa5bbd82eaa340daa9
+Author: Codex
+Message: docs: document agent design patterns
+Files:
+- agentLogsStore.json (+3/-2)
+- docs/agent-design-patterns.md (+82/-0)
+- llms.txt (+10/-0)
+


### PR DESCRIPTION
## Summary
- document roles, metadata, and patterns for new agents in `agent-design-patterns.md`
- mark existing log entries with `designPatternsDocumented`
- record design pattern guidance in `llms.txt`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689484260a008323ac8f5a1ebb67ef28