### PR TITLE
Enable robust SSE hook and update image configuration

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms.txt log matches content hash snapshot 1`] = `"045803737ba8d833490f657c45abdcc1041c86f208490284981cd90326f955f5"`;
+exports[`llms.txt log matches content hash snapshot 1`] = `"060e5e09d96c7ae3982c29e544687226ab4496c4fe05593484fb217b37d3cfa2"`;

--- a/components/PredictionDrawer.tsx
+++ b/components/PredictionDrawer.tsx
@@ -43,9 +43,9 @@ const PredictionDrawer: React.FC<Props> = ({ game, isOpen, onClose }) => {
     )}&awayTeam=${encodeURIComponent(game.awayTeam)}&week=${week}&sessionId=${sessionId}`;
   }, [game]);
 
-  const { status: esStatus, lastMessage, reconnect } = useEventSource(
-    isOpen ? url : null
-  );
+  const { status: esStatus, lastMessage, reconnect } = useEventSource(url, {
+    enabled: isOpen,
+  });
 
   const startRun = () => {
     if (!game) return;

--- a/llms.txt
+++ b/llms.txt
@@ -1228,3 +1228,21 @@ Files:
 - pages/index.tsx (+63/-6)
 
 
+Timestamp: 2025-08-07T23:24:17.986Z
+Commit: 4d482017c0ab5769f13d1e6ab9487a684ae2df97
+Author: Codex
+Message: feat: improve landing sse and config
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- components/PredictionDrawer.tsx (+3/-3)
+- lib/hooks/useEventSource.ts (+31/-11)
+- next.config.js (+6/-1)
+- pages/api/upcoming-games.ts (+4/-1)
+
+Timestamp: 2025-08-07T23:25:07.934Z
+Commit: 84d2c8677f18c2597e4275481a43b9b61c8c1e9f
+Author: Codex
+Message: test: update llms log snapshot
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   images: {
-    domains: ['a.espncdn.com', 'i.espncdn.com', 'static.nfl.com', 's.yimg.com'],
+    remotePatterns: [
+      { protocol: 'https', hostname: 'a.espncdn.com' },
+      { protocol: 'https', hostname: 'i.espncdn.com' },
+      { protocol: 'https', hostname: 'static.nfl.com' },
+      { protocol: 'https', hostname: 's.yimg.com' },
+    ],
   },
 };

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -130,9 +130,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 true
               );
 
+              const sanitize = (s: string) => s.replace(/\s+/g, '-');
               const derivedId =
                 game.gameId ||
-                `${game.league}:${game.homeTeam}:${game.awayTeam}:${game.time}`;
+                `${sanitize(game.league)}:${sanitize(game.homeTeam)}:${sanitize(
+                  game.awayTeam
+                )}:${new Date(game.time).getTime()}`;
 
               const result: Result = {
                 gameId: derivedId,


### PR DESCRIPTION
## Summary
- expand `useEventSource` with `enabled` flag, JSON line parsing, and exponential backoff
- wire PredictionDrawer to new hook API and derive stable game IDs on `upcoming-games`
- allow ESPN/CDN images via Next.js `remotePatterns`
- refresh llms log snapshot

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689533e8568c8323aa6f82eb39eda5f2