### PR TITLE
feat: polish prediction drawer

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms.txt log matches content hash snapshot 1`] = `"9a09cac55e5bb4bbe23fc49af094a8db94b22457bb6b804c37fcbb6d173eccfd"`;
+exports[`llms.txt log matches content hash snapshot 1`] = `"9c1d1e4b38fdedfdf9f57304421bd7839ca036f2f64360f4f550a152354e6a5b"`;

--- a/components/AgentRationalePanel.tsx
+++ b/components/AgentRationalePanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { AgentExecution } from '../lib/flow/runFlow';
 import { AgentName } from '../lib/types';
 import { formatAgentName } from '../lib/utils';
@@ -26,33 +26,59 @@ const agentIcons: Record<AgentName, LucideIcon> = {
 };
 
 const AgentRationalePanel: React.FC<Props> = ({ executions, winner }) => {
-  const agents = executions.filter((e) => e.result && e.name !== 'guardianAgent') as Required<AgentExecution>[];
+  const agents = executions.filter(
+    (e) => e.result && e.name !== 'guardianAgent'
+  ) as Required<AgentExecution>[];
   const maxScore = Math.max(...agents.map((a) => a.result.score));
+  const [expanded, setExpanded] = useState<Record<AgentName, boolean>>({});
+
+  const toggle = (name: AgentName) =>
+    setExpanded((prev) => ({ ...prev, [name]: !prev[name] }));
+
   return (
     <div className="flex flex-col gap-2">
       {agents.map(({ name, result }) => {
         const disagree = result.team !== winner;
         const delta = Math.round((maxScore - result.score) * 100);
         const Icon = (agentIcons[name] || Info) as LucideIcon;
+        const reason = result.reason;
+        const isLong = reason.length > 200;
+        const showFull = expanded[name];
+        const displayText = showFull ? reason : reason.slice(0, 200);
         return (
           <div
             key={name}
-            className={`p-2 border rounded text-sm ${
-              disagree ? 'border-red-300 bg-red-50' : 'border-gray-200'
+            className={`p-4 rounded-xl border text-sm transition hover:shadow ${
+              disagree
+                ? 'border-red-500 bg-red-900/20'
+                : 'border-slate-700 bg-slate-800 hover:bg-slate-700'
             }`}
           >
             <div className="flex items-center justify-between">
               <span className="flex items-center gap-2">
                 <Icon className="w-4 h-4" /> {formatAgentName(name)}
               </span>
-              <span className="confidenceText">{Math.round(result.score * 100)}%</span>
+              <span className="px-2 py-0.5 bg-slate-700 rounded-full text-xs">
+                {Math.round(result.score * 100)}%
+              </span>
             </div>
-            <p className="text-xs text-gray-600 mt-1">{result.reason}</p>
+            <p className="text-xs text-gray-300 mt-1">
+              {displayText}
+              {!showFull && isLong && '...'}
+            </p>
+            {isLong && (
+              <button
+                onClick={() => toggle(name)}
+                className="text-xs text-blue-400 mt-1"
+              >
+                {showFull ? 'Show less' : 'Show more'}
+              </button>
+            )}
             {disagree && (
-              <p className="text-xs text-red-600">Disagrees with pick</p>
+              <p className="text-xs text-red-400">Disagrees with pick</p>
             )}
             {delta > 0 && (
-              <p className="text-xs text-gray-500">Edge Δ {delta}%</p>
+              <p className="text-xs text-gray-400">Edge Δ {delta}%</p>
             )}
           </div>
         );

--- a/llms.txt
+++ b/llms.txt
@@ -1267,3 +1267,12 @@ Message: chore: ignore tests and scripts for eslint
 Files:
 - .eslintignore (+2/-0)
 
+Timestamp: 2025-08-08T02:36:59.268Z
+Commit: d348b473adf365e5c00529510ca30495434802e8
+Author: Codex
+Message: feat: polish prediction drawer
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- components/AgentRationalePanel.tsx (+34/-8)
+- components/PredictionDrawer.tsx (+31/-10)
+


### PR DESCRIPTION
## Summary
- add rounded, sticky headed prediction drawer with escape-to-close
- style agent cards and share button to match GameCard aesthetic
- collapse long agent reasoning with toggle and show skeletons while loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689561ce07f88323b7ebb730ab22cf02