### PR TITLE
feat: guard dev login endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ npm run validate-env
 
 ### Live vs Mock
 
-Local dev defaults to **mock mode**: `NEXT_PUBLIC_MOCK_AUTH=1` and `LIVE_MODE=off`.  
+Local dev defaults to **mock mode**: `NEXT_PUBLIC_MOCK_AUTH=1` and `LIVE_MODE=off`.
 Provide real keys later to test full OAuth + live data.
+
+#### Mock Auth
+
+`/api/dev-login` is only available during local development or when `NEXT_PUBLIC_MOCK_AUTH=1`. Other environments receive `403`.
 
 🧱 Architecture Overview
 

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"29d7532278d91a3c95d0975a978f673472f914bbce962ccaea98f8d1e77e05e2"`;
+exports[`llms log writes entry (stable time) 1`] = `"64a8ac107e6a2693409982e2cf77d0f24ce5c24b61bde0e7e76590d2feff7f09"`;

--- a/__tests__/devlogin.test.ts
+++ b/__tests__/devlogin.test.ts
@@ -1,0 +1,59 @@
+/** @jest-environment node */
+import handler from '../pages/api/dev-login';
+
+const mockRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.end = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('dev-login API', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalMockAuth = process.env.NEXT_PUBLIC_MOCK_AUTH;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    process.env.NEXT_PUBLIC_MOCK_AUTH = originalMockAuth;
+  });
+
+  it('returns mock user in development', async () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.NEXT_PUBLIC_MOCK_AUTH;
+
+    const req: any = {};
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ id: 'dev-user', name: 'Dev User' });
+  });
+
+  it('returns 403 in production without mock flag', async () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.NEXT_PUBLIC_MOCK_AUTH;
+
+    const req: any = {};
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('allows mock auth in production when flag set', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_MOCK_AUTH = '1';
+
+    const req: any = {};
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ id: 'dev-user', name: 'Dev User' });
+  });
+});

--- a/llms.txt
+++ b/llms.txt
@@ -1335,3 +1335,13 @@ Files:
 
 
 
+Timestamp: 2025-08-08T03:41:06.006Z
+Commit: f708451213dbdd16e8d86c20c67ab416ff6a82ed
+Author: Codex
+Message: feat: guard dev login endpoint
+Files:
+- README.md (+5/-1)
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/devlogin.test.ts (+59/-0)
+- pages/api/dev-login.ts (+6/-0)
+

--- a/pages/api/dev-login.ts
+++ b/pages/api/dev-login.ts
@@ -1,5 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { NODE_ENV, NEXT_PUBLIC_MOCK_AUTH } = process.env;
+
+  if (NODE_ENV !== 'development' && NEXT_PUBLIC_MOCK_AUTH !== '1') {
+    return res.status(403).end();
+  }
+
   res.status(200).json({ id: 'dev-user', name: 'Dev User' });
 }


### PR DESCRIPTION
## Summary
- restrict `/api/dev-login` to development or `NEXT_PUBLIC_MOCK_AUTH=1`
- document mock auth behavior in README
- add tests for dev-login and update llms log snapshot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68956f6cb3e48323b07e1dc12cd82d58