### PR TITLE
test: add snapshot regression checks

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,18 @@
+name: CI Snapshot and Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/__tests__/__snapshots__/lifecycle.test.ts.snap
+++ b/__tests__/__snapshots__/lifecycle.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`agent lifecycle logs matches snapshot 1`] = `
+[
+  {
+    "architectureDocumented": true,
+    "command": "npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/docsync-agent.ts",
+    "designPatternsDocumented": true,
+    "lifecycleDocumented": true,
+    "output": "Error: supabaseUrl is required.",
+    "syncAttemptedAt": "2025-08-07T10:25:55.847Z",
+    "syncError": "supabase env missing",
+    "synced": false,
+    "timestamp": "2025-08-07T10:17:20Z",
+  },
+]
+`;

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`llms.txt log matches content hash snapshot 1`] = `"19493763ee93203cdb152eb06a6039908cd67868f088ca9c2f482e29b49993bc"`;

--- a/__tests__/__snapshots__/uiSnapshot.test.tsx.snap
+++ b/__tests__/__snapshots__/uiSnapshot.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AgentStatusPanel UI renders default state 1`] = `
+<DocumentFragment>
+  <div
+    class="fixed left-0 right-0 bottom-16 mx-auto max-w-md"
+  >
+    <div
+      class="bg-white border rounded-t shadow-lg"
+    >
+      <button
+        class="w-full px-4 py-2 text-left font-medium bg-gray-100"
+      >
+        Show Agent Status
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/lifecycle.test.ts
+++ b/__tests__/lifecycle.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('agent lifecycle logs', () => {
+  it('matches snapshot', () => {
+    const file = path.join(__dirname, '..', 'agentLogsStore.json');
+    const logs = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(logs).toMatchSnapshot();
+  });
+});

--- a/__tests__/llmsLog.test.ts
+++ b/__tests__/llmsLog.test.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+describe('llms.txt log', () => {
+  it('matches content hash snapshot', () => {
+    const file = path.join(__dirname, '..', 'llms.txt');
+    const content = fs.readFileSync(file, 'utf8');
+    const hash = crypto.createHash('sha256').update(content).digest('hex');
+    expect(hash).toMatchSnapshot();
+  });
+});

--- a/__tests__/uiSnapshot.test.tsx
+++ b/__tests__/uiSnapshot.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('../lib/agents/registry', () => ({
+  agents: [
+    { name: 'injuryScout', description: '', type: 'injury', weight: 0.5, sources: [] },
+  ],
+}));
+
+import AgentStatusPanel from '../components/AgentStatusPanel';
+
+describe('AgentStatusPanel UI', () => {
+  it('renders default state', () => {
+    const { asFragment } = render(
+      <AgentStatusPanel statuses={{}} sessionId="test-session" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/docs/testing-regression-checks.md
+++ b/docs/testing-regression-checks.md
@@ -1,0 +1,20 @@
+# Testing Regression Checks
+
+Snapshot tests guard against silent breakages in critical files and UI.
+
+## Lifecycle Logs
+
+`__tests__/lifecycle.test.ts` snapshots `agentLogsStore.json` to detect unexpected
+changes to recorded agent lifecycle events.
+
+## UI Snapshot
+
+`__tests__/uiSnapshot.test.ts` captures the default render of `AgentStatusPanel`
+so visual structure changes require an intentional snapshot update.
+
+## Codex Log
+
+`__tests__/llmsLog.test.ts` hashes `llms.txt` to flag undocumented Codex log updates.
+
+Run `npm test` to refresh snapshots. CI runs lint and these tests via
+`.github/workflows/ci-tests.yml`.

--- a/llms.txt
+++ b/llms.txt
@@ -953,3 +953,25 @@ Files:
 - docs/agent-design-patterns.md (+82/-0)
 - llms.txt (+10/-0)
 
+Timestamp: 2025-08-07T10:57:56Z
+codex:ci-snapshot-testing
+Summary:
+- Added CI workflow for lint and snapshot tests.
+- Snapshot tests cover lifecycle logs, UI, and llms log.
+Testing:
+- npm test — passed
+Timestamp: 2025-08-07T11:00:15.795Z
+Commit: ca9de7ab29501e8a1ee9ad37f07d491db7567354
+Author: Codex
+Message: test: add snapshot regression checks
+Files:
+- .github/workflows/ci-tests.yml (+18/-0)
+- __tests__/__snapshots__/lifecycle.test.ts.snap (+17/-0)
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+3/-0)
+- __tests__/__snapshots__/uiSnapshot.test.tsx.snap (+19/-0)
+- __tests__/lifecycle.test.ts (+10/-0)
+- __tests__/llmsLog.test.ts (+12/-0)
+- __tests__/uiSnapshot.test.tsx (+19/-0)
+- docs/testing-regression-checks.md (+20/-0)
+- llms.txt (+7/-0)
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint and run tests
- snapshot lifecycle logs, AgentStatusPanel, and llms log
- document regression snapshot strategy and log entry

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689485e52d7483238347580089a88d64