### PR TITLE
Surface agent metadata in predictions

### DIFF
--- a/components/MatchupInputForm.tsx
+++ b/components/MatchupInputForm.tsx
@@ -5,7 +5,12 @@ import {
   PickSummary,
   AgentLifecycle,
 } from '../lib/types';
-import type { AgentExecution } from '../lib/flow/runFlow';
+import type { AgentExecution as BaseAgentExecution } from '../lib/flow/runFlow';
+
+interface AgentExecution extends BaseAgentExecution {
+  weight?: number;
+  description?: string;
+}
 
 interface SummaryPayload {
   matchup: Matchup;
@@ -64,10 +69,12 @@ const MatchupInputForm: React.FC<Props> = ({
             name: data.name,
             result: data.result,
             error: data.error,
+            weight: data.weight,
             scoreTotal: data.scoreTotal,
             confidenceEstimate: data.confidenceEstimate,
             agentDurationMs: data.agentDurationMs,
             sessionId: data.sessionId,
+            description: data.description,
           });
         } else if (data.type === 'lifecycle') {
           onLifecycle(data as { name: string } & AgentLifecycle);

--- a/components/PredictionsPanel.tsx
+++ b/components/PredictionsPanel.tsx
@@ -37,7 +37,25 @@ const PredictionsPanel: React.FC<Props> = ({ agents, pick, statuses }) => {
                   <span className="font-medium">{name}</span>
                   <span className="text-xs text-gray-400">{status}</span>
                 </div>
-                <p className="text-sm text-gray-300">{result.reason}</p>
+                {result.description && (
+                  <p className="text-xs text-gray-400 mb-1">
+                    {result.description}
+                  </p>
+                )}
+                <p className="text-sm text-gray-300 mb-1">{result.reason}</p>
+                <div className="text-xs text-gray-400 flex flex-wrap gap-2">
+                  {typeof result.weight !== 'undefined' && (
+                    <span>Weight: {result.weight}</span>
+                  )}
+                  {typeof result.scoreTotal !== 'undefined' && (
+                    <span>Score: {result.scoreTotal.toFixed(2)}</span>
+                  )}
+                  {typeof result.confidenceEstimate !== 'undefined' && (
+                    <span>
+                      Confidence: {(result.confidenceEstimate * 100).toFixed(0)}%
+                    </span>
+                  )}
+                </div>
               </li>
             );
           })}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,6 +34,10 @@ export interface AgentResult {
   reason: string;
   warnings?: string[];
   reflection?: AgentReflection;
+  weight?: number;
+  scoreTotal?: number;
+  confidenceEstimate?: number;
+  description?: string;
 }
 
 export interface AgentReflection {

--- a/llms.txt
+++ b/llms.txt
@@ -1129,3 +1129,13 @@ Files:
 - pages/api/run-predictions.ts (+2/-6)
 
 
+Timestamp: 2025-08-07T21:55:11.690Z
+Commit: 224ead48664e8c51ed0ca94f278f355eb5383a4d
+Author: Codex
+Message: Expose agent metadata in predictions
+Files:
+- components/MatchupInputForm.tsx (+8/-1)
+- components/PredictionsPanel.tsx (+19/-1)
+- lib/types.ts (+4/-0)
+- pages/index.tsx (+18/-2)
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,12 @@ import LiveGameLogsPanel from '../components/LiveGameLogsPanel';
 import AgentStatusPanel from '../components/AgentStatusPanel';
 import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
 import type { AgentOutputs, PickSummary } from '../lib/types';
-import type { AgentExecution } from '../lib/flow/runFlow';
+import type { AgentExecution as BaseAgentExecution } from '../lib/flow/runFlow';
+
+interface AgentExecution extends BaseAgentExecution {
+  weight?: number;
+  description?: string;
+}
 
 export default function Home() {
   const [agents, setAgents] = useState<AgentOutputs>({});
@@ -56,7 +61,16 @@ export default function Home() {
       return updated;
     });
     if (exec.result) {
-      setAgents((prev) => ({ ...prev, [exec.name]: exec.result }));
+      setAgents((prev) => ({
+        ...prev,
+        [exec.name]: {
+          ...exec.result,
+          weight: exec.weight,
+          scoreTotal: exec.scoreTotal,
+          confidenceEstimate: exec.confidenceEstimate,
+          description: exec.description,
+        },
+      }));
     }
     if (exec.sessionId) {
       setLeaderboard((prev) => {
@@ -106,10 +120,12 @@ export default function Home() {
             name: data.name,
             result: data.result,
             error: data.error,
+            weight: data.weight,
             scoreTotal: data.scoreTotal,
             confidenceEstimate: data.confidenceEstimate,
             agentDurationMs: data.agentDurationMs,
             sessionId: data.sessionId,
+            description: data.description,
           });
         } else if (data.type === 'lifecycle') {
           handleLifecycleEvent(data);


### PR DESCRIPTION
## Summary
- forward agent weight, score totals, confidence, and descriptions through SSE handler
- display agent metadata alongside each reason in predictions panel
- store additional agent fields in state for retry flows

## Testing
- `npm test` *(fails: merge conflict marker in pages/api/run-agents.ts, snapshot mismatch in llmsLog.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68951f5097ac8323a0160c6b78e4c733