### PR TITLE
Improve prediction drawer SSE resiliency

### DIFF
--- a/lib/analytics/logUiEvent.ts
+++ b/lib/analytics/logUiEvent.ts
@@ -1,0 +1,33 @@
+import { triggerToast } from '../useToast';
+
+export async function logUiEvent(
+  uiEvent: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const meta = metadata ?? {};
+    console.log(`[UI EVENT] ${uiEvent}`, Object.keys(meta).length ? meta : '');
+
+    if (typeof window !== 'undefined') {
+      await fetch('/api/log-status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event: uiEvent, metadata: meta }),
+      });
+      return;
+    }
+
+    const { supabase } = await import('../supabaseClient');
+    await supabase.from('ui_events').insert({
+      event: uiEvent,
+      metadata: meta,
+      created_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error('Failed to log UI event', err);
+    triggerToast({
+      message: 'Unable to log event; please sign in again',
+      type: 'error',
+    });
+  }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1630,3 +1630,13 @@ Files:
 
 
 
+Timestamp: 2025-08-08T06:30:32.153Z
+Commit: 5857e140c1abb35a76c8db494d4428a89d9ee946
+Author: Codex
+Message: Improve prediction drawer SSE resiliency
+Files:
+- __tests__/PredictionDrawer.sse.test.tsx (+31/-0)
+- components/PredictionDrawer.tsx (+36/-12)
+- lib/analytics/logUiEvent.ts (+33/-0)
+- lib/hooks/useEventSource.ts (+41/-2)
+


### PR DESCRIPTION
## Summary
- add resilient SSE hook with jittered backoff, heartbeats, and route-change cancelation
- polish prediction drawer UX with sticky header, share link and keyboard focus trap
- move UI event logging helper under analytics

## Testing
- `npm test __tests__/PredictionDrawer.sse.test.tsx __tests__/LandingDeepLink.test.tsx` *(PredictionDrawer.sse passes; LandingDeepLink test executed but output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68958ee8d8dc8323b82933385c4440a3