### PR TITLE
Polish landing page UI and kickoff display

### DIFF
--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -11,11 +11,20 @@ interface Props {
 function formatRelative(time: string): string {
   const target = new Date(time).getTime();
   const diffMs = target - Date.now();
-  const diffMin = Math.round(diffMs / 60000);
-  if (diffMin <= 0) return 'started';
+  if (diffMs <= 0) return 'started';
+  const diffMin = Math.floor(diffMs / 60000);
   if (diffMin < 60) return `in ${diffMin}m`;
-  const hours = Math.floor(diffMin / 60);
-  return `in ${hours}h`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `in ${diffHr}h`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay <= 7) return `in ${diffDay}d`;
+  const d = new Date(time);
+  const date = d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+  const t = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  return `${date}, ${t}`;
 }
 
 const GameCard: React.FC<Props> = ({ game, onClick, onHover }) => {
@@ -45,7 +54,7 @@ const GameCard: React.FC<Props> = ({ game, onClick, onHover }) => {
       onFocus={handleEnter}
       onMouseLeave={handleLeave}
       onBlur={handleLeave}
-      className="text-left w-full p-4 bg-white rounded shadow transition-transform hover:-translate-y-1 hover:shadow-lg focus:outline focus:outline-2 focus:outline-blue-500"
+      className="w-full text-left p-4 rounded-xl bg-slate-800/60 hover:bg-slate-800 ring-1 ring-transparent hover:ring-slate-700 shadow-sm hover:shadow transition-all"
       aria-label={`Analyze ${game.homeTeam} vs ${game.awayTeam} kickoff ${kickoffLabel}`}
     >
       <div className="flex items-center justify-between mb-2">
@@ -55,7 +64,7 @@ const GameCard: React.FC<Props> = ({ game, onClick, onHover }) => {
           )}
           <span>{game.homeTeam}</span>
         </div>
-        <span className="text-gray-500">vs</span>
+        <span className="text-slate-400">vs</span>
         <div className="flex items-center gap-2">
           {game.awayLogo && (
             <Image src={game.awayLogo} alt="" width={24} height={24} />
@@ -63,21 +72,21 @@ const GameCard: React.FC<Props> = ({ game, onClick, onHover }) => {
           <span>{game.awayTeam}</span>
         </div>
       </div>
-      <div className="text-sm text-gray-600">{kickoff}</div>
+      <div className="text-xs text-slate-400">{kickoff}</div>
       {game.odds ? (
-        <div className="text-xs text-gray-600 mt-1 flex gap-2">
+        <div className="flex flex-wrap gap-2 mt-2 text-xs">
           {game.odds.spread !== undefined && (
-            <span className="px-1 bg-gray-100 rounded" title="Spread">
+            <span className="px-2 py-0.5 rounded-full bg-slate-700" title="Spread">
               {game.homeTeam.slice(0, 3).toUpperCase()} {game.odds.spread}
             </span>
           )}
           {game.odds.overUnder !== undefined && (
-            <span className="px-1 bg-gray-100 rounded" title="Over/Under">
+            <span className="px-2 py-0.5 rounded-full bg-slate-700" title="Over/Under">
               O/U {game.odds.overUnder}
             </span>
           )}
           {game.odds.moneyline && (
-            <span className="px-1 bg-gray-100 rounded" title="Moneyline">
+            <span className="px-2 py-0.5 rounded-full bg-slate-700" title="Moneyline">
               ML {game.odds.moneyline.home ?? ''}
               {game.odds.moneyline.home && game.odds.moneyline.away ? ' / ' : ''}
               {game.odds.moneyline.away ?? ''}
@@ -85,10 +94,11 @@ const GameCard: React.FC<Props> = ({ game, onClick, onHover }) => {
           )}
         </div>
       ) : (
-        <div className="text-xs text-gray-400 mt-1">No odds yet</div>
+        <div className="text-xs text-slate-500 mt-2">No odds yet</div>
       )}
     </button>
   );
 };
 
 export default GameCard;
+

--- a/components/UpcomingGamesGrid.tsx
+++ b/components/UpcomingGamesGrid.tsx
@@ -28,9 +28,10 @@ const UpcomingGamesGrid: React.FC<Props> = ({
       g.awayTeam.toLowerCase().includes(q)
     );
   });
+
   if (isError) {
     return (
-      <div className="p-4 text-center" data-testid="error-panel">
+      <div className="col-span-full text-center" data-testid="error-panel">
         <p className="mb-2">Failed to load games.</p>
         <button className="px-3 py-1 border rounded" onClick={onRetry}>
           Retry
@@ -41,28 +42,31 @@ const UpcomingGamesGrid: React.FC<Props> = ({
 
   if (isLoading) {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <>
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
-            className="h-24 bg-gray-200 rounded animate-pulse"
+            className="h-24 rounded-xl bg-slate-800/40 animate-pulse"
             data-testid="game-skeleton"
           />
         ))}
-      </div>
+      </>
     );
   }
 
   if (filtered.length === 0) {
     return (
-      <div className="p-4 text-center text-gray-500" data-testid="empty-state">
-        No games found
+      <div
+        className="col-span-full text-center text-slate-400"
+        data-testid="empty-state"
+      >
+        No games match your search
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <>
       {filtered.map((game) => (
         <GameCard
           key={game.gameId}
@@ -71,8 +75,9 @@ const UpcomingGamesGrid: React.FC<Props> = ({
           onHover={preload}
         />
       ))}
-    </div>
+    </>
   );
 };
 
 export default UpcomingGamesGrid;
+

--- a/llms.txt
+++ b/llms.txt
@@ -1267,3 +1267,12 @@ Message: chore: ignore tests and scripts for eslint
 Files:
 - .eslintignore (+2/-0)
 
+Timestamp: 2025-08-08T02:40:45.644Z
+Commit: d2e20591301365f8c28aa5430f307cf6e590e68c
+Author: Codex
+Message: refactor: polish landing page
+Files:
+- components/GameCard.tsx (+22/-12)
+- components/UpcomingGamesGrid.tsx (+13/-8)
+- pages/index.tsx (+71/-43)
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react';
 import useSWR from 'swr';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
+import Link from 'next/link';
+import { signIn } from 'next-auth/react';
 import UpcomingGamesGrid from '../components/UpcomingGamesGrid';
 import type { Game } from '../lib/types';
 
@@ -110,55 +112,81 @@ export default function Home() {
         <title>{headTitle}</title>
         <meta name="description" content={headDesc} />
       </Head>
-      <main className="min-h-screen p-4 space-y-4">
-      <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-        <div className="flex gap-2">
-          {LEAGUES.map((l) => (
+      <header className="border-b">
+        <div className="max-w-7xl mx-auto grid grid-cols-3 items-center p-4">
+          <nav className="flex gap-4">
+            <Link href="/predictions" className="hover:underline">
+              Predictions
+            </Link>
+            <Link href="/leaderboard" className="hover:underline">
+              Leaderboard
+            </Link>
+            <Link href="/history" className="hover:underline">
+              History
+            </Link>
+          </nav>
+          <h1 className="text-center font-bold">EdgePicks</h1>
+          <div className="flex justify-end">
             <button
-              key={l}
-              onClick={() => changeLeague(l)}
-              className={`px-3 py-1 rounded border ${
-                l === league ? 'bg-blue-600 text-white' : 'bg-white'
-              }`}
+              onClick={() => signIn('google')}
+              className="px-3 py-1 border rounded"
             >
-              {l}
+              Sign in with Google
             </button>
-          ))}
+          </div>
         </div>
-        <input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search"
-          className="border px-2 py-1 rounded"
-        />
       </header>
-      {pendingId && !games.find((g) => g.gameId === pendingId) && !isLoading ? (
-        <div className="p-4 text-center">
-          <p>Game not found.</p>
-          <button
-            className="mt-2 px-3 py-1 border rounded"
-            onClick={() => {
-              setPendingId(null);
-              const { gameId, ...rest } = router.query;
-              router.push({ query: rest }, undefined, { shallow: true });
-            }}
-          >
-            Back
-          </button>
+      <main className="min-h-screen p-4 space-y-4 max-w-7xl mx-auto">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+          <div className="flex flex-wrap gap-2">
+            {LEAGUES.map((l) => (
+              <button
+                key={l}
+                onClick={() => changeLeague(l)}
+                className={`px-3 py-1 rounded border ${
+                  l === league ? 'bg-blue-600 text-white' : ''
+                }`}
+              >
+                {l}
+              </button>
+            ))}
+          </div>
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search"
+            className="border px-2 py-1 rounded w-full sm:w-auto"
+          />
         </div>
-      ) : (
-        <UpcomingGamesGrid
-          games={games}
-          search={search}
-          onSelect={handleSelect}
-          isLoading={isLoading}
-          isError={!!error}
-          onRetry={() => mutate()}
-          preload={preloadDrawer}
-        />
-      )}
-      <PredictionDrawer game={selected} isOpen={!!selected} onClose={handleClose} />
-    </main>
+        {pendingId && !games.find((g) => g.gameId === pendingId) && !isLoading ? (
+          <div className="text-center">
+            <p>Game not found.</p>
+            <button
+              className="mt-2 px-3 py-1 border rounded"
+              onClick={() => {
+                setPendingId(null);
+                const { gameId, ...rest } = router.query;
+                router.push({ query: rest }, undefined, { shallow: true });
+              }}
+            >
+              Back
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            <UpcomingGamesGrid
+              games={games}
+              search={search}
+              onSelect={handleSelect}
+              isLoading={isLoading}
+              isError={!!error}
+              onRetry={() => mutate()}
+              preload={preloadDrawer}
+            />
+          </div>
+        )}
+        <PredictionDrawer game={selected} isOpen={!!selected} onClose={handleClose} />
+      </main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Revamp game card styling with slate theme, pill odds chips, and accurate kickoff relative formatting
- Build header with centered title, navigation links, Google sign-in, and responsive filters/search
- Simplify UpcomingGamesGrid with fragment items, skeleton loaders, and empty-state messaging

## Testing
- `npm run lint:fix`
- `npm run typecheck`
- `npm run build` *(fails: GOOGLE_CLIENT_ID required)*
- `npm test` *(fails: llms.txt log snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689561b54c78832380a8ee487c28b7fc