### PR TITLE
feat: enforce auth for live-mode APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ npm run validate-env
 
 ### Live vs Mock
 
-Local dev defaults to **mock mode**: `NEXT_PUBLIC_MOCK_AUTH=1` and `LIVE_MODE=off`.
+Local dev defaults to **mock mode** with `LIVE_MODE=off`.
 Provide real keys later to test full OAuth + live data.
-Run-agents allows unauthenticated calls when `LIVE_MODE=off` or `NEXT_PUBLIC_MOCK_AUTH=1`.
+Run-agents returns mock data and bypasses auth when `LIVE_MODE=off`.
 
-#### Mock Auth
+#### Auth Guards
 
-`/api/dev-login` is only available during local development or when `NEXT_PUBLIC_MOCK_AUTH=1`. Other environments receive `403`.
+When `LIVE_MODE=on`, `/api/run-agents`, `/api/run-predictions`, and write requests to `/api/logs` require a valid session. Unauthenticated calls respond with `401` and `{ "error": "auth_required" }`.
+
+`/api/dev-login` is only available when `NODE_ENV=development`; other environments get a `404`.
 
 🧱 Architecture Overview
 
@@ -238,7 +240,7 @@ PRs are gated by CI + required review
 
 Example audit output:
 
-🔴 Missing auth on /api/run-predictions
+🟢 Auth enforced on /api/run-predictions
 
 🟡 No tests for trendsAgent
 

--- a/__tests__/__snapshots__/apiContracts.test.ts.snap
+++ b/__tests__/__snapshots__/apiContracts.test.ts.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`API contract schemas auth error schema snapshot 1`] = `
+{
+  "$ref": "#/definitions/AuthError",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "AuthError": {
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "const": "auth_required",
+          "type": "string",
+        },
+      },
+      "required": [
+        "error",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
 exports[`API contract schemas run-agents live schema snapshot 1`] = `
 {
   "$ref": "#/definitions/RunAgentsLive",

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,15 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-
-exports[`llms log writes entry (stable time) 1`] = `"80eeb373eb36f44b40767c06869803ba97acc6aa0b0882bba746b9e8452b81a2"`;
-=======
-
-exports[`llms log writes entry (stable time) 1`] = `"705052b32a7163cb3d08f0168eed6144faf55e4b3d9f447fc5e1463e0bf96c36"`;
-=======
-
-exports[`llms log writes entry (stable time) 1`] = `"f49e027919e1a0f553a79fbf2a797cd897b0f17bde0e734a4325d86b343311ba"`;
-=======
-exports[`llms log writes entry (stable time) 1`] = `"0fca79cfe9292549a71ee81eeb6d354d8f2ee5648887b9b33bf63e8fb60b8e81"`;
-
-
-
+exports[`llms log writes entry (stable time) 1`] = `"86161fca6f9b36c1e43fa4d214577c318b0c2f14abaaef8cc39a9baa8ac34d02"`;

--- a/__tests__/devlogin.test.ts
+++ b/__tests__/devlogin.test.ts
@@ -11,16 +11,12 @@ const mockRes = () => {
 
 describe('dev-login API', () => {
   const originalNodeEnv = process.env.NODE_ENV;
-  const originalMockAuth = process.env.NEXT_PUBLIC_MOCK_AUTH;
-
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
-    process.env.NEXT_PUBLIC_MOCK_AUTH = originalMockAuth;
   });
 
   it('returns mock user in development', async () => {
     process.env.NODE_ENV = 'development';
-    delete process.env.NEXT_PUBLIC_MOCK_AUTH;
 
     const req: any = {};
     const res = mockRes();
@@ -31,29 +27,15 @@ describe('dev-login API', () => {
     expect(res.json).toHaveBeenCalledWith({ id: 'dev-user', name: 'Dev User' });
   });
 
-  it('returns 403 in production without mock flag', async () => {
+  it('returns 404 outside development', async () => {
     process.env.NODE_ENV = 'production';
-    delete process.env.NEXT_PUBLIC_MOCK_AUTH;
 
     const req: any = {};
     const res = mockRes();
 
     await handler(req, res);
 
-    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).not.toHaveBeenCalled();
-  });
-
-  it('allows mock auth in production when flag set', async () => {
-    process.env.NODE_ENV = 'production';
-    process.env.NEXT_PUBLIC_MOCK_AUTH = '1';
-
-    const req: any = {};
-    const res = mockRes();
-
-    await handler(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ id: 'dev-user', name: 'Dev User' });
   });
 });

--- a/__tests__/llmsLog.test.ts
+++ b/__tests__/llmsLog.test.ts
@@ -13,7 +13,6 @@ afterAll(() => {
   unfreeze();
 });
 
-=======
 // Snapshot hash is sensitive to timestamps inside llms.txt. We freeze time so it
 // remains stable. Update the snapshot if the frozen ISO changes.
 

--- a/__tests__/runAgents.auth.test.ts
+++ b/__tests__/runAgents.auth.test.ts
@@ -2,13 +2,14 @@
 import { getServerSession } from 'next-auth/next';
 import { runFlow } from '../lib/flow/runFlow';
 import { fetchSchedule } from '../lib/data/schedule';
+import { ENV } from '../lib/env';
 
 jest.mock('next-auth/next');
 jest.mock('../lib/flow/runFlow');
 jest.mock('../lib/data/schedule');
 
 process.env.LIVE_MODE = 'on';
-
+ENV.LIVE_MODE = 'on' as any;
 const handler = require('../pages/api/run-agents').default;
 const mockedGetSession = getServerSession as jest.Mock;
 const mockedRunFlow = runFlow as jest.Mock;
@@ -23,8 +24,8 @@ describe('run-agents auth', () => {
   });
 
   afterEach(() => {
-    delete process.env.NEXT_PUBLIC_MOCK_AUTH;
     jest.clearAllMocks();
+    ENV.LIVE_MODE = 'on' as any;
   });
 
   it('returns 401 when no session and LIVE_MODE on', async () => {
@@ -35,6 +36,7 @@ describe('run-agents auth', () => {
     await handler(req, res);
 
     expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'auth_required' });
     expect(mockedRunFlow).not.toHaveBeenCalled();
   });
 
@@ -48,16 +50,14 @@ describe('run-agents auth', () => {
     expect(mockedRunFlow).toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
   });
-
-  it('allows without session when NEXT_PUBLIC_MOCK_AUTH=1', async () => {
-    process.env.NEXT_PUBLIC_MOCK_AUTH = '1';
+  it('allows without session when LIVE_MODE off', async () => {
+    ENV.LIVE_MODE = 'off' as any;
     mockedGetSession.mockResolvedValue(null);
     const req: any = { method: 'POST', body: { league: 'NFL', gameId: '1' } };
     const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
     await handler(req, res);
 
-    expect(mockedRunFlow).toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/__tests__/runAgentsApi.test.ts
+++ b/__tests__/runAgentsApi.test.ts
@@ -1,19 +1,24 @@
 /** @jest-environment node */
 import { runFlow } from '../lib/flow/runFlow';
 import { fetchSchedule } from '../lib/data/schedule';
+import { getServerSession } from 'next-auth/next';
+import { ENV } from '../lib/env';
 
 jest.mock('../lib/flow/runFlow');
 jest.mock('../lib/data/schedule');
+jest.mock('next-auth/next');
 
 process.env.LIVE_MODE = 'on';
-process.env.NEXT_PUBLIC_MOCK_AUTH = '1';
+ENV.LIVE_MODE = 'on' as any;
 
 const handler = require('../pages/api/run-agents').default;
 const mockedRunFlow = runFlow as jest.Mock;
 const mockedSchedule = fetchSchedule as jest.Mock;
+const mockedGetSession = getServerSession as jest.Mock;
 
 describe('run-agents API', () => {
   beforeEach(() => {
+    mockedGetSession.mockResolvedValue({ user: { id: '1' } });
     mockedSchedule.mockResolvedValue([
       { homeTeam: 'A', awayTeam: 'B', time: '', league: 'NFL', gameId: '1' },
     ]);
@@ -22,6 +27,10 @@ describe('run-agents API', () => {
         injuryScout: { team: 'A', score: 0.7, reason: 'healthy' },
       },
     });
+  });
+
+  afterAll(() => {
+    ENV.LIVE_MODE = 'off' as any;
   });
 
   it('returns pick and agents', async () => {

--- a/llms.txt
+++ b/llms.txt
@@ -1630,3 +1630,22 @@ Files:
 
 
 
+Timestamp: 2025-08-08T05:56:22.247Z
+Commit: 886484ad67ff08a052737703cd0e235e0526fb72
+Author: Codex
+Message: feat: guard live APIs with auth
+Files:
+- README.md (+7/-5)
+- __tests__/__snapshots__/apiContracts.test.ts.snap (+22/-0)
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-13)
+- __tests__/apiContracts.test.ts (+25/-2)
+- __tests__/devlogin.test.ts (+2/-20)
+- __tests__/llmsLog.test.ts (+0/-1)
+- __tests__/runAgents.auth.test.ts (+6/-6)
+- __tests__/runAgentsApi.test.ts (+10/-1)
+- middleware.ts (+27/-1)
+- pages/api/dev-login.ts (+3/-4)
+- pages/api/logs.ts (+9/-0)
+- pages/api/run-agents.ts (+2/-3)
+- pages/api/run-predictions.ts (+10/-5)
+

--- a/pages/api/dev-login.ts
+++ b/pages/api/dev-login.ts
@@ -1,10 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { NODE_ENV, NEXT_PUBLIC_MOCK_AUTH } = process.env;
-
-  if (NODE_ENV !== 'development' && NEXT_PUBLIC_MOCK_AUTH !== '1') {
-    return res.status(403).end();
+  if (process.env.NODE_ENV !== 'development') {
+    res.status(404).end();
+    return;
   }
 
   res.status(200).json({ id: 'dev-user', name: 'Dev User' });

--- a/pages/api/logs.ts
+++ b/pages/api/logs.ts
@@ -1,6 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs/promises';
 import path from 'path';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
 
 import { registry as agentRegistry } from '../../lib/agents/registry';
 import type { AgentMeta, AgentName } from '../../lib/agents/registry';
@@ -81,6 +83,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (req.method === 'DELETE') {
+    if (ENV.LIVE_MODE === 'on') {
+      const session = await getServerSession(req, res, authOptions);
+      if (!session) {
+        res.status(401).json({ error: 'auth_required' });
+        return;
+      }
+    }
     await clearAgentLogs();
     res.status(204).end();
     return;

--- a/pages/api/run-agents.ts
+++ b/pages/api/run-agents.ts
@@ -20,12 +20,11 @@ export default async function handler(
   }
 
   const liveMode = ENV?.LIVE_MODE ?? 'off';
-  const isMockAuth = process.env.NEXT_PUBLIC_MOCK_AUTH === '1';
 
-  if (liveMode !== 'off' && !isMockAuth) {
+  if (liveMode === 'on') {
     const session = await getServerSession(req, res, authOptions);
     if (!session) {
-      res.status(401).json({ error: 'Unauthorized' });
+      res.status(401).json({ error: 'auth_required' });
       return;
     }
   }

--- a/pages/api/run-predictions.ts
+++ b/pages/api/run-predictions.ts
@@ -29,10 +29,14 @@ interface Prediction {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getServerSession(req, res, authOptions);
-  if (!session) {
-    res.status(401).json({ error: 'Unauthorized' });
-    return;
+  const liveMode = ENV?.LIVE_MODE ?? 'off';
+  let session: any = null;
+  if (liveMode === 'on') {
+    session = await getServerSession(req, res, authOptions);
+    if (!session) {
+      res.status(401).json({ error: 'auth_required' });
+      return;
+    }
   }
 
   if (req.method !== 'POST') {
@@ -135,7 +139,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       { league },
       {
         requestId: req.headers['x-request-id']?.toString() || crypto.randomUUID(),
-        userId: (session.user as any)?.id || (session.user as any)?.email || undefined,
+        userId:
+          (session as any)?.user?.id || (session as any)?.user?.email || undefined,
       }
     );
 


### PR DESCRIPTION
## Summary
- guard run-agents, run-predictions and log writes behind auth when LIVE_MODE=on
- block dev-login outside development
- document live-mode auth guard and 401 shape

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68958ef5b380832389fe8cc3710cea34