### PR TITLE
feat: add docsync retry and failover

### DIFF
--- a/agentLogsStore.json
+++ b/agentLogsStore.json
@@ -9,5 +9,16 @@
     "architectureDocumented": true,
     "lifecycleDocumented": true,
     "designPatternsDocumented": true
+  },
+  {
+    "timestamp": "2025-08-07T11:05:00Z",
+    "command": "npx ts-node scripts/docsync-agent.ts",
+    "output": "GH_PAT is required.",
+    "synced": false,
+    "syncAttemptedAt": "2025-08-07T11:05:00Z",
+    "syncError": "GH_PAT is required.",
+    "architectureDocumented": true,
+    "lifecycleDocumented": true,
+    "designPatternsDocumented": true
   }
 ]

--- a/docs/docsync-strategy.md
+++ b/docs/docsync-strategy.md
@@ -1,0 +1,19 @@
+# DocSync Retry & Failover Strategy
+
+DocSync ensures documentation updates make it to the GitHub wiki even when
+external services are unavailable. Failed sync attempts are written to
+`agentLogsStore.json` and can be retried later.
+
+## Features
+- **Dry Run:** `scripts/docsync-agent.ts` accepts a `--dry-run` flag to validate
+  environment configuration without making network calls.
+- **Failure Logging:** Any sync failure appends a record to
+  `agentLogsStore.json` with the error message and command executed.
+- **Retry Script:** `scripts/retry-docsync.ts` replays unsynced commands from
+  `agentLogsStore.json`, marking entries as synced on success.
+
+## Usage
+1. `npx ts-node scripts/docsync-agent.ts --dry-run` to verify setup.
+2. Run `npx ts-node scripts/docsync-agent.ts` for a real sync.
+3. If a sync fails, execute `npx ts-node scripts/retry-docsync.ts` once the
+   environment is fixed to replay missed jobs.

--- a/llms.txt
+++ b/llms.txt
@@ -953,3 +953,22 @@ Files:
 - docs/agent-design-patterns.md (+82/-0)
 - llms.txt (+10/-0)
 
+Timestamp: 2025-08-07T11:10:00Z
+Summary:
+- Added docsync dry-run, failure logging, and retry script
+- Documented DocSync failover strategy
+Testing:
+- npm test — passed
+- npx ts-node scripts/docsync-agent.ts --dry-run — passed
+- npx ts-node scripts/retry-docsync.ts — ERR_UNKNOWN_FILE_EXTENSION
+Timestamp: 2025-08-07T11:01:43.073Z
+Commit: 0429ba4861195e5c718e095aa12c137737545b19
+Author: Codex
+Message: feat: add docsync retry and failover
+Files:
+- agentLogsStore.json (+11/-0)
+- docs/docsync-strategy.md (+19/-0)
+- llms.txt (+8/-0)
+- scripts/docsync-agent.ts (+75/-17)
+- scripts/retry-docsync.ts (+39/-0)
+

--- a/scripts/retry-docsync.ts
+++ b/scripts/retry-docsync.ts
@@ -1,0 +1,39 @@
+import fs from "fs";
+import { execSync } from "child_process";
+
+interface AgentLogEntry {
+  command: string;
+  synced: boolean;
+  output?: string;
+  syncAttemptedAt?: string;
+  syncError?: string;
+}
+
+export async function run() {
+  const path = "agentLogsStore.json";
+  if (!fs.existsSync(path)) {
+    console.log("agentLogsStore.json not found");
+    return;
+  }
+  const logs: AgentLogEntry[] = JSON.parse(fs.readFileSync(path, "utf8"));
+  for (const log of logs) {
+    if (!log.synced && log.command) {
+      try {
+        const out = execSync(log.command).toString();
+        log.output = out;
+        log.synced = true;
+        log.syncAttemptedAt = new Date().toISOString();
+        delete log.syncError;
+      } catch (err: any) {
+        log.output = err?.stdout?.toString() || "";
+        log.syncError = err?.message || String(err);
+        log.syncAttemptedAt = new Date().toISOString();
+      }
+    }
+  }
+  fs.writeFileSync(path, JSON.stringify(logs, null, 2));
+}
+
+if (require.main === module) {
+  run();
+}


### PR DESCRIPTION
## Summary
- support dry-run mode and persistent failure logging in docsync-agent
- add retry-docsync script to replay unsynced jobs
- document docsync failover strategy and update logs

## Testing
- `npm test`
- `npx ts-node scripts/docsync-agent.ts --dry-run`
- `npx ts-node scripts/retry-docsync.ts` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_68948605f5c083239463d033f5923084