### PR TITLE
Polish landing journey with dynamic drawer and SSE hook

### DIFF
--- a/__tests__/LandingDeepLink.test.tsx
+++ b/__tests__/LandingDeepLink.test.tsx
@@ -46,4 +46,12 @@ describe('Landing deep link', () => {
     await waitFor(() => expect(global.EventSource).toHaveBeenCalled());
     expect(await screen.findByText('A vs B')).toBeInTheDocument();
   });
+
+  it('deep link with unknown gameId shows not found state', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ json: async () => [] });
+    render(<Home />);
+    expect(
+      await screen.findByText('Game not found.')
+    ).toBeInTheDocument();
+  });
 });

--- a/__tests__/PredictionDrawer.sse.test.tsx
+++ b/__tests__/PredictionDrawer.sse.test.tsx
@@ -19,6 +19,7 @@ class MockEventSource {
 
 describe('PredictionDrawer SSE', () => {
   const originalES = global.EventSource;
+  const originalFetch = global.fetch;
 
   beforeEach(() => {
     Object.defineProperty(global, 'crypto', {
@@ -26,10 +27,12 @@ describe('PredictionDrawer SSE', () => {
       configurable: true,
     });
     (global as any).EventSource = jest.fn(() => new MockEventSource());
+    global.fetch = jest.fn().mockResolvedValue({});
   });
 
   afterEach(() => {
     (global as any).EventSource = originalES;
+    global.fetch = originalFetch as any;
   });
 
   it('processes events and announces final pick', () => {

--- a/__tests__/UpcomingGamesGrid.test.tsx
+++ b/__tests__/UpcomingGamesGrid.test.tsx
@@ -21,6 +21,13 @@ const games: Game[] = [
 ];
 
 describe('UpcomingGamesGrid', () => {
+  it('shows skeletons', () => {
+    render(
+      <UpcomingGamesGrid games={[]} isLoading onSelect={jest.fn()} />
+    );
+    expect(screen.getAllByTestId('game-skeleton').length).toBe(6);
+  });
+
   it('filters by search and handles click', () => {
     const onSelect = jest.fn();
     render(<UpcomingGamesGrid games={games} search="lake" onSelect={onSelect} />);
@@ -28,5 +35,19 @@ describe('UpcomingGamesGrid', () => {
     expect(screen.queryByText('Bulls')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Lakers'));
     expect(onSelect).toHaveBeenCalled();
+  });
+
+  it('error retry calls fetch again', () => {
+    const onRetry = jest.fn();
+    render(
+      <UpcomingGamesGrid
+        games={[]}
+        isError
+        onRetry={onRetry}
+        onSelect={jest.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText('Retry'));
+    expect(onRetry).toHaveBeenCalled();
   });
 });

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms.txt log matches content hash snapshot 1`] = `"2f63bd248fe78985c01fb947032240e3cd53ad6739a3f92c8a5f0e95de38f66a"`;
+exports[`llms.txt log matches content hash snapshot 1`] = `"045803737ba8d833490f657c45abdcc1041c86f208490284981cd90326f955f5"`;

--- a/__tests__/useEventSource.test.ts
+++ b/__tests__/useEventSource.test.ts
@@ -1,0 +1,32 @@
+import { renderHook, act } from '@testing-library/react';
+import useEventSource from '../lib/hooks/useEventSource';
+
+describe('useEventSource', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    class MockES {
+      onmessage: ((ev: any) => void) | null = null;
+      onerror: ((ev: any) => void) | null = null;
+      close = jest.fn();
+    }
+    (global as any).EventSource = jest.fn(() => new MockES());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('retries with backoff and cleans up on unmount', () => {
+    const { unmount } = renderHook(() => useEventSource('/sse'));
+    const esInstance = (global.EventSource as jest.Mock).mock.results[0].value as any;
+    act(() => {
+      esInstance.onerror(new Event('error'));
+    });
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(global.EventSource).toHaveBeenCalledTimes(2);
+    unmount();
+    expect(esInstance.close).toHaveBeenCalled();
+  });
+});

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import Image from 'next/image';
 import type { Game } from '../lib/types';
 
 interface Props {
   game: Game;
   onClick: (game: Game) => void;
+  onHover?: () => void;
 }
 
 function formatRelative(time: string): string {
@@ -16,36 +18,73 @@ function formatRelative(time: string): string {
   return `in ${hours}h`;
 }
 
-const GameCard: React.FC<Props> = ({ game, onClick }) => {
+const GameCard: React.FC<Props> = ({ game, onClick, onHover }) => {
   const kickoff = formatRelative(game.time);
+  const hoverRef = useRef<NodeJS.Timeout>();
+
+  const handleEnter = () => {
+    hoverRef.current = setTimeout(() => onHover?.(), 200);
+  };
+
+  const handleLeave = () => {
+    if (hoverRef.current) clearTimeout(hoverRef.current);
+  };
+
+  const kickoffLabel = new Date(game.time).toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
   return (
-    <div
+    <button
       onClick={() => onClick(game)}
-      className="cursor-pointer p-4 bg-white rounded shadow hover:shadow-lg transition-transform hover:-translate-y-1"
+      onMouseEnter={handleEnter}
+      onFocus={handleEnter}
+      onMouseLeave={handleLeave}
+      onBlur={handleLeave}
+      className="text-left w-full p-4 bg-white rounded shadow transition-transform hover:-translate-y-1 hover:shadow-lg focus:outline focus:outline-2 focus:outline-blue-500"
+      aria-label={`Analyze ${game.homeTeam} vs ${game.awayTeam} kickoff ${kickoffLabel}`}
     >
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           {game.homeLogo && (
-            <img src={game.homeLogo} alt="" className="w-6 h-6" />
+            <Image src={game.homeLogo} alt="" width={24} height={24} />
           )}
           <span>{game.homeTeam}</span>
         </div>
         <span className="text-gray-500">vs</span>
         <div className="flex items-center gap-2">
           {game.awayLogo && (
-            <img src={game.awayLogo} alt="" className="w-6 h-6" />
+            <Image src={game.awayLogo} alt="" width={24} height={24} />
           )}
           <span>{game.awayTeam}</span>
         </div>
       </div>
       <div className="text-sm text-gray-600">{kickoff}</div>
-      {game.odds && (
-        <div className="text-xs text-gray-500 mt-1 flex gap-2">
-          {game.odds.spread !== undefined && <span>Spr {game.odds.spread}</span>}
-          {game.odds.overUnder !== undefined && <span>O/U {game.odds.overUnder}</span>}
+      {game.odds ? (
+        <div className="text-xs text-gray-600 mt-1 flex gap-2">
+          {game.odds.spread !== undefined && (
+            <span className="px-1 bg-gray-100 rounded" title="Spread">
+              {game.homeTeam.slice(0, 3).toUpperCase()} {game.odds.spread}
+            </span>
+          )}
+          {game.odds.overUnder !== undefined && (
+            <span className="px-1 bg-gray-100 rounded" title="Over/Under">
+              O/U {game.odds.overUnder}
+            </span>
+          )}
+          {game.odds.moneyline && (
+            <span className="px-1 bg-gray-100 rounded" title="Moneyline">
+              ML {game.odds.moneyline.home ?? ''}
+              {game.odds.moneyline.home && game.odds.moneyline.away ? ' / ' : ''}
+              {game.odds.moneyline.away ?? ''}
+            </span>
+          )}
         </div>
+      ) : (
+        <div className="text-xs text-gray-400 mt-1">No odds yet</div>
       )}
-    </div>
+    </button>
   );
 };
 

--- a/components/UpcomingGamesGrid.tsx
+++ b/components/UpcomingGamesGrid.tsx
@@ -6,9 +6,21 @@ interface Props {
   games: Game[];
   search?: string;
   onSelect: (game: Game) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+  preload?: () => void;
 }
 
-const UpcomingGamesGrid: React.FC<Props> = ({ games, search = '', onSelect }) => {
+const UpcomingGamesGrid: React.FC<Props> = ({
+  games,
+  search = '',
+  onSelect,
+  isLoading,
+  isError,
+  onRetry,
+  preload,
+}) => {
   const filtered = games.filter((g) => {
     const q = search.toLowerCase();
     return (
@@ -16,10 +28,48 @@ const UpcomingGamesGrid: React.FC<Props> = ({ games, search = '', onSelect }) =>
       g.awayTeam.toLowerCase().includes(q)
     );
   });
+  if (isError) {
+    return (
+      <div className="p-4 text-center" data-testid="error-panel">
+        <p className="mb-2">Failed to load games.</p>
+        <button className="px-3 py-1 border rounded" onClick={onRetry}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-24 bg-gray-200 rounded animate-pulse"
+            data-testid="game-skeleton"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <div className="p-4 text-center text-gray-500" data-testid="empty-state">
+        No games found
+      </div>
+    );
+  }
+
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {filtered.map((game) => (
-        <GameCard key={game.gameId} game={game} onClick={onSelect} />
+        <GameCard
+          key={game.gameId}
+          game={game}
+          onClick={onSelect}
+          onHover={preload}
+        />
       ))}
     </div>
   );

--- a/lib/hooks/useEventSource.ts
+++ b/lib/hooks/useEventSource.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface HookState<T = any> {
+  status: 'idle' | 'connecting' | 'open' | 'error';
+  events: T[];
+  lastMessage: T | null;
+  error: Event | null;
+  reconnect: () => void;
+}
+
+export default function useEventSource(url: string | null): HookState {
+  const [events, setEvents] = useState<any[]>([]);
+  const [lastMessage, setLastMessage] = useState<any | null>(null);
+  const [status, setStatus] = useState<'idle' | 'connecting' | 'open' | 'error'>('idle');
+  const [error, setError] = useState<Event | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+  const retryRef = useRef(0);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  const connect = () => {
+    if (!url) return;
+    setStatus('connecting');
+    const es = new EventSource(url);
+    es.onmessage = (ev) => {
+      const data = JSON.parse(ev.data);
+      setEvents((prev) => [...prev, data]);
+      setLastMessage(data);
+      setStatus('open');
+      retryRef.current = 0;
+    };
+    es.onerror = (e) => {
+      setStatus('error');
+      setError(e as any);
+      es.close();
+      if (retryRef.current < 5) {
+        const delay = Math.min(1000, 250 * Math.pow(2, retryRef.current));
+        retryRef.current += 1;
+        timeoutRef.current = setTimeout(connect, delay);
+      }
+    };
+    esRef.current = es;
+  };
+
+  const reconnect = () => {
+    retryRef.current = 0;
+    esRef.current?.close();
+    connect();
+  };
+
+  useEffect(() => {
+    if (url) {
+      reconnect();
+    }
+    return () => {
+      esRef.current?.close();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url]);
+
+  return { status, events, lastMessage, error, reconnect };
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1194,3 +1194,20 @@ Files:
 - pages/api/upcoming-games.ts (+6/-0)
 - pages/index.tsx (+85/-139)
 
+Timestamp: 2025-08-07T22:46:58.981Z
+Commit: 31f4dffae486f5b692a96277bb0a799d11083d5b
+Author: Codex
+Message: feat: polish landing journey with dynamic drawer and sse hook
+Files:
+- __tests__/LandingDeepLink.test.tsx (+8/-0)
+- __tests__/PredictionDrawer.sse.test.tsx (+3/-0)
+- __tests__/UpcomingGamesGrid.test.tsx (+21/-0)
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/useEventSource.test.ts (+32/-0)
+- components/GameCard.tsx (+50/-11)
+- components/PredictionDrawer.tsx (+73/-42)
+- components/UpcomingGamesGrid.tsx (+52/-2)
+- lib/hooks/useEventSource.ts (+62/-0)
+- next.config.js (+5/-0)
+- pages/index.tsx (+63/-6)
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  images: {
+    domains: ['a.espncdn.com', 'i.espncdn.com', 'static.nfl.com', 's.yimg.com'],
+  },
+};


### PR DESCRIPTION
## Summary
- replace image tags with next/image and show odds badges on game cards
- add skeleton/empty/error states and prefetch handling to upcoming games grid
- switch prediction drawer to reusable SSE hook with share button and disabled state
- persist league selection, support deep-link not-found messaging, and configure image domains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689529f0c994832388321afa7126a494