### PR TITLE
feat: audit agent metadata

### DIFF
--- a/agentLogsStore.json
+++ b/agentLogsStore.json
@@ -9,5 +9,11 @@
     "architectureDocumented": true,
     "lifecycleDocumented": true,
     "designPatternsDocumented": true
+  },
+  {
+    "timestamp": "2025-08-07T10:58:40Z",
+    "command": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/audit-agent-metadata.ts",
+    "output": "Agent metadata is valid and docs are in sync.",
+    "metadataAudited": true
   }
 ]

--- a/docs/agent-guardianAgent.md
+++ b/docs/agent-guardianAgent.md
@@ -1,0 +1,3 @@
+# guardianAgent
+
+Reviews outputs for inconsistent or incomplete reasoning.

--- a/docs/agent-injuryScout.md
+++ b/docs/agent-injuryScout.md
@@ -1,0 +1,3 @@
+# injuryScout
+
+Tracks player injuries and availability.

--- a/docs/agent-lineWatcher.md
+++ b/docs/agent-lineWatcher.md
@@ -1,0 +1,3 @@
+# lineWatcher
+
+Monitors betting line movement and market signals.

--- a/docs/agent-statCruncher.md
+++ b/docs/agent-statCruncher.md
@@ -1,0 +1,3 @@
+# statCruncher
+
+Crunches historical statistics for trends.

--- a/docs/agent-trendsAgent.md
+++ b/docs/agent-trendsAgent.md
@@ -1,0 +1,3 @@
+# trendsAgent
+
+Analyzes recent matchups for flow popularity and agent hit rates.

--- a/lib/validateAgentMetadata.ts
+++ b/lib/validateAgentMetadata.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+import { z } from 'zod';
+
+const AgentSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  type: z.enum(['injury', 'line', 'stat', 'analytics', 'guardian']),
+  weight: z.number(),
+  sources: z.array(z.string()),
+}).strict();
+
+export type AgentMetadata = z.infer<typeof AgentSchema>;
+
+export function validateAgents(metaPath: string, docsDir: string): AgentMetadata[] {
+  const raw = fs.readFileSync(metaPath, 'utf-8');
+  const data = JSON.parse(raw);
+  const agents = z.array(AgentSchema).parse(data);
+
+  const names = new Set<string>();
+  for (const agent of agents) {
+    if (names.has(agent.name)) {
+      throw new Error(`Duplicate agent name detected: ${agent.name}`);
+    }
+    names.add(agent.name);
+
+    const docPath = path.join(docsDir, `agent-${agent.name}.md`);
+    if (!fs.existsSync(docPath)) {
+      throw new Error(`Missing doc for agent ${agent.name}`);
+    }
+    const docContent = fs.readFileSync(docPath, 'utf-8');
+    if (!docContent.includes(agent.description)) {
+      throw new Error(`Doc for agent ${agent.name} is out of sync with description`);
+    }
+  }
+
+  const docFiles = fs
+    .readdirSync(docsDir)
+    .filter((f) => /^agent-[A-Za-z0-9]+\.md$/.test(f));
+  const extraDocs = docFiles.filter((f) => {
+    const name = f.replace(/^agent-(.*)\.md$/, '$1');
+    return !agents.some((a) => a.name === name);
+  });
+  if (extraDocs.length) {
+    throw new Error(`Doc files without matching agent metadata: ${extraDocs.join(', ')}`);
+  }
+
+  return agents;
+}

--- a/llms.txt
+++ b/llms.txt
@@ -953,3 +953,10 @@ Files:
 - docs/agent-design-patterns.md (+82/-0)
 - llms.txt (+10/-0)
 
+Timestamp: 2025-08-07T10:58:40Z
+Summary:
+- Added agent metadata validation library and audit script.
+- Created per-agent documentation to enforce registry governance.
+Testing:
+- npm test — passed
+- npm run test:metadata — passed

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:local": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/testLocal.ts",
     "validate-env": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/validateEnv.ts",
     "list-missing-env": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/listMissingEnv.ts",
+    "test:metadata": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/audit-agent-metadata.ts",
     "postinstall": "node -e \"try{require.resolve('@types/react')}catch(e){console.warn('@types/react not found')}\"",
     "postpush": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/log-llms-entry.ts",
     "prepare": "husky",

--- a/scripts/audit-agent-metadata.ts
+++ b/scripts/audit-agent-metadata.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+import { validateAgents } from '../lib/validateAgentMetadata';
+
+try {
+  const metaPath = path.join(__dirname, '../lib/agents/agents.json');
+  const docsDir = path.join(__dirname, '../docs');
+  validateAgents(metaPath, docsDir);
+  console.log('✅ Agent metadata is valid and docs are in sync.');
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('❌ Agent metadata validation failed:', message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add zod-based agent metadata validator with doc sync checks
- wire up audit script and npm test:metadata task
- document each agent and log metadata audit

## Testing
- `npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/audit-agent-metadata.ts`
- `npm run test:metadata`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689485d116b08323a8947977d0de5ad9