### PR TITLE
DocSync: fail-open mode that files GitHub issues on sync errors

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,3 +10,6 @@ SPORTS_DB_NFL_ID=
 SPORTS_DB_MLB_ID=
 SPORTS_DB_NBA_ID=
 SPORTS_DB_NHL_ID=
+# DocSync fail-open (optional)
+# GITHUB_TOKEN=ghp_xxx
+# GITHUB_REPOSITORY=owner/repo

--- a/.env.local.example
+++ b/.env.local.example
@@ -10,3 +10,6 @@ SPORTS_DB_NFL_ID=<thesportsdb-nfl-league-id>
 SPORTS_DB_MLB_ID=<thesportsdb-mlb-league-id>
 SPORTS_DB_NBA_ID=<thesportsdb-nba-league-id>
 SPORTS_DB_NHL_ID=<thesportsdb-nhl-league-id>
+# DocSync fail-open (optional)
+# GITHUB_TOKEN=ghp_xxx
+# GITHUB_REPOSITORY=owner/repo

--- a/.env.production
+++ b/.env.production
@@ -10,3 +10,6 @@ SPORTS_DB_NFL_ID=
 SPORTS_DB_MLB_ID=
 SPORTS_DB_NBA_ID=
 SPORTS_DB_NHL_ID=
+# DocSync fail-open (optional)
+# GITHUB_TOKEN=ghp_xxx
+# GITHUB_REPOSITORY=owner/repo

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms.txt log matches content hash snapshot 1`] = `"2f63bd248fe78985c01fb947032240e3cd53ad6739a3f92c8a5f0e95de38f66a"`;
+exports[`llms.txt log matches content hash snapshot 1`] = `"045803737ba8d833490f657c45abdcc1041c86f208490284981cd90326f955f5"`;

--- a/__tests__/docsync.failopen.test.ts
+++ b/__tests__/docsync.failopen.test.ts
@@ -1,0 +1,55 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { run } from "../scripts/docsync-agent";
+
+jest.mock("../github/api", () => ({
+  createIssue: jest.fn().mockResolvedValue({
+    html_url: "https://github.com/o/r/issues/1",
+  }),
+}));
+
+const { createIssue } = require("../github/api");
+
+describe("docsync fail-open", () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = process.cwd();
+  });
+  afterEach(() => {
+    process.chdir(cwd);
+    jest.clearAllMocks();
+  });
+
+  it("dry run skips API call and logs DRY RUN", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docsync-"));
+    fs.writeFileSync(path.join(tmp, "agentLogsStore.json"), "[]");
+    process.chdir(tmp);
+    process.argv = ["node", "scripts/docsync-agent.ts", "--fail-open", "--dry-run"];
+    await run();
+    expect(createIssue).not.toHaveBeenCalled();
+    const logs = JSON.parse(fs.readFileSync("agentLogsStore.json", "utf8"));
+    const entry = logs.find((l: any) => l.type === "github_issue");
+    expect(entry.issueUrl).toBe("DRY_RUN");
+  });
+
+  it("opens issue when fail-open", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docsync-"));
+    fs.writeFileSync(path.join(tmp, "agentLogsStore.json"), "[]");
+    process.chdir(tmp);
+    process.argv = ["node", "scripts/docsync-agent.ts", "--fail-open"];
+    await run();
+    expect(createIssue).toHaveBeenCalledTimes(1);
+    const logs = JSON.parse(fs.readFileSync("agentLogsStore.json", "utf8"));
+    const entry = logs.find((l: any) => l.type === "github_issue");
+    expect(entry.issueUrl).toBe("https://github.com/o/r/issues/1");
+  });
+
+  it("throws when fail-open not provided", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docsync-"));
+    fs.writeFileSync(path.join(tmp, "agentLogsStore.json"), "[]");
+    process.chdir(tmp);
+    process.argv = ["node", "scripts/docsync-agent.ts"];
+    await expect(run()).rejects.toThrow();
+  });
+});

--- a/__tests__/github.api.test.ts
+++ b/__tests__/github.api.test.ts
@@ -1,0 +1,34 @@
+import { createIssue } from "../github/api";
+
+describe("createIssue", () => {
+  afterEach(() => {
+    // @ts-ignore
+    delete global.fetch;
+    delete process.env.GITHUB_TOKEN;
+  });
+
+  it("calls fetch with correct params", async () => {
+    process.env.GITHUB_TOKEN = "t";
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ html_url: "https://github.com/o/r/issues/1" }),
+    } as any);
+    (global as any).fetch = fetchMock;
+    await createIssue({ repo: "o/r", title: "t", body: "b", labels: ["l"] });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/o/r/issues",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer t",
+        }),
+      })
+    );
+  });
+
+  it("throws without token", async () => {
+    await expect(
+      createIssue({ repo: "o/r", title: "t", body: "b" })
+    ).rejects.toThrow("GITHUB_TOKEN is required to create issues");
+  });
+});

--- a/docs/docsync-strategy.md
+++ b/docs/docsync-strategy.md
@@ -17,3 +17,24 @@ external services are unavailable. Failed sync attempts are written to
 2. Run `npx ts-node scripts/docsync-agent.ts` for a real sync.
 3. If a sync fails, execute `npx ts-node scripts/retry-docsync.ts` once the
    environment is fixed to replay missed jobs.
+
+## Fail-Open Mode
+
+Running DocSync with `--fail-open` allows pipelines to continue even when
+syncing fails. The script opens a GitHub issue and exits with code 0 instead of
+halting.
+
+```bash
+npx ts-node scripts/docsync-agent.ts --fail-open
+```
+
+- `--dry-run` skips the actual GitHub API call and prints the issue it would
+  create.
+- `--repo owner/name` overrides `GITHUB_REPOSITORY` for issue creation.
+
+The issue title follows `[DocSync Failure] <logId> @ <timestamp>` and the body
+includes the error stack, commit SHA, and log ID. Set `GITHUB_TOKEN` and
+`GITHUB_REPOSITORY` in the environment when using fail-open.
+
+> **Security:** The token only needs `repo` scope to create issues. Keep it
+> secret and scoped to the target repository.

--- a/github/api.ts
+++ b/github/api.ts
@@ -1,0 +1,39 @@
+export async function createIssue({
+  repo,
+  title,
+  body,
+  labels = [],
+}: {
+  repo?: string;
+  title: string;
+  body: string;
+  labels?: string[];
+}) {
+  const repository = repo || process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    throw new Error("No repo provided. Set --repo or GITHUB_REPOSITORY");
+  }
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("GITHUB_TOKEN is required to create issues");
+  }
+  const [owner, name] = repository.split("/");
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${name}/issues`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ title, body, labels }),
+    }
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub createIssue failed: ${res.status} ${text}`);
+  }
+  const json = await res.json();
+  return { html_url: json.html_url as string };
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -10,3 +10,4 @@ process.env.SPORTS_API_KEY = 'sports-key';
 process.env.LIVE_MODE = 'on';
 process.env.PREDICTION_CACHE_TTL_SEC = '120';
 process.env.MAX_FLOW_CONCURRENCY = '3';
+process.env.GITHUB_REPOSITORY = 'owner/repo';

--- a/scripts/docsync-agent.ts
+++ b/scripts/docsync-agent.ts
@@ -1,6 +1,8 @@
 import { Octokit } from "@octokit/rest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import fs from "fs";
+import crypto from "crypto";
+import { createIssue } from "../github/api";
 
 export interface CodexLog {
   id: string;
@@ -108,34 +110,38 @@ export async function syncLogRecord(
   await supabase.from("codex_logs").update({ synced: true }).eq("id", log.id);
 }
 
-export async function run() {
+function appendAgentLog(entry: any) {
+  try {
+    const path = "agentLogsStore.json";
+    const existing = fs.existsSync(path)
+      ? JSON.parse(fs.readFileSync(path, "utf8"))
+      : [];
+    const arr = Array.isArray(existing) ? existing : [];
+    arr.push(entry);
+    fs.writeFileSync(path, JSON.stringify(arr, null, 2));
+  } catch (err) {
+    console.error("Failed to write agent log", err);
+  }
+}
+
+export async function runDocSync() {
   const dryRun = process.argv.includes("--dry-run");
   if (dryRun) {
     console.log("DocSync running in dry-run mode. No external calls will be made.");
-    return;
   }
 
   const logFailure = (message: string) => {
-    try {
-      const path = "agentLogsStore.json";
-      const existing = fs.existsSync(path)
-        ? JSON.parse(fs.readFileSync(path, "utf8"))
-        : [];
-      existing.push({
-        timestamp: new Date().toISOString(),
-        command: "npx ts-node scripts/docsync-agent.ts",
-        output: message,
-        synced: false,
-        syncAttemptedAt: new Date().toISOString(),
-        syncError: message,
-        architectureDocumented: true,
-        lifecycleDocumented: true,
-        designPatternsDocumented: true,
-      });
-      fs.writeFileSync(path, JSON.stringify(existing, null, 2));
-    } catch (err) {
-      console.error("Failed to write agent log", err);
-    }
+    appendAgentLog({
+      timestamp: new Date().toISOString(),
+      command: "npx ts-node scripts/docsync-agent.ts",
+      output: message,
+      synced: false,
+      syncAttemptedAt: new Date().toISOString(),
+      syncError: message,
+      architectureDocumented: true,
+      lifecycleDocumented: true,
+      designPatternsDocumented: true,
+    });
   };
 
   const requiredEnv = [
@@ -150,11 +156,15 @@ export async function run() {
       const msg = `${key} is required.`;
       console.error(msg);
       logFailure(msg);
-      return;
+      const err = new Error(msg);
+      throw err;
     }
   }
 
   try {
+    if (dryRun) {
+      return;
+    }
     const { createClient } = await import("@supabase/supabase-js");
     const supabase = createClient(
       process.env.SUPABASE_URL!,
@@ -178,6 +188,8 @@ export async function run() {
           const msg = `log #${log.id} failed: ${err?.message || err}`;
           console.error(msg);
           logFailure(msg);
+          err.logId = log.id;
+          throw err;
         }
       }
     }
@@ -185,6 +197,48 @@ export async function run() {
     const msg = err?.message || String(err);
     console.error(msg);
     logFailure(msg);
+    throw err;
+  }
+}
+
+export async function run() {
+  const argv = process.argv.slice(2);
+  const failOpen = argv.includes("--fail-open");
+  const dryRun = argv.includes("--dry-run");
+  const repoIdx = argv.indexOf("--repo");
+  const repoArg = repoIdx >= 0 ? argv[repoIdx + 1] : undefined;
+
+  try {
+    await runDocSync();
+  } catch (err: any) {
+    if (!failOpen) {
+      throw err;
+    }
+    const logId = err?.logId || crypto.randomUUID();
+    const title = `[DocSync Failure] ${logId} @ ${new Date().toISOString()}`;
+    const sha = process.env.VERCEL_GIT_COMMIT_SHA || "";
+    const body = `Error Stack:\n\n${err.stack || err}\n\nLog ID: ${logId}\nCommit SHA: ${sha}`;
+    let issueUrl = "DRY_RUN";
+    if (dryRun) {
+      console.warn(`DRY RUN: would open issue for ${logId}`);
+    } else {
+      const { html_url } = await createIssue({
+        repo: repoArg,
+        title,
+        body,
+        labels: ["docsync", "automated"],
+      });
+      issueUrl = html_url;
+    }
+    appendAgentLog({
+      type: "github_issue",
+      logId,
+      issueUrl,
+      createdAt: new Date().toISOString(),
+    });
+    if (process.env.JEST_WORKER_ID === undefined) {
+      process.exit(0);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add fail-open and dry-run flags to docsync agent, opening GitHub issues on sync errors
- introduce lightweight GitHub client for creating issues without dependencies
- document fail-open usage and environment variables

## Testing
- `npm test`
- `npx ts-node --compiler-options '{"module":"CommonJS"}' scripts/docsync-agent.ts --fail-open --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68952ad969608323be908f1b00a3b6d6