### PR TITLE
feat: support mock auth env defaults

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,3 +13,9 @@ SPORTS_DB_NHL_ID=<thesportsdb-nhl-league-id>
 # DocSync fail-open (optional)
 # GITHUB_TOKEN=ghp_xxx
 # GITHUB_REPOSITORY=owner/repo
+# --- Local developer conveniences ---
+# Set mock auth to bypass Google OAuth in local dev
+NEXT_PUBLIC_MOCK_AUTH=1
+
+# Use local/mocked data sources
+LIVE_MODE=off

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 🧠 EdgePicks
 
-EdgePicks is a modular, explainable AI research assistant for Pick'em players, sports analysts, and data-driven fans. It aggregates insights from lightweight agents to generate confident, transparent recommendations for NFL matchups and beyond.
-
-Last Updated: 2025-08-07
+EdgePicks is an AI assistant for pick’em players. It streams agent reasoning for upcoming games and lets you share deep links to specific matchups.  
+**This repo is actively moving toward “sports bettor → click live game → watch agents run”.**
 
 Quick access:
 
@@ -14,7 +13,7 @@ AI Constitution
 
 🚀 Local Setup
 
-git clone https://github.com/edgepicks/EdgePicks.git
+git clone https://github.com/Csp-Ai/EdgePicks.git
 cd EdgePicks
 cp .env.local.example .env.local
 npm install
@@ -22,11 +21,15 @@ npm run dev
 
 Verify environment variables:
 
+# If you have Vercel envs, you can also:
+# vercel login && vercel env pull .env.local
+# then:
 npm run validate-env
 
 ### Live vs Mock
 
-EdgePicks can run entirely from local mocks to avoid external API calls. Set `LIVE_MODE=off` to use bundled fixtures and skip network requests. When `LIVE_MODE=on`, the app fetches live data.
+Local dev defaults to **mock mode**: `NEXT_PUBLIC_MOCK_AUTH=1` and `LIVE_MODE=off`.  
+Provide real keys later to test full OAuth + live data.
 
 🧱 Architecture Overview
 

--- a/llms.txt
+++ b/llms.txt
@@ -1304,3 +1304,12 @@ Files:
 
 
 
+Timestamp: 2025-08-08T03:18:06.846Z
+Commit: eb7592856ecb2a10156f06f61b99a6c0b2b31c14
+Author: Codex
+Message: feat: support mock auth env defaults
+Files:
+- .env.local.example (+6/-0)
+- README.md (+8/-5)
+- scripts/validateEnv.ts (+33/-2)
+

--- a/scripts/validateEnv.ts
+++ b/scripts/validateEnv.ts
@@ -1,5 +1,36 @@
-import { ENV } from '../lib/env';
+const required = [
+  'NEXTAUTH_URL',
+  'NEXTAUTH_SECRET',
+  'SUPABASE_URL',
+  'SUPABASE_KEY',
+  'SPORTS_API_KEY'
+] as const;
 
-void ENV; // Access to trigger validation via zod
+// In mock mode we allow Google OAuth vars to be missing locally
+const isMockAuth =
+  process.env.NEXT_PUBLIC_MOCK_AUTH === '1' ||
+  process.env.LIVE_MODE === 'off';
+
+const issues: string[] = [];
+
+const addIssue = (msg: string) => {
+  issues.push(msg);
+};
+
+const missing = required.filter((k) => !process.env[k]);
+if (missing.length) addIssue(`Missing env: ${missing.join(', ')}`);
+
+if (!isMockAuth) {
+  ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'].forEach((k) => {
+    if (!process.env[k]) addIssue(`Missing env: ${k}`);
+  });
+}
+
+if (issues.length) {
+  console.error('❌ Env validation failed.');
+  issues.forEach((i) => console.error(` - ${i}`));
+  process.exit(1);
+}
 
 console.log('✅ All env files contain required keys.');
+


### PR DESCRIPTION
## Summary
- allow running without Google OAuth keys in mock mode
- add mock-friendly defaults to env example and docs

## Testing
- `NEXT_PUBLIC_MOCK_AUTH=1 LIVE_MODE=off npm run validate-env`
- `npm run dev`
- `npm test` *(fails: llms.txt snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68956a1c7360832393f3a0d30e386946