### PR TITLE
feat: add codex prompt registry

### DIFF
--- a/__tests__/__snapshots__/lifecycle.test.ts.snap
+++ b/__tests__/__snapshots__/lifecycle.test.ts.snap
@@ -4,6 +4,7 @@ exports[`agent lifecycle logs matches snapshot 1`] = `
 [
   {
     "architectureDocumented": true,
+    "codexRegistered": true,
     "command": "npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/docsync-agent.ts",
     "designPatternsDocumented": true,
     "lifecycleDocumented": true,
@@ -12,6 +13,25 @@ exports[`agent lifecycle logs matches snapshot 1`] = `
     "syncError": "supabase env missing",
     "synced": false,
     "timestamp": "2025-08-07T10:17:20Z",
+  },
+  {
+    "architectureDocumented": true,
+    "codexRegistered": true,
+    "command": "npx ts-node scripts/docsync-agent.ts",
+    "designPatternsDocumented": true,
+    "lifecycleDocumented": true,
+    "output": "GH_PAT is required.",
+    "syncAttemptedAt": "2025-08-07T11:05:00Z",
+    "syncError": "GH_PAT is required.",
+    "synced": false,
+    "timestamp": "2025-08-07T11:05:00Z",
+  },
+  {
+    "codexRegistered": true,
+    "command": "npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/audit-agent-metadata.ts",
+    "metadataAudited": true,
+    "output": "Agent metadata is valid and docs are in sync.",
+    "timestamp": "2025-08-07T10:58:40Z",
   },
 ]
 `;

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms.txt log matches content hash snapshot 1`] = `"19493763ee93203cdb152eb06a6039908cd67868f088ca9c2f482e29b49993bc"`;
+exports[`llms.txt log matches content hash snapshot 1`] = `"ea1701456bad2501a63bf781387f5e9018528ad123dd1207876f9491ba11e96b"`;

--- a/agentLogsStore.json
+++ b/agentLogsStore.json
@@ -8,10 +8,10 @@
     "syncError": "supabase env missing",
     "architectureDocumented": true,
     "lifecycleDocumented": true,
-    "designPatternsDocumented": true
+    "designPatternsDocumented": true,
+    "codexRegistered": true
   },
   {
-
     "timestamp": "2025-08-07T11:05:00Z",
     "command": "npx ts-node scripts/docsync-agent.ts",
     "output": "GH_PAT is required.",
@@ -20,12 +20,14 @@
     "syncError": "GH_PAT is required.",
     "architectureDocumented": true,
     "lifecycleDocumented": true,
-    "designPatternsDocumented": true
-=======
+    "designPatternsDocumented": true,
+    "codexRegistered": true
+  },
+  {
     "timestamp": "2025-08-07T10:58:40Z",
     "command": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/audit-agent-metadata.ts",
     "output": "Agent metadata is valid and docs are in sync.",
-    "metadataAudited": true
-
+    "metadataAudited": true,
+    "codexRegistered": true
   }
 ]

--- a/components/PromptDashboard.tsx
+++ b/components/PromptDashboard.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import promptRegistry from '../data/prompt-registry.json';
+
+interface Entry {
+  source: string;
+  timestamp?: string;
+  header: string;
+  summary: string;
+}
+
+const PromptDashboard: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const entries = (promptRegistry as Entry[]).filter((e) => {
+    const q = query.toLowerCase();
+    return (
+      e.header.toLowerCase().includes(q) ||
+      e.summary.toLowerCase().includes(q) ||
+      (e.timestamp || '').toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Codex Prompt Registry</h1>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search prompts..."
+        className="border p-2 mb-4 w-full"
+      />
+      <ul>
+        {entries.map((e, idx) => (
+          <li key={idx} className="mb-4 border-b pb-2">
+            {e.timestamp && (
+              <div className="text-xs text-gray-500">{e.timestamp}</div>
+            )}
+            <div className="font-semibold">{e.header}</div>
+            <div className="text-sm">{e.summary}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default PromptDashboard;

--- a/data/prompt-registry.json
+++ b/data/prompt-registry.json
@@ -1,0 +1,596 @@
+[
+  {
+    "timestamp": "2025-08-06T01:35:19Z",
+    "summary": "Repository docs synced (README + AGENTS.md) AgentStatusPanel added for real-time visibility ConfidenceMeter refactored to accept structured team objects and history UpcomingGamesPanel now fetches live matchups via `/api/upcoming-games`",
+    "source": "llms",
+    "header": "Repository docs synced (README + AGENTS.md) AgentStatusPanel"
+  },
+  {
+    "timestamp": "2025-08-06T02:16:43Z",
+    "summary": "Landing page features UpcomingGamesPanel with hero heading and manual entry toggle. Toggle logs `uiEvent: 'toggleManualEntry'` to Supabase and reveals MatchupInputForm with animation. UpcomingGamesPanel shows three matchups by default, mobile agent accordions, and \"Show More Matchups\" loader.",
+    "source": "llms",
+    "header": "Landing page features UpcomingGamesPanel with hero heading a"
+  },
+  {
+    "timestamp": "2025-08-06T19:42:00Z",
+    "summary": "Codex audit `codex:edgepicks-prep-beta-ux-polish` completed for public beta readiness. Evaluated visual hierarchy, clarity, toggle logic, confidence meter labels, glossary usage, and first-load UX. Logged improvements needed for mobile responsiveness, tooltip accessibility, keyboard navigation, and color contrast. Recommends glossary CTA, better toggle labels, confidence meter text, and layout polish for ADHD-friendliness. Treats llms.txt and README.md as living documents for agent state alignment.",
+    "source": "llms",
+    "header": "Codex audit `codex:edgepicks-prep-beta-ux-polish` completed "
+  },
+  {
+    "timestamp": "2025-08-06T02:56:23Z",
+    "header": "codex:edgepicks-landing-emotional-hook-and-agent-preview",
+    "summary": "",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-06T03:12:17Z",
+    "header": "codex:edgepicks-integrate-thesportsdb-oddsapi",
+    "summary": "",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-06T03:28:19Z",
+    "header": "codex:edgepicks-agent-beta-sweep",
+    "summary": "",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-06T03:38:12Z",
+    "header": "codex:fix-liveMatchup-fetch-failure",
+    "summary": "",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-06T03:39:45Z",
+    "header": "codex:landing-multisport-forecast-panel",
+    "summary": "",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-06T03:55:25Z",
+    "summary": "Integrated NextAuth Google OAuth with `/api/auth/[...nextauth]`. Wrapped app in SessionProvider and added header sign-in/out buttons with user name display. Protected index and dashboard pages via server-side session checks redirecting unauthenticated users.",
+    "source": "llms",
+    "header": "Integrated NextAuth Google OAuth with `/api/auth/[...nextaut"
+  },
+  {
+    "timestamp": "2025-08-06T04:01:38Z",
+    "summary": "Documented NextAuth environment variables in README and `.env.example` for Google sign-in configuration.",
+    "source": "llms",
+    "header": "Documented NextAuth environment variables in README and `.en"
+  },
+  {
+    "timestamp": "2025-08-06T04:16:02.317Z",
+    "header": "codex:auto-generated-llms-log",
+    "summary": "",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-06T04:35:34.940Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T04:36:27.171Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T04:48:12.951Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T04:56:44.608Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T05:08:06.703Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T05:08:26.996Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T05:18:52.490Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T05:29:39.118Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T05:39:38.366Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T20:27:27.868Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T20:35:23.287Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T20:50:58.528Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T20:59:29.308Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T21:22:24.804Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T21:26:35.121Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T21:26:50.181Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T21:38:18.700Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:04:28.622Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:06:01.459Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:03:21.354Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:04:48.157Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:02:59.752Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:04:08.496Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:03:35.141Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:33:18.591Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:29:43.682Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:29:16.958Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:54:10.476Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:54:21.567Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T22:59:53.707Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T23:00:17.712Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T23:10:29.798Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T23:09:44.509Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T23:18:42.008Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T23:39:07.226Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T23:54:30.849Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-06T23:58:36.103Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T00:10:56.863Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T00:22:01.562Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T00:26:31.440Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T01:06:26.514Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T01:18:44.402Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T01:44:52.111Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T02:15:07.755Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T02:35:38.824Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T03:36:45Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T03:41:43.721Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T04:00:19.811Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T04:13:35.181Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T04:13:53.864Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T04:27:36.474Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T04:42:36.685Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T04:49:17Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T04:55:15.897Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T05:09:00Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T05:13:20.775Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T06:13:26.737Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T06:57:01.656Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T07:09:01Z",
+    "summary": "Rewrote README.md to reflect modular architecture, Codex governance, and API documentation for beta launch. Validated Supabase environment variables using `scripts/validateEnv.ts` to ensure required settings. Ran `audit-agent.ts` to capture current audit findings and roadmap. Verified Vercel build logs and resolved Edge Runtime warnings. Committed README.md update (\"docs: rewrite README for beta launch with architecture, API, and Codex audit details\").",
+    "source": "llms",
+    "header": "Rewrote README.md to reflect modular architecture, Codex gov"
+  },
+  {
+    "timestamp": "2025-08-07T07:09:59.022Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T07:26:48.336Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T07:26:13.821Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T07:26:34.227Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T07:42:26.340Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T08:14:06.596Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T08:29:11.155Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T08:41:47.559Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T09:07:43.252Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T09:23:25.358Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T09:36:32.394Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T09:46:05.782Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T09:57:16.468Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T10:04:28.292Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T10:17:20Z",
+    "header": "codex:ui-components-docsync-update",
+    "summary": "",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-07T10:18:51.107Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T10:28:03.553Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T10:34:27Z",
+    "header": "codex:prediction-flow-architecture",
+    "summary": "Documented prediction flow from MatchupInputForm through agent orchestration and UI updates. Logged fallback UI spacing issue in `.github/ui-components-review.md`. Marked existing logs with \"architectureDocumented\": true.",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-07T10:36:38.248Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T10:42:11Z",
+    "summary": "Added agent-lifecycle-overview.md documenting lifecycle states and transitions with mermaid diagrams. Marked agentLogsStore.json entries with \"lifecycleDocumented\": true.",
+    "source": "llms",
+    "header": "Added agent-lifecycle-overview.md documenting lifecycle stat"
+  },
+  {
+    "timestamp": "2025-08-07T10:43:37.921Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T10:49:16Z",
+    "summary": "Documented agent design patterns to guide modular, reliable agent development.",
+    "source": "llms",
+    "header": "Documented agent design patterns to guide modular, reliable "
+  },
+  {
+    "timestamp": "2025-08-07T10:50:20.777Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T11:10:00Z",
+    "summary": "Added docsync dry-run, failure logging, and retry script Documented DocSync failover strategy",
+    "source": "llms",
+    "header": "Added docsync dry-run, failure logging, and retry script Doc"
+  },
+  {
+    "timestamp": "2025-08-07T11:01:43.073Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T10:58:40Z",
+    "summary": "Added agent metadata validation library and audit script. Created per-agent documentation to enforce registry governance.",
+    "source": "llms",
+    "header": "Added agent metadata validation library and audit script. Cr"
+  },
+  {
+    "timestamp": "2025-08-07T10:57:56Z",
+    "header": "codex:ci-snapshot-testing",
+    "summary": "Added CI workflow for lint and snapshot tests. Snapshot tests cover lifecycle logs, UI, and llms log.",
+    "source": "llms"
+  },
+  {
+    "timestamp": "2025-08-07T11:00:15.795Z",
+    "summary": "",
+    "source": "llms",
+    "header": ""
+  },
+  {
+    "timestamp": "2025-08-07T11:08:06Z",
+    "summary": "Added Codex Prompt Registry generator and dashboard. Marked agent logs with codexRegistered and documented registry structure.",
+    "source": "llms",
+    "header": "Added Codex Prompt Registry generator and dashboard. Marked "
+  }
+]

--- a/docs/codex-prompt-registry.md
+++ b/docs/codex-prompt-registry.md
@@ -1,0 +1,21 @@
+# Codex Prompt Registry
+
+The Codex Prompt Registry aggregates historical prompt metadata from `llms.txt` and the Git commit history. Use `scripts/generatePromptRegistry.ts` to rebuild the registry and write the results to `data/prompt-registry.json`.
+
+## Entry Structure
+Each registry entry contains:
+
+- `source`: `"llms"` or `"pr"`
+- `timestamp`: ISO timestamp when available
+- `header`: prompt title or commit subject
+- `summary`: short description of the prompt
+- `commit`: commit hash when sourced from PR history
+
+## Regeneration
+Run:
+
+```bash
+npx ts-node scripts/generatePromptRegistry.ts
+```
+
+The dashboard at `/codex/prompts` loads this JSON to provide a searchable interface for auditing past prompts.

--- a/llms.txt
+++ b/llms.txt
@@ -1006,3 +1006,25 @@ Files:
 
 
 
+Timestamp: 2025-08-07T11:08:06Z
+Summary:
+- Added Codex Prompt Registry generator and dashboard.
+- Marked agent logs with codexRegistered and documented registry structure.
+Testing:
+- npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/generatePromptRegistry.ts — passed
+- npm test — passed
+Timestamp: 2025-08-07T11:09:58.338Z
+Commit: 486691b8235fa0308ccd6fa4337c8d9da1ace40a
+Author: Codex
+Message: feat: add codex prompt registry
+Files:
+- __tests__/__snapshots__/lifecycle.test.ts.snap (+20/-0)
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- agentLogsStore.json (+8/-6)
+- components/PromptDashboard.tsx (+47/-0)
+- data/prompt-registry.json (+596/-0)
+- docs/codex-prompt-registry.md (+21/-0)
+- llms.txt (+7/-0)
+- pages/codex/prompts.tsx (+8/-0)
+- scripts/generatePromptRegistry.ts (+87/-0)
+

--- a/pages/codex/prompts.tsx
+++ b/pages/codex/prompts.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import PromptDashboard from '../../components/PromptDashboard';
+
+const PromptsPage: React.FC = () => {
+  return <PromptDashboard />;
+};
+
+export default PromptsPage;

--- a/scripts/generatePromptRegistry.ts
+++ b/scripts/generatePromptRegistry.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+type PromptEntry = {
+  source: 'llms' | 'pr';
+  timestamp?: string;
+  header: string;
+  summary: string;
+  commit?: string;
+};
+
+function parseLlms(filePath: string): PromptEntry[] {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.split(/\r?\n/);
+  const entries: PromptEntry[] = [];
+
+  let current: Partial<PromptEntry> | null = null;
+  let summaryLines: string[] = [];
+  let inSummary = false;
+
+  for (const line of lines) {
+    if (line.startsWith('Timestamp:')) {
+      if (current) {
+        current.summary = summaryLines.join(' ');
+        entries.push({ ...(current as PromptEntry), source: 'llms' });
+      }
+      current = { timestamp: line.replace('Timestamp:', '').trim() };
+      summaryLines = [];
+      inSummary = false;
+    } else if (line.startsWith('codex:')) {
+      if (current) {
+        current.header = line.trim();
+      }
+    } else if (line === 'Summary:') {
+      inSummary = true;
+    } else if (inSummary && line.startsWith('-')) {
+      summaryLines.push(line.replace(/^-\s*/, '').trim());
+    } else if (inSummary && (line.trim() === '' || /^[A-Za-z]+:/.test(line))) {
+      inSummary = false;
+    }
+  }
+
+  if (current) {
+    current.summary = summaryLines.join(' ');
+    entries.push({ ...(current as PromptEntry), source: 'llms' });
+  }
+
+  return entries.map((e) => ({ ...e, header: e.header || e.summary.slice(0, 60) }));
+}
+
+function parsePRHistory(): PromptEntry[] {
+  let output = '';
+  try {
+    output = execSync("git log --grep='Prompt' --grep='codex:' --no-merges --pretty=format:'%H|%cI|%s<<SEP>>'", {
+      encoding: 'utf-8',
+    });
+  } catch {
+    return [];
+  }
+  const entries: PromptEntry[] = [];
+  const parts = output.split('<<SEP>>');
+  for (const part of parts) {
+    const line = part.trim();
+    if (!line) continue;
+    const [hash, date, subject] = line.split('|');
+    entries.push({
+      source: 'pr',
+      commit: hash,
+      timestamp: date,
+      header: subject.trim(),
+      summary: subject.trim(),
+    });
+  }
+  return entries;
+}
+
+function main() {
+  const llmsPath = path.join(__dirname, '..', 'llms.txt');
+  const entries = [...parseLlms(llmsPath), ...parsePRHistory()];
+  const outPath = path.join(__dirname, '..', 'data', 'prompt-registry.json');
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify(entries, null, 2));
+  console.log(`Wrote ${entries.length} prompt entries to ${outPath}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to compile prompt headers and summaries from `llms.txt` and git history into `data/prompt-registry.json`
- introduce searchable `PromptDashboard` and route at `/codex/prompts`
- document registry structure and mark agent logs as codex registered

## Testing
- `npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/generatePromptRegistry.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68948854fca08323a75d9b9cf80a5a4a