### PR TITLE
Add kickoff time formatting utility

### DIFF
--- a/__tests__/formatKickoff.test.ts
+++ b/__tests__/formatKickoff.test.ts
@@ -1,0 +1,32 @@
+import { formatKickoff } from '../lib/utils/formatKickoff';
+
+describe('formatKickoff', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-08-15T00:00:00Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns "started" for past times', () => {
+    expect(formatKickoff('2025-08-14T23:00:00Z')).toBe('started');
+  });
+
+  it('formats times less than an hour away', () => {
+    expect(formatKickoff('2025-08-15T00:30:00Z')).toBe('in 30m');
+  });
+
+  it('formats times less than a day away', () => {
+    expect(formatKickoff('2025-08-15T03:00:00Z')).toBe('in 3h');
+  });
+
+  it('formats times within seven days', () => {
+    expect(formatKickoff('2025-08-18T00:00:00Z')).toBe('in 3d');
+  });
+
+  it('formats times beyond seven days', () => {
+    expect(formatKickoff('2025-08-25T19:30:00Z')).toBe('Aug 25, 7:30 PM');
+  });
+});

--- a/lib/utils/formatKickoff.ts
+++ b/lib/utils/formatKickoff.ts
@@ -1,0 +1,29 @@
+export function formatKickoff(time: string): string {
+  const kickoff = new Date(time);
+  const now = new Date();
+  const diffMs = kickoff.getTime() - now.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (isNaN(kickoff.getTime()) || diffMs <= 0) {
+    return 'started';
+  }
+  if (diffMs < hour) {
+    const m = Math.round(diffMs / minute);
+    return `in ${m}m`;
+  }
+  if (diffMs < day) {
+    const h = Math.round(diffMs / hour);
+    return `in ${h}h`;
+  }
+  if (diffMs <= 7 * day) {
+    const d = Math.round(diffMs / day);
+    return `in ${d}d`;
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(kickoff);
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1267,3 +1267,18 @@ Message: chore: ignore tests and scripts for eslint
 Files:
 - .eslintignore (+2/-0)
 
+Timestamp: 2025-08-08T02:35:50.811Z
+Commit: 4f9a58188d7597bae0cc0cae8538f1cbbddbb194
+Author: Codex
+Message: Add kickoff display formatting
+Files:
+- pages/api/upcoming-games.ts (+3/-0)
+
+Timestamp: 2025-08-08T02:36:19.822Z
+Commit: 062fe439033dda4089f9a925681ce6b0744b9cc8
+Author: Codex
+Message: Add kickoff formatting util and tests
+Files:
+- __tests__/formatKickoff.test.ts (+32/-0)
+- lib/utils/formatKickoff.ts (+29/-0)
+

--- a/pages/api/upcoming-games.ts
+++ b/pages/api/upcoming-games.ts
@@ -10,6 +10,7 @@ import { registry } from '../../lib/agents/registry';
 import type { AgentOutputs, PickSummary } from '../../lib/types';
 import { logToSupabase } from '../../lib/logToSupabase';
 import { getFallbackMatchups } from '../../lib/utils/fallbackMatchups';
+import { formatKickoff } from '../../lib/utils/formatKickoff';
 import pLimit from 'p-limit';
 
 const CONCURRENCY_LIMIT = 3;
@@ -39,6 +40,7 @@ type Result = {
   agentDelta?: number;
   disagreements: string[];
   edgePick: AgentExecution[];
+  kickoffDisplay: string;
 };
 
 type LeagueCacheEntry = { results: Result[]; timestamp: number };
@@ -154,6 +156,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 agentDelta,
                 disagreements,
                 edgePick: executions,
+                kickoffDisplay: formatKickoff(game.time),
               };
               return result;
             } catch (err) {


### PR DESCRIPTION
## Summary
- add reusable `formatKickoff` helper to format upcoming game start times
- include human-readable `kickoffDisplay` on upcoming game API responses
- cover kickoff formatter with unit tests

## Testing
- `npm test -- __tests__/formatKickoff.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689561bc47388323a17cb1474214f86e