### PR TITLE
feat: add RLS policies with pgTAP tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,3 +16,24 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm test
+
+  db:
+    runs-on: ubuntu-latest
+    container: postgres:15
+    env:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pgTAP
+        run: |
+          apt-get update
+          apt-get install -y postgresql-15-pgtap
+      - name: Wait for Postgres
+        run: |
+          until pg_isready -h localhost; do sleep 1; done
+      - name: Apply schema
+        run: psql -h localhost -U postgres -f supabase/schema.sql
+      - name: Run policy tests
+        run: psql -h localhost -U postgres -v ON_ERROR_STOP=1 -f db/policies.test.sql

--- a/__tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap
+++ b/__tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap
@@ -32,6 +32,16 @@ exports[`docs refresh snapshots generates docs 3`] = `
 "\`\`\`sql
 -- Supabase schema for EdgePicks
 
+create schema if not exists auth;
+
+create or replace function auth.uid() returns text as $$
+  select current_setting('request.jwt.claim.sub', true);
+$$ language sql stable;
+
+create or replace function auth.role() returns text as $$
+  select current_setting('request.jwt.claim.role', true);
+$$ language sql stable;
+
 create table if not exists matchups (
   id uuid primary key default gen_random_uuid(),
   team_a text not null,
@@ -43,7 +53,9 @@ create table if not exists matchups (
   actual_winner text,
   is_auto_pick boolean,
   extras jsonb,
-  created_at timestamptz default now()
+  created_at timestamptz default now(),
+  user_id text,
+  is_public boolean default false
 );
 
 create table if not exists agent_stats (
@@ -98,7 +110,7 @@ create table if not exists agent_outcomes (
 
 -- Indexes
 create index if not exists logs_user_id_ts_idx on logs (user_id, ts);
-create index if not exists matchups_game_id_idx on matchups (game_id);
+create index if not exists matchups_user_id_idx on matchups (user_id);
 create index if not exists predictions_user_id_created_at_idx on predictions (user_id, created_at);
 
 -- Row Level Security policies
@@ -110,6 +122,9 @@ create policy "Users can view their logs" on logs
   for select using (auth.uid() = user_id);
 create policy "Users can insert their logs" on logs
   for insert with check (auth.uid() = user_id);
+create policy "Users can update their logs" on logs
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to logs" on logs
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
@@ -118,12 +133,20 @@ create policy "Users can view their predictions" on predictions
   for select using (auth.uid() = user_id);
 create policy "Users can insert their predictions" on predictions
   for insert with check (auth.uid() = user_id);
+create policy "Users can update their predictions" on predictions
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to predictions" on predictions
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
 
 create policy "Public read access to matchups" on matchups
-  for select using (true);
+  for select using (is_public or auth.uid() = user_id);
+create policy "Users can insert their matchups" on matchups
+  for insert with check (auth.uid() = user_id);
+create policy "Users can update their matchups" on matchups
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to matchups" on matchups
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');

--- a/db/policies.test.sql
+++ b/db/policies.test.sql
@@ -1,32 +1,74 @@
 -- db/policies.test.sql
--- Validate RLS policies for logs, predictions, and matchups tables.
--- Uses pgTAP style tests.
+-- Validate RLS policies for logs, predictions, and matchups using pgTAP.
+
+create extension if not exists pgtap;
+create schema if not exists auth;
+
+create or replace function auth.uid() returns text as $$
+  select current_setting('request.jwt.claim.sub', true);
+$$ language sql stable;
+
+create or replace function auth.role() returns text as $$
+  select current_setting('request.jwt.claim.role', true);
+$$ language sql stable;
+
+do $$
+begin
+  create role anon login;
+  create role authenticated login;
+  create role service_role login;
+exception when duplicate_object then null;
+end$$;
+
+grant usage on schema public to anon, authenticated, service_role;
+grant all on all tables in schema public to anon, authenticated, service_role;
+grant all on all sequences in schema public to anon, authenticated, service_role;
 
 begin;
-select plan(7);
+select plan(14);
 
 -- Seed data as service role
 set role service_role;
-insert into logs (kind, user_id) values ('test', 'user1');
-insert into predictions (user_id, created_at) values ('user1', now());
-insert into matchups (team_a, team_b, agents, pick, flow) values ('A', 'B', '{}'::jsonb, '{}'::jsonb, 'football-pick');
+select set_config('request.jwt.claim.role','service_role',true);
+insert into matchups (team_a, team_b, agents, pick, flow, user_id, is_public) values
+('A','B','{}'::jsonb,'{}'::jsonb,'football-pick','user1', false),
+('C','D','{}'::jsonb,'{}'::jsonb,'football-pick','user2', true);
+insert into logs (kind, user_id) values ('test1','user1'), ('test2','user2');
+insert into predictions (user_id, matchup_id, prediction) values
+('user1',(select id from matchups where user_id='user1'),'{}'::jsonb),
+('user2',(select id from matchups where user_id='user2'),'{}'::jsonb);
 
--- anon role: can read matchups but not logs or predictions
+-- anon role: only public matchups, no logs or predictions
 set role anon;
-select ok((select count(*) from matchups) > 0, 'anon can read matchups');
-select throws_like('select * from logs', '%policy%', 'anon cannot read logs');
-select throws_like('select * from predictions', '%policy%', 'anon cannot read predictions');
+select set_config('request.jwt.claim.role','anon',true);
+select ok((select count(*) from matchups) = 1, 'anon sees only public matchups');
+select is_empty('select * from logs', 'anon cannot read logs');
+select is_empty('select * from predictions', 'anon cannot read predictions');
 
--- service role: full access
-set role service_role;
-select ok((select count(*) from logs) = 1, 'service role can read logs');
-select ok((select count(*) from predictions) = 1, 'service role can read predictions');
-
--- authenticated user: access only own rows
+-- authenticated user1: own rows + public matchups
 set role authenticated;
-select set_config('request.jwt.claims', '{"sub":"user1"}', true);
-select ok((select count(*) from logs) = 1, 'user1 can read own logs');
-select ok((select count(*) from predictions) = 1, 'user1 can read own predictions');
+select set_config('request.jwt.claim.role','authenticated',true);
+select set_config('request.jwt.claim.sub','user1',true);
+select ok((select count(*) from logs) = 1, 'user1 sees own logs');
+select ok((select count(*) from predictions) = 1, 'user1 sees own predictions');
+select ok((select count(*) from matchups) = 2, 'user1 sees own and public matchups');
+select throws_like('insert into logs(kind,user_id) values (''hack'',''user2'')', '%policy%', 'user1 cannot insert log for others');
+select throws_like('insert into predictions(user_id, matchup_id) values (''user2'', (select id from matchups limit 1))', '%policy%', 'user1 cannot insert prediction for others');
+select throws_like('insert into matchups(team_a,team_b,agents,pick,flow,user_id) values (''E'',''F'',''{}''::jsonb,''{}''::jsonb,''football-pick'',''user2'')', '%policy%', 'user1 cannot insert matchup for others');
+
+-- authenticated user2: own rows, no access to user1 private matchup
+set role authenticated;
+select set_config('request.jwt.claim.role','authenticated',true);
+select set_config('request.jwt.claim.sub','user2',true);
+select ok((select count(*) from logs) = 1, 'user2 sees own logs');
+select ok((select count(*) from matchups) = 1, 'user2 does not see user1 private matchup');
+
+-- service role bypass
+set role service_role;
+select set_config('request.jwt.claim.role','service_role',true);
+select ok((select count(*) from logs) = 2, 'service role reads all logs');
+select ok((select count(*) from predictions) = 2, 'service role reads all predictions');
+select ok((select count(*) from matchups) = 2, 'service role reads all matchups');
 
 select finish();
 rollback;

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1,6 +1,16 @@
 ```sql
 -- Supabase schema for EdgePicks
 
+create schema if not exists auth;
+
+create or replace function auth.uid() returns text as $$
+  select current_setting('request.jwt.claim.sub', true);
+$$ language sql stable;
+
+create or replace function auth.role() returns text as $$
+  select current_setting('request.jwt.claim.role', true);
+$$ language sql stable;
+
 create table if not exists matchups (
   id uuid primary key default gen_random_uuid(),
   team_a text not null,
@@ -12,7 +22,9 @@ create table if not exists matchups (
   actual_winner text,
   is_auto_pick boolean,
   extras jsonb,
-  created_at timestamptz default now()
+  created_at timestamptz default now(),
+  user_id text,
+  is_public boolean default false
 );
 
 create table if not exists agent_stats (
@@ -67,7 +79,7 @@ create table if not exists agent_outcomes (
 
 -- Indexes
 create index if not exists logs_user_id_ts_idx on logs (user_id, ts);
-create index if not exists matchups_game_id_idx on matchups (game_id);
+create index if not exists matchups_user_id_idx on matchups (user_id);
 create index if not exists predictions_user_id_created_at_idx on predictions (user_id, created_at);
 
 -- Row Level Security policies
@@ -79,6 +91,9 @@ create policy "Users can view their logs" on logs
   for select using (auth.uid() = user_id);
 create policy "Users can insert their logs" on logs
   for insert with check (auth.uid() = user_id);
+create policy "Users can update their logs" on logs
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to logs" on logs
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
@@ -87,12 +102,20 @@ create policy "Users can view their predictions" on predictions
   for select using (auth.uid() = user_id);
 create policy "Users can insert their predictions" on predictions
   for insert with check (auth.uid() = user_id);
+create policy "Users can update their predictions" on predictions
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to predictions" on predictions
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
 
 create policy "Public read access to matchups" on matchups
-  for select using (true);
+  for select using (is_public or auth.uid() = user_id);
+create policy "Users can insert their matchups" on matchups
+  for insert with check (auth.uid() = user_id);
+create policy "Users can update their matchups" on matchups
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to matchups" on matchups
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');

--- a/llms.txt
+++ b/llms.txt
@@ -1630,3 +1630,15 @@ Files:
 
 
 
+Timestamp: 2025-08-08T05:55:43.160Z
+Commit: 04fe0dfb7156e76c7092c45864487d5fa573581e
+Author: Codex
+Message: feat(db): add rls policies and tests
+Files:
+- .github/workflows/ci-tests.yml (+21/-0)
+- __tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap (+26/-3)
+- db/policies.test.sql (+60/-18)
+- docs/db-schema.md (+26/-3)
+- supabase/migrations/20240901000000_add_indexes_and_rls.sql (+27/-6)
+- supabase/schema.sql (+26/-3)
+

--- a/supabase/migrations/20240901000000_add_indexes_and_rls.sql
+++ b/supabase/migrations/20240901000000_add_indexes_and_rls.sql
@@ -1,5 +1,13 @@
--- Add indexes and RLS policies for logs, predictions, matchups
--- Ensure predictions table exists
+create schema if not exists auth;
+
+create or replace function auth.uid() returns text as $$
+  select current_setting('request.jwt.claim.sub', true);
+$$ language sql stable;
+
+create or replace function auth.role() returns text as $$
+  select current_setting('request.jwt.claim.role', true);
+$$ language sql stable;
+
 create table if not exists predictions (
   id uuid primary key default gen_random_uuid(),
   user_id text not null,
@@ -8,10 +16,13 @@ create table if not exists predictions (
   created_at timestamptz default now()
 );
 
+-- Ensure matchups has ownership and visibility columns
+alter table matchups add column if not exists user_id text;
+alter table matchups add column if not exists is_public boolean default false;
 
--- Indexes
+
 create index if not exists logs_user_id_ts_idx on logs (user_id, ts);
-create index if not exists matchups_game_id_idx on matchups (game_id);
+create index if not exists matchups_user_id_idx on matchups (user_id);
 create index if not exists predictions_user_id_created_at_idx on predictions (user_id, created_at);
 
 -- Enable RLS
@@ -24,6 +35,9 @@ create policy "Users can view their logs" on logs
   for select using (auth.uid() = user_id);
 create policy "Users can insert their logs" on logs
   for insert with check (auth.uid() = user_id);
+create policy "Users can update their logs" on logs
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to logs" on logs
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
@@ -33,13 +47,20 @@ create policy "Users can view their predictions" on predictions
   for select using (auth.uid() = user_id);
 create policy "Users can insert their predictions" on predictions
   for insert with check (auth.uid() = user_id);
+create policy "Users can update their predictions" on predictions
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to predictions" on predictions
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');
 
--- Matchups policies
 create policy "Public read access to matchups" on matchups
-  for select using (true);
+  for select using (is_public or auth.uid() = user_id);
+create policy "Users can insert their matchups" on matchups
+  for insert with check (auth.uid() = user_id);
+create policy "Users can update their matchups" on matchups
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
 create policy "Service role full access to matchups" on matchups
   for all using (auth.role() = 'service_role')
   with check (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- enforce RLS and indexes for logs, predictions and matchups tables
- add pgTAP policy tests and CI job to run them
- document updated schema with auth helpers and public matchups

## Testing
- `psql -v ON_ERROR_STOP=1 -f db/policies.test.sql`
- `npm test` *(fails: Merge conflict marker in __tests__/llmsLog.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68958f2636e08323b0af34a40f25abcc