### PR TITLE
Require auth for run-agents API

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"29d7532278d91a3c95d0975a978f673472f914bbce962ccaea98f8d1e77e05e2"`;
+exports[`llms log writes entry (stable time) 1`] = `"64a8ac107e6a2693409982e2cf77d0f24ce5c24b61bde0e7e76590d2feff7f09"`;

--- a/__tests__/runAgents.auth.test.ts
+++ b/__tests__/runAgents.auth.test.ts
@@ -1,0 +1,78 @@
+/** @jest-environment node */
+import handler from '../pages/api/run-agents';
+import { getServerSession } from 'next-auth/next';
+import { runFlow } from '../lib/flow/runFlow';
+import { logToSupabase } from '../lib/logToSupabase';
+
+jest.mock('next-auth/next');
+jest.mock('../lib/flow/runFlow');
+jest.mock('../lib/logToSupabase');
+
+const mockedGetSession = getServerSession as jest.Mock;
+const mockedRunFlow = runFlow as jest.Mock;
+
+describe('run-agents auth', () => {
+  beforeEach(() => {
+    mockedRunFlow.mockResolvedValue({
+      outputs: {},
+      executions: [],
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_MOCK_AUTH;
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when no session and LIVE_MODE on', async () => {
+    mockedGetSession.mockResolvedValue(null);
+    const req: any = { query: { homeTeam: 'A', awayTeam: 'B', week: '1' } };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockedRunFlow).not.toHaveBeenCalled();
+  });
+
+  it('allows when session exists', async () => {
+    mockedGetSession.mockResolvedValue({ user: { name: 'Test' } });
+    const req: any = {
+      query: { homeTeam: 'A', awayTeam: 'B', week: '1', sessionId: '1' },
+    };
+    const res: any = {
+      setHeader: jest.fn(),
+      write: jest.fn(),
+      end: jest.fn(),
+      flushHeaders: jest.fn(),
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(mockedRunFlow).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalledWith(401);
+  });
+
+  it('allows without session when NEXT_PUBLIC_MOCK_AUTH=1', async () => {
+    process.env.NEXT_PUBLIC_MOCK_AUTH = '1';
+    mockedGetSession.mockResolvedValue(null);
+    const req: any = {
+      query: { homeTeam: 'A', awayTeam: 'B', week: '1', sessionId: '1' },
+    };
+    const res: any = {
+      setHeader: jest.fn(),
+      write: jest.fn(),
+      end: jest.fn(),
+      flushHeaders: jest.fn(),
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(mockedRunFlow).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalledWith(401);
+  });
+});

--- a/__tests__/runAgentsApi.test.ts
+++ b/__tests__/runAgentsApi.test.ts
@@ -9,6 +9,8 @@ jest.mock('../lib/logToSupabase');
 const mockedRunFlow = runFlow as jest.Mock;
 const mockedLog = logToSupabase as jest.Mock;
 
+process.env.NEXT_PUBLIC_MOCK_AUTH = '1';
+
 describe('run-agents API', () => {
   it('streams agent results and logs summary', async () => {
     mockedRunFlow.mockResolvedValue({

--- a/llms.txt
+++ b/llms.txt
@@ -1335,3 +1335,13 @@ Files:
 
 
 
+Timestamp: 2025-08-08T03:40:43.944Z
+Commit: 35426a767f0c53df96d1d1296e7c134f8ace1e9a
+Author: Codex
+Message: require auth for run-agents
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/runAgents.auth.test.ts (+78/-0)
+- __tests__/runAgentsApi.test.ts (+2/-0)
+- pages/api/run-agents.ts (+10/-0)
+


### PR DESCRIPTION
## Summary
- enforce NextAuth session on `/api/run-agents` when `LIVE_MODE` is on
- allow bypass when `NEXT_PUBLIC_MOCK_AUTH=1`
- add tests for authenticated, unauthenticated, and mock auth scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68956f78a5608323867fb9029df2c2b5