### PR TITLE
feat: store agent outcomes and add backfill

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"073a908dd795826fdc3d4febd3c72acfb051d4538efaddd1ed7aabc94dce0951"`;
+exports[`llms log writes entry (stable time) 1`] = `"37fb65b6bf97aaa9be27c0aeafb06a2698275f322cfa7eaac6eb811298697435"`;

--- a/__tests__/__snapshots__/runAgentsApi.test.ts.snap
+++ b/__tests__/__snapshots__/runAgentsApi.test.ts.snap
@@ -12,10 +12,4 @@ exports[`run-agents API matches snapshot 1`] = `
   "finalConfidence": 0.36,
   "pick": "A",
 }
-=======
-exports[`run-agents API matches snapshot of agent stream 1`] = `
-"data: {"type":"summary","sessionId":"test-session","matchup":{"homeTeam":"A","awayTeam":"B","matchDay":1,"time":"","league":""},"agents":{"injuryScout":{"team":"A","score":0.72,"reason":"Key WR out"}},"pick":{"winner":"A","confidence":0.36,"topReasons":["Key WR out"]},"cacheVersion":"v1"}
-
-"
-
 `;

--- a/__tests__/agentOutcomes.test.ts
+++ b/__tests__/agentOutcomes.test.ts
@@ -1,0 +1,44 @@
+/** @jest-environment node */
+import { recordAgentOutcomes } from '../lib/accuracy';
+import { supabase } from '../lib/supabaseClient';
+
+jest.mock('../lib/supabaseClient', () => ({
+  supabase: { from: jest.fn() },
+}));
+
+describe('recordAgentOutcomes', () => {
+  it('stores outcomes per agent', async () => {
+    const upsert = jest.fn().mockResolvedValue({ error: null });
+    (supabase.from as jest.Mock).mockReturnValue({ upsert });
+
+    const agents = {
+      injuryScout: { team: 'A', score: 0.7, reason: 'x' },
+      lineWatcher: { team: 'B', score: 0.6, reason: 'y' },
+    } as any;
+
+    await recordAgentOutcomes('game1', agents, 'A', '2024-01-01');
+
+    expect(supabase.from).toHaveBeenCalledWith('agent_outcomes');
+    expect(upsert).toHaveBeenCalledWith(
+      [
+        {
+          game_id: 'game1',
+          agent: 'injuryScout',
+          pick: 'A',
+          correct: true,
+          confidence: 0.7,
+          ts: '2024-01-01',
+        },
+        {
+          game_id: 'game1',
+          agent: 'lineWatcher',
+          pick: 'B',
+          correct: false,
+          confidence: 0.6,
+          ts: '2024-01-01',
+        },
+      ],
+      { onConflict: 'game_id,agent' }
+    );
+  });
+});

--- a/lib/accuracy.ts
+++ b/lib/accuracy.ts
@@ -16,6 +16,26 @@ export interface AccuracyStat {
   accuracy: number;
 }
 
+export async function recordAgentOutcomes(
+  gameId: string,
+  agents: AgentOutputs,
+  actualWinner: string,
+  ts: string = new Date().toISOString()
+) {
+  const rows = Object.entries(agents).map(([agent, result]) => ({
+    game_id: gameId,
+    agent,
+    pick: result.team,
+    correct: result.team === actualWinner,
+    confidence: result.score,
+    ts,
+  }));
+  if (rows.length === 0) return;
+  await supabase
+    .from('agent_outcomes')
+    .upsert(rows, { onConflict: 'game_id,agent' });
+}
+
 export async function recomputeAccuracy() {
   const { data, error } = await supabase
     .from('matchups')

--- a/llms.txt
+++ b/llms.txt
@@ -1469,3 +1469,18 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T04:59:28.223Z
+Commit: 132db6b1138e362404d370f001c195e189b27a67
+Author: Codex
+Message: feat: store agent outcomes and add backfill
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/__snapshots__/runAgentsApi.test.ts.snap (+0/-6)
+- __tests__/agentOutcomes.test.ts (+44/-0)
+- lib/accuracy.ts (+20/-0)
+- lib/logToSupabase.ts (+26/-14)
+- pages/api/run-agents.ts (+0/-40)
+- scripts/backfillAgentOutcomes.ts (+24/-0)
+- supabase/migrations/20240808090000_create_agent_outcomes_table.sql (+9/-0)
+- supabase/schema.sql (+10/-0)
+

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -101,45 +101,5 @@ export default async function handler(
     console.error(err);
     res.status(500).json({ error: 'Failed to run agents' });
   }
-=======
-  const winner = scores[homeTeam] >= scores[awayTeam] ? homeTeam : awayTeam;
-  const confidence = Math.max(scores[homeTeam], scores[awayTeam]);
-  const topReasons = flow.agents
-    .map((name) => outputs[name]?.reason)
-    .filter((r): r is string => Boolean(r));
-
-  const pickSummary: PickSummary = {
-    winner,
-    confidence,
-    topReasons,
-  };
-
-  await logEvent(
-    'run-agents',
-    { homeTeam, awayTeam, week: weekNum },
-    { requestId: req.headers?.['x-request-id']?.toString() || crypto.randomUUID() }
-  );
-
-  const loggedAt = logToSupabase(
-    matchup,
-    outputs as AgentOutputs,
-    pickSummary,
-    null,
-    flow.name
-  );
-
-  res.write(
-    `data: ${JSON.stringify({
-      type: 'summary',
-      sessionId,
-      matchup,
-      agents: outputs,
-      pick: pickSummary,
-      loggedAt,
-      cacheVersion: ENV.FLOW_CACHE_VERSION,
-    })}\n\n`
-  );
-  res.end();
-
 }
 

--- a/scripts/backfillAgentOutcomes.ts
+++ b/scripts/backfillAgentOutcomes.ts
@@ -1,0 +1,24 @@
+import { supabase } from '../lib/supabaseClient';
+import { recordAgentOutcomes } from '../lib/accuracy';
+
+async function main() {
+  const { data, error } = await supabase
+    .from('matchups')
+    .select('id, agents, actual_winner, created_at')
+    .not('actual_winner', 'is', null);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+  if (!data) return;
+
+  for (const row of data as any[]) {
+    await recordAgentOutcomes(row.id, row.agents, row.actual_winner, row.created_at);
+  }
+  console.log('✅ Agent outcomes backfill complete');
+}
+
+main().catch((err) => {
+  console.error('Backfill failed', err);
+  process.exit(1);
+});

--- a/supabase/migrations/20240808090000_create_agent_outcomes_table.sql
+++ b/supabase/migrations/20240808090000_create_agent_outcomes_table.sql
@@ -1,0 +1,9 @@
+create table if not exists agent_outcomes (
+  game_id uuid not null references matchups(id) on delete cascade,
+  agent text not null,
+  pick text,
+  correct boolean,
+  confidence float,
+  ts timestamptz not null default now(),
+  primary key (game_id, agent)
+);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -45,3 +45,13 @@ create table if not exists logs (
   payload jsonb,
   ts timestamptz default now()
 );
+
+create table if not exists agent_outcomes (
+  game_id uuid not null references matchups(id) on delete cascade,
+  agent text not null,
+  pick text,
+  correct boolean,
+  confidence float,
+  ts timestamptz default now(),
+  primary key (game_id, agent)
+);


### PR DESCRIPTION
## Summary
- add `agent_outcomes` table and migration
- log per-agent results when games conclude
- backfill historical matchups and cover with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895822dc85c8323bf20690599caeab9