### PR TITLE
Add concurrency limit and caching for upcoming games API

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1128,3 +1128,13 @@ Files:
 - tsconfig.json (+1/-1)
 
 
+Timestamp: 2025-08-07T21:42:33.229Z
+Commit: 6e8232a40c833aed8d01004988417d5cc2aec141
+Author: Codex
+Message: Limit concurrency and add prediction cache
+Files:
+- lib/data/liveSports.ts (+33/-5)
+- lib/flow/runFlow.ts (+10/-26)
+- pages/api/run-agents.ts (+3/-14)
+- pages/api/upcoming-games.ts (+99/-113)
+

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -1,8 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { agents } from '../../lib/agents/registry';
-import type { AgentMeta, AgentName } from '../../lib/agents/registry';
-=======
-import { registry as agentRegistry } from '../../lib/agents/registry';
+import { registry as agentRegistry, type AgentMeta, type AgentName } from '../../lib/agents/registry';
 import { AgentOutputs, Matchup, PickSummary } from '../../lib/types';
 import { logToSupabase } from '../../lib/logToSupabase';
 import { lifecycleAgent } from '../../lib/agents/lifecycleAgent';
@@ -50,7 +47,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const agentMetaMap = new Map<AgentName, AgentMeta>(
-    agents.map((a) => [a.name as AgentName, a])
+    agentRegistry.map((a) => [a.name as AgentName, a])
   );
 
   res.setHeader('Content-Type', 'text/event-stream');
@@ -105,9 +102,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (event.status === 'completed') {
           const result = agentsOutput[event.name];
           if (result) {
-
-=======
-
             const scoreTotal = result.score * (meta?.weight ?? 1);
             const confidenceEstimate = result.score;
             res.write(
@@ -186,11 +180,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const scores: Record<string, number> = { [homeTeam]: 0, [awayTeam]: 0 };
   flow.agents.forEach((name) => {
-
     const meta = agentMetaMap.get(name as AgentName);
-=======
-    const meta = agentRegistry.find((a) => a.name === name);
-
     const result = agentsOutput[name];
     if (!meta || !result) return;
     scores[result.team] += result.score * meta.weight;
@@ -212,7 +202,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     matchup,
     agentsOutput as AgentOutputs,
     pickSummary,
-    null, // Optional actualWinner for future expansion
+    null,
     flowName
   );
 
@@ -228,5 +218,4 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   );
   res.end();
 }
-
 


### PR DESCRIPTION
## Summary
- Limit game processing concurrency using p-limit
- Cache per-league predictions with short TTL
- Retry upstream API requests and surface rate limiting

## Testing
- `npm test` *(fails: Snapshot mismatch for llms.txt log)*

------
https://chatgpt.com/codex/tasks/task_e_68951bceb94483238c871de16af4d174