### PR TITLE
feat: snapshot dynamic weights

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,15 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-
-exports[`llms log writes entry (stable time) 1`] = `"80eeb373eb36f44b40767c06869803ba97acc6aa0b0882bba746b9e8452b81a2"`;
-=======
-
-exports[`llms log writes entry (stable time) 1`] = `"705052b32a7163cb3d08f0168eed6144faf55e4b3d9f447fc5e1463e0bf96c36"`;
-=======
-
-exports[`llms log writes entry (stable time) 1`] = `"f49e027919e1a0f553a79fbf2a797cd897b0f17bde0e734a4325d86b343311ba"`;
-=======
-exports[`llms log writes entry (stable time) 1`] = `"0fca79cfe9292549a71ee81eeb6d354d8f2ee5648887b9b33bf63e8fb60b8e81"`;
-
-
-
+exports[`llms log writes entry (stable time) 1`] = `"86161fca6f9b36c1e43fa4d214577c318b0c2f14abaaef8cc39a9baa8ac34d02"`;

--- a/__tests__/llmsLog.test.ts
+++ b/__tests__/llmsLog.test.ts
@@ -13,7 +13,6 @@ afterAll(() => {
   unfreeze();
 });
 
-=======
 // Snapshot hash is sensitive to timestamps inside llms.txt. We freeze time so it
 // remains stable. Update the snapshot if the frozen ISO changes.
 

--- a/__tests__/runPredictions.weights.test.ts
+++ b/__tests__/runPredictions.weights.test.ts
@@ -60,7 +60,7 @@ describe('run-predictions dynamic weights', () => {
 
     expect(mockedWeights).toHaveBeenCalled();
     const data = json.mock.calls[0][0];
-    expect(data.weights.injuryScout).toBe(0.8);
+    expect(data.weightsUsed.injuryScout).toBe(0.8);
     expect(data.predictions[0].confidence).toBe(72);
   });
 
@@ -82,7 +82,7 @@ describe('run-predictions dynamic weights', () => {
     await handler(req, res);
 
     const data = json.mock.calls[0][0];
-    expect(data.weights.injuryScout).toBe(0.5);
+    expect(data.weightsUsed.injuryScout).toBe(0.5);
     expect(data.predictions[0].confidence).toBe(45);
   });
 });

--- a/__tests__/weights.snapshot.test.ts
+++ b/__tests__/weights.snapshot.test.ts
@@ -1,0 +1,44 @@
+jest.mock('../lib/supabaseClient', () => ({ supabase: { from: jest.fn() } }));
+import { getDynamicWeights } from '../lib/weights';
+import { supabase } from '../lib/supabaseClient';
+
+describe('getDynamicWeights snapshots', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads latest snapshot first', async () => {
+    const limit = jest.fn().mockResolvedValue({
+      data: [
+        { agent: 'injuryScout', weight: 0.7, ts: '2024-02-01' },
+        { agent: 'injuryScout', weight: 0.6, ts: '2024-01-01' },
+      ],
+      error: null,
+    });
+    const order = jest.fn().mockReturnValue({ limit });
+    const select = jest.fn().mockReturnValue({ order });
+    (supabase.from as jest.Mock).mockReturnValueOnce({ select });
+
+    const weights = await getDynamicWeights();
+    expect(supabase.from).toHaveBeenCalledWith('agent_weights_snapshot');
+    expect(weights.injuryScout).toBe(0.7);
+  });
+
+  it('falls back to compute when no snapshot', async () => {
+    const limitSnap = jest.fn().mockResolvedValue({ data: [], error: null });
+    const orderSnap = jest.fn().mockReturnValue({ limit: limitSnap });
+    const selectSnap = jest.fn().mockReturnValue({ order: orderSnap });
+    const selectStats = jest.fn().mockResolvedValue({
+      data: [{ agent: 'injuryScout', wins: 1, losses: 0 }],
+      error: null,
+    });
+    (supabase.from as jest.Mock)
+      .mockReturnValueOnce({ select: selectSnap })
+      .mockReturnValueOnce({ select: selectStats });
+
+    const weights = await getDynamicWeights();
+    expect(supabase.from).toHaveBeenCalledWith('agent_weights_snapshot');
+    expect(supabase.from).toHaveBeenCalledWith('agent_stats');
+    expect(weights.injuryScout).toBeGreaterThan(0.5);
+  });
+});

--- a/llms.txt
+++ b/llms.txt
@@ -1630,3 +1630,18 @@ Files:
 
 
 
+Timestamp: 2025-08-08T06:01:23.168Z
+Commit: 1fde5c5b6505b336c8f10b4504620d89fe4ccafe
+Author: Codex
+Message: feat: snapshot dynamic weights
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-13)
+- __tests__/llmsLog.test.ts (+0/-1)
+- __tests__/runPredictions.weights.test.ts (+2/-2)
+- __tests__/weights.snapshot.test.ts (+44/-0)
+- lib/weights/index.ts (+25/-0)
+- pages/admin/weights.tsx (+86/-0)
+- pages/api/run-predictions.ts (+14/-4)
+- scripts/snapshotWeights.ts (+40/-0)
+- supabase/migrations/20240915000000_create_agent_weights_snapshot_table.sql (+9/-0)
+

--- a/pages/admin/weights.tsx
+++ b/pages/admin/weights.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import type { GetServerSideProps } from 'next';
+import { getSession } from 'next-auth/react';
+import { supabase } from '../../lib/supabaseClient';
+import { ENV } from '../../lib/env';
+
+interface SnapshotRow {
+  agent: string;
+  alpha: number;
+  beta: number;
+  weight: number;
+  sample_size: number;
+  ts: string;
+}
+
+interface Props {
+  snapshots: SnapshotRow[];
+  flag: string;
+}
+
+const WeightsAdminPage: React.FC<Props> = ({ snapshots, flag }) => {
+  const toggle = async () => {
+    const target = flag === 'on' ? 'off' : 'on';
+    await fetch(`/admin/weights?toggle=${target}`);
+    window.location.reload();
+  };
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Agent Weights Snapshot</h1>
+      <button
+        className="border px-2 py-1 mb-4"
+        onClick={toggle}
+      >
+        WEIGHTS_DYNAMIC: {flag}
+      </button>
+      <table className="table-auto border">
+        <thead>
+          <tr>
+            <th className="border px-2">Agent</th>
+            <th className="border px-2">Weight</th>
+            <th className="border px-2">α</th>
+            <th className="border px-2">β</th>
+            <th className="border px-2">Samples</th>
+            <th className="border px-2">Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {snapshots.map((s, idx) => (
+            <tr key={idx}>
+              <td className="border px-2">{s.agent}</td>
+              <td className="border px-2">{s.weight.toFixed(3)}</td>
+              <td className="border px-2">{s.alpha}</td>
+              <td className="border px-2">{s.beta}</td>
+              <td className="border px-2">{s.sample_size}</td>
+              <td className="border px-2">{new Date(s.ts).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const session = await getSession(ctx);
+  if (!session) {
+    return { redirect: { destination: '/auth/signin', permanent: false } };
+  }
+  const toggle = ctx.query.toggle as string | undefined;
+  if (toggle === 'on' || toggle === 'off') {
+    (ENV as any).WEIGHTS_DYNAMIC = toggle;
+  }
+  const { data } = await supabase
+    .from('agent_weights_snapshot')
+    .select('*')
+    .order('ts', { ascending: false })
+    .limit(20);
+  return {
+    props: {
+      snapshots: data || [],
+      flag: ENV.WEIGHTS_DYNAMIC,
+    },
+  };
+};
+
+export default WeightsAdminPage;

--- a/scripts/snapshotWeights.ts
+++ b/scripts/snapshotWeights.ts
@@ -1,0 +1,40 @@
+import { supabase } from '../lib/supabaseClient';
+import { computeWeight } from '../lib/weights';
+
+interface AgentStatsRow {
+  agent: string;
+  wins: number | null;
+  losses: number | null;
+}
+
+export async function run(): Promise<void> {
+  const { data, error } = await supabase
+    .from('agent_stats')
+    .select('agent, wins, losses');
+  if (error || !data) {
+    console.error('Failed to load agent_stats', error?.message);
+    return;
+  }
+  const rows = (data as AgentStatsRow[]).map((row) => {
+    const wins = row.wins ?? 0;
+    const losses = row.losses ?? 0;
+    const weight = computeWeight({ wins, losses });
+    return {
+      agent: row.agent,
+      alpha: wins + 1,
+      beta: losses + 1,
+      weight,
+      sample_size: wins + losses,
+    };
+  });
+  const { error: insertError } = await supabase
+    .from('agent_weights_snapshot')
+    .insert(rows);
+  if (insertError) {
+    console.error('Failed to insert agent_weights_snapshot', insertError.message);
+  }
+}
+
+if (require.main === module) {
+  run();
+}

--- a/supabase/migrations/20240915000000_create_agent_weights_snapshot_table.sql
+++ b/supabase/migrations/20240915000000_create_agent_weights_snapshot_table.sql
@@ -1,0 +1,9 @@
+create table if not exists agent_weights_snapshot (
+  agent text not null,
+  alpha float not null,
+  beta float not null,
+  weight float not null,
+  sample_size int not null,
+  ts timestamptz not null default now(),
+  primary key (agent, ts)
+);


### PR DESCRIPTION
## Summary
- snapshot agent weights to `agent_weights_snapshot`
- expose weights snapshot in API and admin page
- add nightly snapshot script and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958f02d38883238b23765636c79d8f