### PR TITLE
feat(logging): centralize server log events

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"29d7532278d91a3c95d0975a978f673472f914bbce962ccaea98f8d1e77e05e2"`;
+exports[`llms log writes entry (stable time) 1`] = `"64a8ac107e6a2693409982e2cf77d0f24ce5c24b61bde0e7e76590d2feff7f09"`;

--- a/__tests__/logEvent.test.ts
+++ b/__tests__/logEvent.test.ts
@@ -1,0 +1,23 @@
+/** @jest-environment node */
+import { logEvent } from '../lib/server/logEvent';
+import { supabase } from '../lib/supabaseClient';
+
+jest.mock('../lib/supabaseClient', () => ({
+  supabase: { from: jest.fn() },
+}));
+
+describe('logEvent', () => {
+  it('retries on transient errors', async () => {
+    const insert = jest
+      .fn()
+      .mockResolvedValueOnce({ error: new Error('temporary') })
+      .mockResolvedValue({ error: null });
+
+    (supabase.from as jest.Mock).mockReturnValue({ insert });
+
+    await logEvent('test', { foo: 'bar' }, { requestId: 'req', userId: 'user' });
+
+    expect(insert).toHaveBeenCalledTimes(2);
+    expect(supabase.from).toHaveBeenCalledWith('logs');
+  });
+});

--- a/__tests__/runAgentsApi.test.ts
+++ b/__tests__/runAgentsApi.test.ts
@@ -2,12 +2,15 @@
 import handler from '../pages/api/run-agents';
 import { runFlow } from '../lib/flow/runFlow';
 import { logToSupabase } from '../lib/logToSupabase';
+import { logEvent } from '../lib/server/logEvent';
 
 jest.mock('../lib/flow/runFlow');
 jest.mock('../lib/logToSupabase');
+jest.mock('../lib/server/logEvent');
 
 const mockedRunFlow = runFlow as jest.Mock;
 const mockedLog = logToSupabase as jest.Mock;
+const mockedLogEvent = logEvent as jest.Mock;
 
 describe('run-agents API', () => {
   it('streams agent results and logs summary', async () => {
@@ -25,6 +28,7 @@ describe('run-agents API', () => {
 
     const req: any = {
       query: { homeTeam: 'A', awayTeam: 'B', week: '1', sessionId: 'test-session' },
+      headers: {},
     };
     const chunks: string[] = [];
     const res: any = {
@@ -39,6 +43,7 @@ describe('run-agents API', () => {
 
     expect(mockedRunFlow).toHaveBeenCalled();
     expect(mockedLog).toHaveBeenCalled();
+    expect(mockedLogEvent).toHaveBeenCalled();
     const summary = chunks.find((c) => c.includes('summary'));
     expect(summary).toBeDefined();
   });
@@ -58,6 +63,7 @@ describe('run-agents API', () => {
 
     const req: any = {
       query: { homeTeam: 'A', awayTeam: 'B', week: '1', sessionId: 'test-session' },
+      headers: {},
     };
     const chunks: string[] = [];
     const res: any = {

--- a/lib/server/logEvent.ts
+++ b/lib/server/logEvent.ts
@@ -1,0 +1,51 @@
+import { supabase } from '../supabaseClient';
+import fs from 'fs';
+import path from 'path';
+
+interface LogOptions {
+  requestId?: string;
+  userId?: string;
+}
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 200;
+
+export async function logEvent(
+  kind: string,
+  payload: Record<string, unknown> = {},
+  options: LogOptions = {}
+): Promise<void> {
+  const { requestId, userId } = options;
+  const ts = new Date().toISOString();
+  const entry = { kind, payload, request_id: requestId, user_id: userId, ts };
+
+  let attempt = 0;
+  let lastError: any = null;
+
+  while (attempt < MAX_RETRIES) {
+    attempt += 1;
+    const { error } = await supabase.from('logs').insert(entry);
+    if (!error) {
+      lastError = null;
+      break;
+    }
+    lastError = error;
+    if (attempt < MAX_RETRIES) {
+      await new Promise((res) => setTimeout(res, BASE_DELAY_MS * attempt));
+    }
+  }
+
+  if (lastError) {
+    console.error('Failed to log event', lastError);
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    try {
+      const logPath = path.join(process.cwd(), 'llms.txt');
+      const line = `[${ts}] ${kind} ${JSON.stringify(payload)}\n`;
+      await fs.promises.appendFile(logPath, line);
+    } catch (err) {
+      console.error('Failed to mirror log to file', err);
+    }
+  }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1335,3 +1335,17 @@ Files:
 
 
 
+Timestamp: 2025-08-08T03:37:37.748Z
+Commit: 0b675168ef3ed003e54103bbc9743418189ba5be
+Author: Codex
+Message: feat(logging): centralize server log events
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/logEvent.test.ts (+23/-0)
+- __tests__/runAgentsApi.test.ts (+6/-0)
+- lib/server/logEvent.ts (+51/-0)
+- pages/api/run-agents.ts (+15/-1)
+- pages/api/run-predictions.ts (+10/-11)
+- supabase/migrations/20240101000000_create_logs_table.sql (+8/-0)
+- supabase/schema.sql (+9/-0)
+

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -6,6 +6,8 @@ import { loadFlow } from '../../lib/flow/loadFlow';
 import { runFlow } from '../../lib/flow/runFlow';
 import { ENV } from '../../lib/env';
 import mockData from '../../__mocks__/run-agents.json';
+import crypto from 'crypto';
+import { logEvent } from '../../lib/server/logEvent';
 
 export const config = {
   api: { bodyParser: false },
@@ -81,7 +83,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     topReasons,
   };
 
-  const loggedAt = logToSupabase(matchup, outputs as AgentOutputs, pickSummary, null, flow.name);
+  await logEvent(
+    'run-agents',
+    { homeTeam, awayTeam, week: weekNum },
+    { requestId: req.headers['x-request-id']?.toString() || crypto.randomUUID() }
+  );
+
+  const loggedAt = logToSupabase(
+    matchup,
+    outputs as AgentOutputs,
+    pickSummary,
+    null,
+    flow.name
+  );
 
   res.write(
     `data: ${JSON.stringify({

--- a/supabase/migrations/20240101000000_create_logs_table.sql
+++ b/supabase/migrations/20240101000000_create_logs_table.sql
@@ -1,0 +1,8 @@
+create table if not exists logs (
+  id uuid primary key default gen_random_uuid(),
+  kind text not null,
+  payload jsonb,
+  request_id text,
+  user_id text,
+  ts timestamptz not null default now()
+);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -36,3 +36,12 @@ create table if not exists ui_events (
   extras jsonb,
   created_at timestamptz default now()
 );
+
+create table if not exists logs (
+  id uuid primary key default gen_random_uuid(),
+  kind text not null,
+  request_id text,
+  user_id text,
+  payload jsonb,
+  ts timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add Supabase migration for generic `logs` table
- implement `logEvent` helper with retry and dev file mirroring
- use `logEvent` in prediction and agent APIs
- test logging retry behavior with mocked Supabase client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68956fb0616c832386690f2756f0d5c5