### PR TITLE
feat: improve dark mode styling

### DIFF
--- a/components/AgentLeaderboardPanel.tsx
+++ b/components/AgentLeaderboardPanel.tsx
@@ -23,14 +23,14 @@ const AgentLeaderboardPanel: React.FC<Props> = ({ stats }) => {
 
   if (rows.length === 0) {
     return (
-      <div className="p-4 bg-white rounded shadow text-center text-gray-600">
+      <div className="p-4 rounded shadow text-center bg-neutral-100 dark:bg-neutral-900 text-neutral-600 dark:text-neutral-400">
         No data yet
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded shadow divide-y">
+    <div className="rounded shadow divide-y divide-neutral-200 dark:divide-neutral-700 bg-neutral-100 dark:bg-neutral-900">
       {rows.map((r, idx) => (
         <div key={r.name} className="flex items-center justify-between p-2 text-sm">
           <span className="font-medium flex-1">
@@ -38,7 +38,7 @@ const AgentLeaderboardPanel: React.FC<Props> = ({ stats }) => {
           </span>
           <span className="w-24 text-right">{(r.avgConfidence * 100).toFixed(1)}%</span>
           <span className="w-24 text-right">{r.totalScore.toFixed(2)}</span>
-          <span className="w-16 text-right text-gray-500">{r.count}</span>
+          <span className="w-16 text-right text-neutral-500 dark:text-neutral-400">{r.count}</span>
         </div>
       ))}
     </div>

--- a/components/MatchupInputForm.tsx
+++ b/components/MatchupInputForm.tsx
@@ -5,6 +5,7 @@ import {
   PickSummary,
   AgentLifecycle,
 } from '../lib/types';
+import { matchupCard } from '../styles/cardStyles';
 import type { AgentExecution } from '../lib/flow/runFlow';
 
 interface SummaryPayload {
@@ -131,16 +132,19 @@ const MatchupInputForm: React.FC<Props> = ({
   return (
     <form
       onSubmit={handleSubmit}
-      className="bg-white rounded-lg shadow p-4 sm:p-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4"
+      className={`${matchupCard} grid gap-4 sm:grid-cols-2 lg:grid-cols-4`}
     >
       <div className="flex flex-col">
-        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="homeTeam">
+        <label
+          className="block text-sm font-medium mb-1 text-neutral-700 dark:text-neutral-300"
+          htmlFor="homeTeam"
+        >
           Home Team
         </label>
         <input
           id="homeTeam"
           type="text"
-          className="w-full border rounded px-3 py-2"
+          className="w-full rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-50 dark:bg-neutral-800 px-3 py-2"
           value={homeTeam}
           onChange={(e) => setHomeTeam(e.target.value)}
           disabled={loading}
@@ -148,13 +152,16 @@ const MatchupInputForm: React.FC<Props> = ({
         />
       </div>
       <div className="flex flex-col">
-        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="awayTeam">
+        <label
+          className="block text-sm font-medium mb-1 text-neutral-700 dark:text-neutral-300"
+          htmlFor="awayTeam"
+        >
           Away Team
         </label>
         <input
           id="awayTeam"
           type="text"
-          className="w-full border rounded px-3 py-2"
+          className="w-full rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-50 dark:bg-neutral-800 px-3 py-2"
           value={awayTeam}
           onChange={(e) => setAwayTeam(e.target.value)}
           disabled={loading}
@@ -162,13 +169,16 @@ const MatchupInputForm: React.FC<Props> = ({
         />
       </div>
       <div className="flex flex-col">
-        <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="week">
+        <label
+          className="block text-sm font-medium mb-1 text-neutral-700 dark:text-neutral-300"
+          htmlFor="week"
+        >
           Week
         </label>
         <input
           id="week"
           type="number"
-          className="w-full border rounded px-3 py-2"
+          className="w-full rounded border border-neutral-300 dark:border-neutral-600 bg-neutral-50 dark:bg-neutral-800 px-3 py-2"
           value={week}
           onChange={(e) => setWeek(e.target.value)}
           disabled={loading}

--- a/llms.txt
+++ b/llms.txt
@@ -1129,3 +1129,13 @@ Files:
 - pages/api/run-predictions.ts (+2/-6)
 
 
+Timestamp: 2025-08-07T21:51:59.705Z
+Commit: 832b79200e3d86bd9e7f8af22549b75223fbd993
+Author: Codex
+Message: feat: improve dark mode styling
+Files:
+- components/AgentLeaderboardPanel.tsx (+3/-3)
+- components/MatchupInputForm.tsx (+17/-7)
+- pages/predictions.tsx (+1/-1)
+- styles/cardStyles.ts (+6/-3)
+

--- a/pages/predictions.tsx
+++ b/pages/predictions.tsx
@@ -11,7 +11,7 @@ const PredictionsPage: React.FC = () => {
   const { statuses, handleLifecycleEvent, reset } = useFlowVisualizer();
 
   return (
-    <main className="min-h-screen bg-gray-50 p-6 space-y-6">
+    <main className="min-h-screen p-6 space-y-6 bg-neutral-100 dark:bg-neutral-900">
       <MatchupInputForm
         onStart={(
           _info: { homeTeam: string; awayTeam: string; week: number }

--- a/styles/cardStyles.ts
+++ b/styles/cardStyles.ts
@@ -1,3 +1,6 @@
-export const matchupCard = "bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-4 sm:p-6";
-export const agentCard = "relative p-4 bg-gray-50 rounded-xl border flex flex-col gap-2 transition-all duration-500 ease-out";
-export const agentCardSkeleton = "p-4 rounded-xl border bg-gray-100 animate-pulse";
+export const matchupCard =
+  'rounded-lg shadow-md hover:shadow-lg transition-shadow p-4 sm:p-6 bg-neutral-100 dark:bg-neutral-900';
+export const agentCard =
+  'relative p-4 rounded-xl border flex flex-col gap-2 transition-all duration-500 ease-out bg-neutral-100 dark:bg-neutral-900 border-neutral-200 dark:border-neutral-700';
+export const agentCardSkeleton =
+  'p-4 rounded-xl border animate-pulse bg-neutral-200 dark:bg-neutral-800 border-neutral-200 dark:border-neutral-700';


### PR DESCRIPTION
## Summary
- add neutral/dark theme styles to card components
- update predictions page and matchup input form for dark mode
- theme agent leaderboard panel and share card styles

## Testing
- `npm test` *(fails: snapshot mismatch and merge conflict in run-agents API)*

------
https://chatgpt.com/codex/tasks/task_e_68951ef48738832380e331b8d834ad32