### PR TITLE
feat: add data adapters for schedule and odds

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"29d7532278d91a3c95d0975a978f673472f914bbce962ccaea98f8d1e77e05e2"`;
+exports[`llms log writes entry (stable time) 1`] = `"64a8ac107e6a2693409982e2cf77d0f24ce5c24b61bde0e7e76590d2feff7f09"`;

--- a/__tests__/env.liveMockSwitch.test.ts
+++ b/__tests__/env.liveMockSwitch.test.ts
@@ -8,8 +8,8 @@ describe('LIVE_MODE switch', () => {
   it('serves mock data when off', async () => {
     process.env.LIVE_MODE = 'off';
     const fetchSpy = jest.spyOn(global, 'fetch');
-    const { fetchNflGames } = await import('../lib/data/liveSports');
-    const games = await fetchNflGames();
+    const { fetchSchedule } = await import('../lib/data/schedule');
+    const games = await fetchSchedule('NFL');
     expect(games.length).toBeGreaterThan(0);
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
@@ -21,8 +21,8 @@ describe('LIVE_MODE switch', () => {
     const fetchSpy = jest
       .spyOn(global, 'fetch')
       .mockResolvedValue({ ok: true, json: async () => ({ events: [] }) } as any);
-    const { fetchNflGames } = await import('../lib/data/liveSports');
-    await fetchNflGames();
+    const { fetchSchedule } = await import('../lib/data/schedule');
+    await fetchSchedule('NFL');
     expect(fetchSpy).toHaveBeenCalled();
     fetchSpy.mockRestore();
   });

--- a/__tests__/upcomingGamesApi.joinOdds.test.ts
+++ b/__tests__/upcomingGamesApi.joinOdds.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment node */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+jest.mock('../lib/data/schedule', () => ({
+  fetchSchedule: jest.fn(),
+}));
+jest.mock('../lib/data/odds', () => ({
+  fetchOdds: jest.fn(),
+}));
+jest.mock('../lib/flow/runFlow', () => ({
+  runFlow: jest.fn().mockResolvedValue({ outputs: {}, executions: [] }),
+}));
+jest.mock('../lib/logToSupabase', () => ({ logToSupabase: jest.fn() }));
+jest.mock('../lib/utils/fallbackMatchups', () => ({ getFallbackMatchups: jest.fn(() => []) }));
+jest.mock('../lib/utils/formatKickoff', () => ({ formatKickoff: () => '' }));
+jest.mock('../lib/agents/registry', () => ({ registry: [] }));
+
+const handler = require('../pages/api/upcoming-games').default;
+const { fetchSchedule } = require('../lib/data/schedule');
+const { fetchOdds } = require('../lib/data/odds');
+
+describe('upcoming-games API', () => {
+  it('joins odds data with schedule', async () => {
+    fetchSchedule.mockResolvedValue([
+      { homeTeam: 'A', awayTeam: 'B', time: '2020', league: 'NFL' },
+    ]);
+    fetchOdds.mockResolvedValue([
+      {
+        home_team: 'A',
+        away_team: 'B',
+        bookmakers: [
+          {
+            title: 'Book',
+            last_update: '2020',
+            markets: [
+              { key: 'h2h', outcomes: [{ name: 'A', price: -110 }, { name: 'B', price: 100 }] },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const req = { query: { league: 'NFL' } } as unknown as NextApiRequest;
+    const json = jest.fn();
+    const status = jest.fn(() => ({ json }));
+    const res = { status } as unknown as NextApiResponse;
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          odds: expect.objectContaining({
+            moneyline: { home: -110, away: 100 },
+          }),
+        }),
+      ])
+    );
+  });
+});

--- a/lib/data/injuries.ts
+++ b/lib/data/injuries.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { ENV } from '../env';
+import type { League } from './schedule';
+
+const InjurySchema = z.object({
+  team: z.string(),
+  player: z.string(),
+  status: z.string().optional(),
+});
+
+export type Injury = z.infer<typeof InjurySchema>;
+
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+  retries = 2,
+  backoff = 500
+): Promise<Response> {
+  let res: Response = await fetch(url, options);
+  for (let attempt = 0; attempt < retries && res.status === 429; attempt++) {
+    await new Promise((r) => setTimeout(r, backoff * (attempt + 1)));
+    res = await fetch(url, options);
+  }
+  return res;
+}
+
+export async function fetchInjuries(_league: League): Promise<Injury[]> {
+  if (ENV.LIVE_MODE !== 'on') return [];
+  // Placeholder API - replace with real injury endpoint when available
+  const url = 'https://example.com/injuries';
+  const res = await fetchWithRetry(url);
+  if (res.status === 429) {
+    throw new Error('INJURY_API_RATE_LIMIT');
+  }
+  const data = z.array(InjurySchema).parse(await res.json());
+  return data;
+}

--- a/lib/data/odds.ts
+++ b/lib/data/odds.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { ENV } from '../env';
+import type { League } from './schedule';
+
+const ODDS_API_SPORT_MAP: Record<League, string> = {
+  NFL: 'americanfootball_nfl',
+  MLB: 'baseball_mlb',
+  NBA: 'basketball_nba',
+  NHL: 'icehockey_nhl',
+};
+
+const OutcomeSchema = z.object({
+  name: z.string(),
+  price: z.number().optional(),
+  point: z.number().optional(),
+});
+
+const MarketSchema = z.object({
+  key: z.string(),
+  outcomes: z.array(OutcomeSchema),
+});
+
+const BookmakerSchema = z.object({
+  title: z.string(),
+  last_update: z.string(),
+  markets: z.array(MarketSchema),
+});
+
+const OddsGameSchema = z.object({
+  home_team: z.string(),
+  away_team: z.string(),
+  bookmakers: z.array(BookmakerSchema),
+});
+
+export type OddsGame = z.infer<typeof OddsGameSchema>;
+
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+  retries = 2,
+  backoff = 500
+): Promise<Response> {
+  let res: Response = await fetch(url, options);
+  for (let attempt = 0; attempt < retries && res.status === 429; attempt++) {
+    await new Promise((r) => setTimeout(r, backoff * (attempt + 1)));
+    res = await fetch(url, options);
+  }
+  return res;
+}
+
+export async function fetchOdds(league: League): Promise<OddsGame[]> {
+  if (ENV.LIVE_MODE !== 'on') return [];
+  const sport = ODDS_API_SPORT_MAP[league];
+  const apiKey = ENV.ODDS_API_KEY;
+  if (!sport || !apiKey) return [];
+  const url = `https://api.the-odds-api.com/v4/sports/${sport}/odds/?regions=us&markets=h2h,spreads,totals&apiKey=${apiKey}`;
+  const res = await fetchWithRetry(url);
+  if (res.status === 429) {
+    throw new Error('ODDS_API_RATE_LIMIT');
+  }
+  const data = z.array(OddsGameSchema).parse(await res.json());
+  return data;
+}

--- a/lib/data/schedule.ts
+++ b/lib/data/schedule.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { ENV } from '../env';
+import mockUpcoming from '../../mock/upcoming-games.json';
+import type { Matchup } from '../types';
+
+export type League = 'NFL' | 'MLB' | 'NBA' | 'NHL';
+
+const SPORTS_DB_LEAGUE_IDS: Record<League, string | undefined> = {
+  NFL: ENV.SPORTS_DB_NFL_ID,
+  MLB: ENV.SPORTS_DB_MLB_ID,
+  NBA: ENV.SPORTS_DB_NBA_ID,
+  NHL: ENV.SPORTS_DB_NHL_ID,
+};
+
+const EventSchema = z.object({
+  idEvent: z.string().optional(),
+  strHomeTeam: z.string().nullable(),
+  strAwayTeam: z.string().nullable(),
+  dateEvent: z.string().nullable(),
+  strTime: z.string().nullable(),
+});
+
+const EventsResponseSchema = z.object({
+  events: z.array(EventSchema).nullish(),
+});
+
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+  retries = 2,
+  backoff = 500
+): Promise<Response> {
+  let res: Response = await fetch(url, options);
+  for (let attempt = 0; attempt < retries && res.status === 429; attempt++) {
+    await new Promise((r) => setTimeout(r, backoff * (attempt + 1)));
+    res = await fetch(url, options);
+  }
+  return res;
+}
+
+export async function fetchSchedule(league: League): Promise<Matchup[]> {
+  if (ENV.LIVE_MODE !== 'on') {
+    return (mockUpcoming as Matchup[]).filter((g) => g.league === league);
+  }
+  const leagueId = SPORTS_DB_LEAGUE_IDS[league];
+  if (!leagueId) return [];
+  const url = `https://www.thesportsdb.com/api/v1/json/${ENV.SPORTS_API_KEY}/eventsnextleague.php?id=${leagueId}`;
+  const res = await fetchWithRetry(url);
+  if (res.status === 429) {
+    throw new Error('SPORTS_DB_RATE_LIMIT');
+  }
+  const json = EventsResponseSchema.parse(await res.json());
+  const events = json.events ?? [];
+  return events.map((e) => ({
+    homeTeam: e.strHomeTeam ?? '',
+    awayTeam: e.strAwayTeam ?? '',
+    time: e.dateEvent && e.strTime ? `${e.dateEvent} ${e.strTime}` : e.dateEvent || '',
+    league,
+    gameId: e.idEvent,
+    source: `live-${league.toLowerCase()}-api`,
+  })) as Matchup[];
+}
+
+export const fetchNflSchedule = () => fetchSchedule('NFL');
+export const fetchMlbSchedule = () => fetchSchedule('MLB');
+export const fetchNbaSchedule = () => fetchSchedule('NBA');
+export const fetchNhlSchedule = () => fetchSchedule('NHL');

--- a/llms.txt
+++ b/llms.txt
@@ -1335,3 +1335,16 @@ Files:
 
 
 
+Timestamp: 2025-08-08T03:42:51.752Z
+Commit: a435c60bf921cbaefbe7673f18693befe51185a1
+Author: Codex
+Message: feat: add data adapters for schedule and odds
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/env.liveMockSwitch.test.ts (+4/-4)
+- __tests__/upcomingGamesApi.joinOdds.test.ts (+62/-0)
+- lib/data/injuries.ts (+37/-0)
+- lib/data/odds.ts (+63/-0)
+- lib/data/schedule.ts (+67/-0)
+- pages/api/upcoming-games.ts (+34/-18)
+


### PR DESCRIPTION
## Summary
- add schedule, odds, and injury adapters with retry and zod parsing
- switch upcoming-games API to adapters and join odds data
- test LIVE_MODE mock switch and odds join

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68956f9e49fc83238dede7fc5cc73957