### PR TITLE
feat: add advanced agent graph view

### DIFF
--- a/__tests__/viz.playground.test.tsx
+++ b/__tests__/viz.playground.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import VizPage from '../pages/viz';
 import { happyPath } from '../lib/mock/agentRuns';
 
-jest.mock('../components/AgentNodeGraph', () => ({ statuses }: any) => (
-  <div data-testid="graph">{Object.keys(statuses).join(',')}</div>
+jest.mock('../components/AgentNodeGraph', () => ({ nodes }: any) => (
+  <div data-testid="graph">{nodes.map((n: any) => n.id).join(',')}</div>
 ));
 
 jest.useFakeTimers();

--- a/components/PredictionDrawer.tsx
+++ b/components/PredictionDrawer.tsx
@@ -24,7 +24,8 @@ interface AgentExecution extends BaseAgentExecution {
 }
 
 const PredictionDrawer: React.FC<Props> = ({ game, isOpen, onClose }) => {
-  const { statuses, handleLifecycleEvent, reset } = useFlowVisualizer();
+  const { statuses, handleLifecycleEvent, reset, nodes, edges } =
+    useFlowVisualizer();
   const [executions, setExecutions] = useState<AgentExecution[]>([]);
   const [pick, setPick] = useState<PickSummary | null>(null);
   const [confidence, setConfidence] = useState(0);
@@ -161,7 +162,7 @@ const PredictionDrawer: React.FC<Props> = ({ game, isOpen, onClose }) => {
           <div className="text-xs text-gray-400">{new Date(game.time).toLocaleString()}</div>
         </header>
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
-          <AgentNodeGraph statuses={statuses} />
+          <AgentNodeGraph nodes={nodes} edges={edges} />
           {pick ? (
             <PickSummaryComp
               teamA={game.homeTeam}

--- a/components/PredictionsPanel.tsx
+++ b/components/PredictionsPanel.tsx
@@ -1,16 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
+import AgentNodeGraph from './AgentNodeGraph';
 import type { AgentOutputs, AgentLifecycle, PickSummary, AgentName } from '../lib/types';
+import type { FlowNode, FlowEdge } from '../lib/dashboard/useFlowVisualizer';
 
 interface Props {
   agents: AgentOutputs;
   pick: PickSummary | null;
   statuses: Record<AgentName, { status: AgentLifecycle['status'] | 'idle'; durationMs?: number }>;
+  nodes: FlowNode[];
+  edges: FlowEdge[];
 }
 
-const PredictionsPanel: React.FC<Props> = ({ agents, pick, statuses }) => {
+const PredictionsPanel: React.FC<Props> = ({
+  agents,
+  pick,
+  statuses,
+  nodes,
+  edges,
+}) => {
+  const [advanced, setAdvanced] = useState(false);
   const agentNames = Object.keys(agents) as AgentName[];
   return (
     <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Matchup Insights</h2>
+        <button
+          className="text-sm text-blue-500 underline"
+          onClick={() => setAdvanced((v) => !v)}
+        >
+          {advanced ? 'Basic View' : 'Advanced View'}
+        </button>
+      </div>
+      {advanced && <AgentNodeGraph nodes={nodes} edges={edges} />}
       {pick && (
         <div className="p-4 bg-white/10 rounded">
           <h2 className="text-xl font-semibold">Prediction: {pick.winner}</h2>

--- a/lib/hooks/useEventSource.ts
+++ b/lib/hooks/useEventSource.ts
@@ -29,13 +29,7 @@ export default function useEventSource(
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastActivityRef = useRef<number>(Date.now());
-  const router = (() => {
-    try {
-      return useRouter();
-    } catch {
-      return null as any;
-    }
-  })();
+  const router = useRouter();
 
   const connect = () => {
     if (!url || !enabled) return;

--- a/llms.txt
+++ b/llms.txt
@@ -1751,3 +1751,16 @@ Files:
 - styles/globals.css (+5/-0)
 - styles/typography.css (+8/-0)
 
+Timestamp: 2025-08-08T07:11:22.947Z
+Commit: a4aa3e5dc4e6f338de732b9124c23bba3e027dd3
+Author: Codex
+Message: feat: add advanced agent graph view
+Files:
+- __tests__/viz.playground.test.tsx (+2/-2)
+- components/AgentNodeGraph.tsx (+95/-68)
+- components/AgentVizCanvas.tsx (+30/-11)
+- components/PredictionDrawer.tsx (+3/-2)
+- components/PredictionsPanel.tsx (+23/-2)
+- lib/hooks/useEventSource.ts (+1/-7)
+- pages/predictions.tsx (+9/-2)
+

--- a/pages/predictions.tsx
+++ b/pages/predictions.tsx
@@ -8,7 +8,8 @@ import type { AgentExecution } from '../lib/flow/runFlow';
 const PredictionsPage: React.FC = () => {
   const [agents, setAgents] = useState<AgentOutputs>({});
   const [pick, setPick] = useState<PickSummary | null>(null);
-  const { statuses, handleLifecycleEvent, reset } = useFlowVisualizer();
+  const { statuses, handleLifecycleEvent, reset, nodes, edges } =
+    useFlowVisualizer();
 
   return (
     <main className="min-h-screen p-6 space-y-6 bg-neutral-100 dark:bg-neutral-900">
@@ -28,7 +29,13 @@ const PredictionsPage: React.FC = () => {
         onComplete={(data: { pick: PickSummary }) => setPick(data.pick)}
         onLifecycle={handleLifecycleEvent}
       />
-      <PredictionsPanel agents={agents} pick={pick} statuses={statuses} />
+      <PredictionsPanel
+        agents={agents}
+        pick={pick}
+        statuses={statuses}
+        nodes={nodes}
+        edges={edges}
+      />
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- add AgentNodeGraph with arrow connections and pulsing active nodes
- expose advanced view toggle in predictions panel and wire up graph data
- update prediction drawer and viz canvas to consume new node graph API

## Testing
- `npm test` *(fails: upcoming-games API joins odds data, llms log snapshot)*
- `npm test __tests__/upcomingGamesApi.joinOdds.test.ts` *(fails: joins odds data with schedule)*
- `npm test __tests__/llmsLog.test.ts` *(fails: writes entry snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_6895a10df0c88323b81500c198c194a9