### PR TITLE
feat: add upcoming games flow with prediction drawer

### DIFF
--- a/__tests__/LandingDeepLink.test.tsx
+++ b/__tests__/LandingDeepLink.test.tsx
@@ -1,0 +1,49 @@
+import { render, waitFor, screen } from '@testing-library/react';
+import React from 'react';
+import Home from '../pages/index';
+
+jest.mock('../components/PickSummary', () => () => <div />);
+jest.mock('../components/AgentNodeGraph', () => () => <div />);
+jest.mock('../components/AgentRationalePanel', () => () => <div />);
+jest.mock('../components/ConfidenceMeter', () => () => <div />);
+
+jest.mock('next/router', () => ({
+  useRouter() {
+    return { push: jest.fn(), query: { league: 'NFL', gameId: '1' } } as any;
+  },
+}));
+
+describe('Landing deep link', () => {
+  const originalFetch = global.fetch;
+  const originalES = global.EventSource;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: { randomUUID: () => 'uuid' },
+      configurable: true,
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => [
+        {
+          gameId: '1',
+          league: 'NFL',
+          homeTeam: { name: 'A' },
+          awayTeam: { name: 'B' },
+          time: new Date().toISOString(),
+        },
+      ],
+    }) as any;
+    (global as any).EventSource = jest.fn(() => ({ close: jest.fn() }));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    (global as any).EventSource = originalES;
+  });
+
+  it('opens drawer and auto starts run', async () => {
+    render(<Home />);
+    await waitFor(() => expect(global.EventSource).toHaveBeenCalled());
+    expect(await screen.findByText('A vs B')).toBeInTheDocument();
+  });
+});

--- a/__tests__/PredictionDrawer.sse.test.tsx
+++ b/__tests__/PredictionDrawer.sse.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import PredictionDrawer from '../components/PredictionDrawer';
+import type { Game } from '../lib/types';
+
+jest.mock('../components/PickSummary', () => () => <div />);
+jest.mock('../components/AgentNodeGraph', () => () => <div />);
+jest.mock('../components/AgentRationalePanel', () => () => <div />);
+jest.mock('../components/ConfidenceMeter', () => () => <div />);
+
+class MockEventSource {
+  onmessage: ((ev: any) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = jest.fn();
+  emit(data: any) {
+    this.onmessage && this.onmessage({ data: JSON.stringify(data) });
+  }
+}
+
+describe('PredictionDrawer SSE', () => {
+  const originalES = global.EventSource;
+
+  beforeEach(() => {
+    Object.defineProperty(global, 'crypto', {
+      value: { randomUUID: () => 'uuid' },
+      configurable: true,
+    });
+    (global as any).EventSource = jest.fn(() => new MockEventSource());
+  });
+
+  afterEach(() => {
+    (global as any).EventSource = originalES;
+  });
+
+  it('processes events and announces final pick', () => {
+    const game: Game = {
+      gameId: '1',
+      league: 'NFL',
+      homeTeam: 'A',
+      awayTeam: 'B',
+      time: new Date().toISOString(),
+    };
+    render(<PredictionDrawer game={game} isOpen={true} onClose={() => {}} />);
+    const esInstance = (global.EventSource as jest.Mock).mock.results[0].value as MockEventSource;
+    act(() => {
+      esInstance.emit({
+        type: 'agent',
+        name: 'injuryScout',
+        result: { team: 'A', score: 0.7, reason: 'ok' },
+        confidenceEstimate: 0.7,
+      });
+      esInstance.emit({
+        type: 'summary',
+        pick: { winner: 'A', confidence: 0.7, topReasons: ['ok'] },
+      });
+    });
+    expect(screen.getByTestId('a11y-result').textContent).toContain('A');
+  });
+});

--- a/__tests__/UpcomingGamesGrid.test.tsx
+++ b/__tests__/UpcomingGamesGrid.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import UpcomingGamesGrid from '../components/UpcomingGamesGrid';
+import type { Game } from '../lib/types';
+
+const games: Game[] = [
+  {
+    gameId: '1',
+    league: 'NFL',
+    homeTeam: 'Lakers',
+    awayTeam: 'Celtics',
+    time: new Date().toISOString(),
+  },
+  {
+    gameId: '2',
+    league: 'NFL',
+    homeTeam: 'Bulls',
+    awayTeam: 'Heat',
+    time: new Date().toISOString(),
+  },
+];
+
+describe('UpcomingGamesGrid', () => {
+  it('filters by search and handles click', () => {
+    const onSelect = jest.fn();
+    render(<UpcomingGamesGrid games={games} search="lake" onSelect={onSelect} />);
+    expect(screen.getByText('Lakers')).toBeInTheDocument();
+    expect(screen.queryByText('Bulls')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Lakers'));
+    expect(onSelect).toHaveBeenCalled();
+  });
+});

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms.txt log matches content hash snapshot 1`] = `"b45d41f86470059b8364295fb27162c0e5f44792e2646786427d758bea6ecd4d"`;
+exports[`llms.txt log matches content hash snapshot 1`] = `"2f63bd248fe78985c01fb947032240e3cd53ad6739a3f92c8a5f0e95de38f66a"`;

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { Game } from '../lib/types';
+
+interface Props {
+  game: Game;
+  onClick: (game: Game) => void;
+}
+
+function formatRelative(time: string): string {
+  const target = new Date(time).getTime();
+  const diffMs = target - Date.now();
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin <= 0) return 'started';
+  if (diffMin < 60) return `in ${diffMin}m`;
+  const hours = Math.floor(diffMin / 60);
+  return `in ${hours}h`;
+}
+
+const GameCard: React.FC<Props> = ({ game, onClick }) => {
+  const kickoff = formatRelative(game.time);
+  return (
+    <div
+      onClick={() => onClick(game)}
+      className="cursor-pointer p-4 bg-white rounded shadow hover:shadow-lg transition-transform hover:-translate-y-1"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          {game.homeLogo && (
+            <img src={game.homeLogo} alt="" className="w-6 h-6" />
+          )}
+          <span>{game.homeTeam}</span>
+        </div>
+        <span className="text-gray-500">vs</span>
+        <div className="flex items-center gap-2">
+          {game.awayLogo && (
+            <img src={game.awayLogo} alt="" className="w-6 h-6" />
+          )}
+          <span>{game.awayTeam}</span>
+        </div>
+      </div>
+      <div className="text-sm text-gray-600">{kickoff}</div>
+      {game.odds && (
+        <div className="text-xs text-gray-500 mt-1 flex gap-2">
+          {game.odds.spread !== undefined && <span>Spr {game.odds.spread}</span>}
+          {game.odds.overUnder !== undefined && <span>O/U {game.odds.overUnder}</span>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GameCard;

--- a/components/UpcomingGamesGrid.tsx
+++ b/components/UpcomingGamesGrid.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { Game } from '../lib/types';
+import GameCard from './GameCard';
+
+interface Props {
+  games: Game[];
+  search?: string;
+  onSelect: (game: Game) => void;
+}
+
+const UpcomingGamesGrid: React.FC<Props> = ({ games, search = '', onSelect }) => {
+  const filtered = games.filter((g) => {
+    const q = search.toLowerCase();
+    return (
+      g.homeTeam.toLowerCase().includes(q) ||
+      g.awayTeam.toLowerCase().includes(q)
+    );
+  });
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {filtered.map((game) => (
+        <GameCard key={game.gameId} game={game} onClick={onSelect} />
+      ))}
+    </div>
+  );
+};
+
+export default UpcomingGamesGrid;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,21 @@
+export interface Game {
+  gameId: string;
+  league: 'NFL' | 'NBA' | 'MLB' | 'NHL';
+  homeTeam: string;
+  awayTeam: string;
+  time: string; // ISO
+  homeLogo?: string;
+  awayLogo?: string;
+  odds?: {
+    spread?: number;
+    overUnder?: number;
+    moneyline?: { home?: number; away?: number };
+    bookmaker?: string;
+    lastUpdate?: string;
+  };
+  source?: 'live-nfl-api' | 'live-nba-api' | 'fallback' | 'mock';
+}
+
 export interface Matchup {
   homeTeam: string;
   awayTeam: string;

--- a/llms.txt
+++ b/llms.txt
@@ -1178,3 +1178,19 @@ Files:
 - lib/flow/runFlow.ts (+21/-13)
 - pages/api/run-agents.ts (+20/-177)
 
+Timestamp: 2025-08-07T22:30:19.786Z
+Commit: 48daa7411a456d31ae427258b95c5e15b41eea09
+Author: Codex
+Message: feat: add upcoming games flow with prediction drawer
+Files:
+- __tests__/LandingDeepLink.test.tsx (+49/-0)
+- __tests__/PredictionDrawer.sse.test.tsx (+59/-0)
+- __tests__/UpcomingGamesGrid.test.tsx (+32/-0)
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- components/GameCard.tsx (+52/-0)
+- components/PredictionDrawer.tsx (+139/-0)
+- components/UpcomingGamesGrid.tsx (+28/-0)
+- lib/types.ts (+18/-0)
+- pages/api/upcoming-games.ts (+6/-0)
+- pages/index.tsx (+85/-139)
+

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -16,6 +16,7 @@ const CONCURRENCY_LIMIT = 3;
 const CACHE_TTL_MS = 60_000; // cache results for one minute
 
 type Result = {
+  gameId: string;
   homeTeam: { name: string; logo?: string };
   awayTeam: { name: string; logo?: string };
   confidence: number;
@@ -129,7 +130,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 true
               );
 
+              const derivedId =
+                game.gameId ||
+                `${game.league}:${game.homeTeam}:${game.awayTeam}:${game.time}`;
+
               const result: Result = {
+                gameId: derivedId,
                 homeTeam: { name: game.homeTeam, logo: game.homeLogo },
                 awayTeam: { name: game.awayTeam, logo: game.awayLogo },
                 confidence,


### PR DESCRIPTION
## Summary
- add `Game` type and ensure upcoming games API supplies a unique `gameId`
- show league-filterable upcoming games grid with search
- introduce prediction drawer that streams agent results and announces final pick

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895270dfea88323a52ca9fe131ce2f7