### PR TITLE
feat: harden data adapters with caching and circuit breaker

### DIFF
--- a/__tests__/adapters.circuit.test.ts
+++ b/__tests__/adapters.circuit.test.ts
@@ -1,0 +1,26 @@
+import { setCacheDriver } from '../lib/infra/cache';
+import { MemoryCacheDriver } from '../lib/infra/cache/memory';
+
+jest.mock('../lib/analytics/logUiEvent', () => ({
+  logAdapterMetric: jest.fn(),
+}));
+
+describe('adapter circuit breaker', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.LIVE_MODE = 'on';
+    setCacheDriver(new MemoryCacheDriver());
+  });
+
+  test('trips circuit after error budget', async () => {
+    const { fetchStats, ERROR_BUDGET } = await import('../lib/data/stats');
+    const fetchMock = jest.fn().mockRejectedValue(new Error('fail'));
+    global.fetch = fetchMock as any;
+    for (let i = 0; i < ERROR_BUDGET; i++) {
+      await fetchStats('NFL' as any);
+    }
+    fetchMock.mockClear();
+    await fetchStats('NFL' as any);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/adapters.contract.test.ts
+++ b/__tests__/adapters.contract.test.ts
@@ -1,0 +1,42 @@
+import { setCacheDriver } from '../lib/infra/cache';
+import { MemoryCacheDriver } from '../lib/infra/cache/memory';
+
+jest.mock('../lib/analytics/logUiEvent', () => ({
+  logAdapterMetric: jest.fn(),
+}));
+
+describe('adapters contract', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.LIVE_MODE = 'on';
+    process.env.ODDS_API_KEY = 'key';
+    setCacheDriver(new MemoryCacheDriver());
+  });
+
+  test('injuries invalid schema falls back to mock', async () => {
+    const { fetchInjuries } = await import('../lib/data/injuries');
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: async () => [{ team: 1 }],
+    } as any);
+    const data = await fetchInjuries('NFL' as any);
+    expect(data).toEqual([]);
+  });
+
+  test(
+    'odds timeout returns mock',
+    async () => {
+      jest.setTimeout(10000);
+      const { fetchOdds } = await import('../lib/data/odds');
+      global.fetch = jest.fn((_url, opts) => {
+        const signal = (opts as RequestInit).signal as AbortSignal;
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('Aborted')));
+        });
+      }) as any;
+      const data = await fetchOdds('NFL' as any);
+      expect(data).toEqual([]);
+    },
+    15000,
+  );
+});

--- a/__tests__/llmsLog.test.ts
+++ b/__tests__/llmsLog.test.ts
@@ -13,7 +13,6 @@ afterAll(() => {
   unfreeze();
 });
 
-=======
 // Snapshot hash is sensitive to timestamps inside llms.txt. We freeze time so it
 // remains stable. Update the snapshot if the frozen ISO changes.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,3 +9,11 @@
 - /api/run-predictions
 - /api/trends
 - /api/upcoming-games
+
+## Data Adapter Guarantees
+
+Live data adapters for injuries, odds, and stats enforce strict Zod schemas and
+abort provider requests after 3s. Responses are cached using the configured
+`CACHE_DRIVER` and failures increment an error budget. When the budget is
+exhausted, a 10‑minute circuit breaker returns mock data. Metrics for adapter
+success and failure are emitted via `logUiEvent`.

--- a/lib/analytics/logUiEvent.ts
+++ b/lib/analytics/logUiEvent.ts
@@ -1,0 +1,9 @@
+import { logUiEvent } from '../logUiEvent';
+
+export async function logAdapterMetric(
+  adapter: string,
+  metric: string,
+  metadata: Record<string, unknown> = {},
+): Promise<void> {
+  await logUiEvent('adapterMetric', { adapter, metric, ...metadata });
+}

--- a/lib/data/injuries.ts
+++ b/lib/data/injuries.ts
@@ -1,14 +1,37 @@
 import { z } from 'zod';
 import { ENV } from '../env';
 import type { League } from './schedule';
+import { getCacheDriver } from '../infra/cache';
+import { logAdapterMetric } from '../analytics/logUiEvent';
 
-const InjurySchema = z.object({
-  team: z.string(),
-  player: z.string(),
-  status: z.string().optional(),
-});
+const InjurySchema = z
+  .object({
+    team: z.string(),
+    player: z.string(),
+    status: z.string().optional(),
+  })
+  .strict();
 
 export type Injury = z.infer<typeof InjurySchema>;
+
+const CACHE_TTL = 60; // seconds
+const CIRCUIT_TTL = 600; // 10 minutes
+export const ERROR_BUDGET = 3;
+const PROVIDER_TIMEOUT_MS = 3000;
+
+async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeout = PROVIDER_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 async function fetchWithRetry(
   url: string,
@@ -16,22 +39,52 @@ async function fetchWithRetry(
   retries = 2,
   backoff = 500
 ): Promise<Response> {
-  let res: Response = await fetch(url, options);
+  let res: Response = await fetchWithTimeout(url, options);
   for (let attempt = 0; attempt < retries && res.status === 429; attempt++) {
     await new Promise((r) => setTimeout(r, backoff * (attempt + 1)));
-    res = await fetch(url, options);
+    res = await fetchWithTimeout(url, options);
   }
   return res;
 }
 
 export async function fetchInjuries(_league: League): Promise<Injury[]> {
   if (ENV.LIVE_MODE !== 'on') return [];
+  const cache = getCacheDriver();
+  const circuitKey = 'injuries:circuit';
+  if (await cache.get<boolean>(circuitKey)) {
+    await logAdapterMetric('injuries', 'circuit_bypass');
+    return [];
+  }
+  const cacheKey = 'injuries:data';
+  const cached = await cache.get<Injury[]>(cacheKey);
+  if (cached) return cached;
+
   // Placeholder API - replace with real injury endpoint when available
   const url = 'https://example.com/injuries';
-  const res = await fetchWithRetry(url);
-  if (res.status === 429) {
-    throw new Error('INJURY_API_RATE_LIMIT');
+  const start = Date.now();
+  try {
+    const res = await fetchWithRetry(url);
+    if (res.status === 429) {
+      throw new Error('INJURY_API_RATE_LIMIT');
+    }
+    const data = z.array(InjurySchema).parse(await res.json());
+    await cache.set(cacheKey, data, CACHE_TTL);
+    await cache.set('injuries:failures', 0, CIRCUIT_TTL);
+    await logAdapterMetric('injuries', 'success', {
+      latencyMs: Date.now() - start,
+    });
+    return data;
+  } catch (err) {
+    await logAdapterMetric('injuries', 'error', {
+      message: (err as Error).message,
+    });
+    const failures = (await cache.get<number>('injuries:failures')) ?? 0;
+    const next = failures + 1;
+    await cache.set('injuries:failures', next, CIRCUIT_TTL);
+    if (next >= ERROR_BUDGET) {
+      await cache.set(circuitKey, true, CIRCUIT_TTL);
+      await logAdapterMetric('injuries', 'circuit_open', { failures: next });
+    }
+    return cached ?? [];
   }
-  const data = z.array(InjurySchema).parse(await res.json());
-  return data;
 }

--- a/lib/data/odds.ts
+++ b/lib/data/odds.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { ENV } from '../env';
 import type { League } from './schedule';
+import { getCacheDriver } from '../infra/cache';
+import { logAdapterMetric } from '../analytics/logUiEvent';
 
 const ODDS_API_SPORT_MAP: Record<League, string> = {
   NFL: 'americanfootball_nfl',
@@ -9,55 +11,110 @@ const ODDS_API_SPORT_MAP: Record<League, string> = {
   NHL: 'icehockey_nhl',
 };
 
-const OutcomeSchema = z.object({
-  name: z.string(),
-  price: z.number().optional(),
-  point: z.number().optional(),
-});
+const OutcomeSchema = z
+  .object({
+    name: z.string(),
+    price: z.number().optional(),
+    point: z.number().optional(),
+  })
+  .strict();
 
-const MarketSchema = z.object({
-  key: z.string(),
-  outcomes: z.array(OutcomeSchema),
-});
+const MarketSchema = z
+  .object({
+    key: z.string(),
+    outcomes: z.array(OutcomeSchema),
+  })
+  .strict();
 
-const BookmakerSchema = z.object({
-  title: z.string(),
-  last_update: z.string(),
-  markets: z.array(MarketSchema),
-});
+const BookmakerSchema = z
+  .object({
+    title: z.string(),
+    last_update: z.string(),
+    markets: z.array(MarketSchema),
+  })
+  .strict();
 
-const OddsGameSchema = z.object({
-  home_team: z.string(),
-  away_team: z.string(),
-  bookmakers: z.array(BookmakerSchema),
-});
+const OddsGameSchema = z
+  .object({
+    home_team: z.string(),
+    away_team: z.string(),
+    bookmakers: z.array(BookmakerSchema),
+  })
+  .strict();
 
 export type OddsGame = z.infer<typeof OddsGameSchema>;
+
+const CACHE_TTL = 60; // seconds
+const CIRCUIT_TTL = 600; // 10 minutes
+export const ERROR_BUDGET = 3;
+const PROVIDER_TIMEOUT_MS = 3000;
+
+async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeout = PROVIDER_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 async function fetchWithRetry(
   url: string,
   options: RequestInit = {},
   retries = 2,
-  backoff = 500
+  backoff = 500,
 ): Promise<Response> {
-  let res: Response = await fetch(url, options);
+  let res: Response = await fetchWithTimeout(url, options);
   for (let attempt = 0; attempt < retries && res.status === 429; attempt++) {
     await new Promise((r) => setTimeout(r, backoff * (attempt + 1)));
-    res = await fetch(url, options);
+    res = await fetchWithTimeout(url, options);
   }
   return res;
 }
 
 export async function fetchOdds(league: League): Promise<OddsGame[]> {
   if (ENV.LIVE_MODE !== 'on') return [];
+  const cache = getCacheDriver();
+  const circuitKey = 'odds:circuit';
+  if (await cache.get<boolean>(circuitKey)) {
+    await logAdapterMetric('odds', 'circuit_bypass');
+    return [];
+  }
   const sport = ODDS_API_SPORT_MAP[league];
   const apiKey = ENV.ODDS_API_KEY;
   if (!sport || !apiKey) return [];
+  const cacheKey = `odds:${sport}`;
+  const cached = await cache.get<OddsGame[]>(cacheKey);
+  if (cached) return cached;
+
   const url = `https://api.the-odds-api.com/v4/sports/${sport}/odds/?regions=us&markets=h2h,spreads,totals&apiKey=${apiKey}`;
-  const res = await fetchWithRetry(url);
-  if (res.status === 429) {
-    throw new Error('ODDS_API_RATE_LIMIT');
+  const start = Date.now();
+  try {
+    const res = await fetchWithRetry(url);
+    if (res.status === 429) {
+      throw new Error('ODDS_API_RATE_LIMIT');
+    }
+    const data = z.array(OddsGameSchema).parse(await res.json());
+    await cache.set(cacheKey, data, CACHE_TTL);
+    await cache.set('odds:failures', 0, CIRCUIT_TTL);
+    await logAdapterMetric('odds', 'success', {
+      latencyMs: Date.now() - start,
+    });
+    return data;
+  } catch (err) {
+    await logAdapterMetric('odds', 'error', { message: (err as Error).message });
+    const failures = (await cache.get<number>('odds:failures')) ?? 0;
+    const next = failures + 1;
+    await cache.set('odds:failures', next, CIRCUIT_TTL);
+    if (next >= ERROR_BUDGET) {
+      await cache.set(circuitKey, true, CIRCUIT_TTL);
+      await logAdapterMetric('odds', 'circuit_open', { failures: next });
+    }
+    return cached ?? [];
   }
-  const data = z.array(OddsGameSchema).parse(await res.json());
-  return data;
 }

--- a/lib/data/stats.ts
+++ b/lib/data/stats.ts
@@ -1,13 +1,36 @@
 import { z } from 'zod';
 import { ENV } from '../env';
 import type { League } from './schedule';
+import { getCacheDriver } from '../infra/cache';
+import { logAdapterMetric } from '../analytics/logUiEvent';
 
-const TeamStatSchema = z.object({
-  team: z.string(),
-  efficiency: z.number(),
-});
+const TeamStatSchema = z
+  .object({
+    team: z.string(),
+    efficiency: z.number(),
+  })
+  .strict();
 
 export type TeamStat = z.infer<typeof TeamStatSchema>;
+
+const CACHE_TTL = 60; // seconds
+const CIRCUIT_TTL = 600; // 10 minutes
+export const ERROR_BUDGET = 3;
+const PROVIDER_TIMEOUT_MS = 3000;
+
+async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeout = PROVIDER_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 async function fetchWithRetry(
   url: string,
@@ -15,22 +38,48 @@ async function fetchWithRetry(
   retries = 2,
   backoff = 500
 ): Promise<Response> {
-  let res: Response = await fetch(url, options);
+  let res: Response = await fetchWithTimeout(url, options);
   for (let attempt = 0; attempt < retries && res.status === 429; attempt++) {
     await new Promise((r) => setTimeout(r, backoff * (attempt + 1)));
-    res = await fetch(url, options);
+    res = await fetchWithTimeout(url, options);
   }
   return res;
 }
 
 export async function fetchStats(_league: League): Promise<TeamStat[]> {
   if (ENV.LIVE_MODE !== 'on') return [];
+  const cache = getCacheDriver();
+  const circuitKey = 'stats:circuit';
+  if (await cache.get<boolean>(circuitKey)) {
+    await logAdapterMetric('stats', 'circuit_bypass');
+    return [];
+  }
+  const cacheKey = 'stats:data';
+  const cached = await cache.get<TeamStat[]>(cacheKey);
+  if (cached) return cached;
+
   // Placeholder API - replace with real stats endpoint when available
   const url = 'https://example.com/stats';
-  const res = await fetchWithRetry(url);
-  if (res.status === 429) {
-    throw new Error('STATS_API_RATE_LIMIT');
+  const start = Date.now();
+  try {
+    const res = await fetchWithRetry(url);
+    if (res.status === 429) {
+      throw new Error('STATS_API_RATE_LIMIT');
+    }
+    const data = z.array(TeamStatSchema).parse(await res.json());
+    await cache.set(cacheKey, data, CACHE_TTL);
+    await cache.set('stats:failures', 0, CIRCUIT_TTL);
+    await logAdapterMetric('stats', 'success', { latencyMs: Date.now() - start });
+    return data;
+  } catch (err) {
+    await logAdapterMetric('stats', 'error', { message: (err as Error).message });
+    const failures = (await cache.get<number>('stats:failures')) ?? 0;
+    const next = failures + 1;
+    await cache.set('stats:failures', next, CIRCUIT_TTL);
+    if (next >= ERROR_BUDGET) {
+      await cache.set(circuitKey, true, CIRCUIT_TTL);
+      await logAdapterMetric('stats', 'circuit_open', { failures: next });
+    }
+    return cached ?? [];
   }
-  const data = z.array(TeamStatSchema).parse(await res.json());
-  return data;
 }

--- a/llms.txt
+++ b/llms.txt
@@ -1630,3 +1630,17 @@ Files:
 
 
 
+Timestamp: 2025-08-08T05:57:18.828Z
+Commit: 2ac3632c371cee1fc090894dbd77fa6afb52c0ce
+Author: Codex
+Message: feat: harden live data adapters with caching and circuit breaker
+Files:
+- __tests__/adapters.circuit.test.ts (+26/-0)
+- __tests__/adapters.contract.test.ts (+42/-0)
+- __tests__/llmsLog.test.ts (+0/-1)
+- docs/api.md (+8/-0)
+- lib/analytics/logUiEvent.ts (+9/-0)
+- lib/data/injuries.ts (+65/-12)
+- lib/data/odds.ts (+87/-30)
+- lib/data/stats.ts (+60/-11)
+


### PR DESCRIPTION
## Summary
- add strict schemas, caching, timeouts, and circuit breakers for injuries, odds, and stats adapters
- track adapter metrics via logUiEvent and document adapter guarantees
- cover adapters with contract and circuit breaker tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958f0fd1108323896df2e552cdb9c1