### PR TITLE
Stabilize odds join and freeze log timestamps

### DIFF
--- a/__tests__/PredictionDrawer.sse.test.tsx
+++ b/__tests__/PredictionDrawer.sse.test.tsx
@@ -7,6 +7,9 @@ jest.mock('../components/PickSummary', () => () => <div />);
 jest.mock('../components/AgentNodeGraph', () => () => <div />);
 jest.mock('../components/AgentRationalePanel', () => () => <div />);
 jest.mock('../components/ConfidenceMeter', () => () => <div />);
+jest.mock('next/router', () => ({
+  useRouter: () => ({ replace: jest.fn(), prefetch: jest.fn(), push: jest.fn() }),
+}));
 
 class MockEventSource {
   onmessage: ((ev: any) => void) | null = null;

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"6a22624626995da2ba93b63ce44081516a76586a7b5d027a64fa68842afdeafa"`;
+exports[`llms log writes entry (stable time) 1`] = `"9a9b3b98eb9a8ed15fca7b974607406a49433bb1f1b13f7fe9463c207cf12227"`;

--- a/__tests__/fixtures/odds.json
+++ b/__tests__/fixtures/odds.json
@@ -1,0 +1,28 @@
+[
+  {
+    "home_team": "A",
+    "away_team": "B",
+    "bookmakers": [
+      {
+        "title": "Book",
+        "last_update": "2020",
+        "markets": [
+          { "key": "h2h", "outcomes": [ { "name": "A", "price": -110 }, { "name": "B", "price": 100 } ] },
+          { "key": "spreads", "outcomes": [ { "name": "A", "point": -3.5 }, { "name": "B", "point": 3.5 } ] },
+          { "key": "totals", "outcomes": [ { "name": "over", "point": 40.5 } ] }
+        ]
+      }
+    ]
+  },
+  {
+    "home_team": "E",
+    "away_team": "F",
+    "bookmakers": [
+      {
+        "title": "OtherBook",
+        "last_update": "2020",
+        "markets": []
+      }
+    ]
+  }
+]

--- a/__tests__/fixtures/schedule.json
+++ b/__tests__/fixtures/schedule.json
@@ -1,0 +1,5 @@
+[
+  { "homeTeam": "C", "awayTeam": "D", "time": "2020-01-02T00:00:00Z", "league": "NFL", "gameId": "2" },
+  { "homeTeam": "A", "awayTeam": "B", "time": "2020-01-01T00:00:00Z", "league": "NFL", "gameId": "1" },
+  { "homeTeam": "E", "awayTeam": "F", "time": "2020-01-03T00:00:00Z", "league": "NFL", "gameId": "3" }
+]

--- a/__tests__/llmsLog.test.ts
+++ b/__tests__/llmsLog.test.ts
@@ -3,28 +3,19 @@ import path from 'path';
 import crypto from 'crypto';
 import { freezeTime } from './utils/freezeTime';
 
-let unfreeze: () => void;
-
-beforeAll(() => {
-  unfreeze = freezeTime('2025-02-02T02:02:02.000Z');
-});
-
-afterAll(() => {
-  unfreeze();
-});
-
-// Snapshot hash is sensitive to timestamps inside llms.txt. We freeze time so it
-// remains stable. Update the snapshot if the frozen ISO changes.
-
 describe('llms log', () => {
-  let restore: () => void;
+  let unfreeze: () => void;
+  let restoreRand: () => void;
 
   beforeAll(() => {
-    restore = freezeTime('2024-01-02T03:04:05.000Z');
+    unfreeze = freezeTime('2024-01-01T00:00:00.000Z');
+    const rand = jest.spyOn(Math, 'random').mockReturnValue(0.123456);
+    restoreRand = () => rand.mockRestore();
   });
 
   afterAll(() => {
-    restore();
+    unfreeze();
+    restoreRand();
   });
 
   it('writes entry (stable time)', () => {

--- a/__tests__/utils/freezeTime.ts
+++ b/__tests__/utils/freezeTime.ts
@@ -1,4 +1,5 @@
-export function freezeTime(iso = '2025-01-01T00:00:00.000Z') {
-  jest.useFakeTimers().setSystemTime(new Date(iso));
-  return () => jest.useRealTimers();
+export function freezeTime(iso = '2024-01-01T00:00:00.000Z') {
+  const fixed = new Date(iso).valueOf();
+  const spy = jest.spyOn(Date, 'now').mockReturnValue(fixed);
+  return () => spy.mockRestore();
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -22,4 +22,5 @@ jest.mock('./lib/supabaseClient', () => ({
 
 afterEach(() => {
   jest.useRealTimers?.();
+  jest.restoreAllMocks();
 });

--- a/llms.txt
+++ b/llms.txt
@@ -1764,3 +1764,18 @@ Files:
 - lib/hooks/useEventSource.ts (+1/-7)
 - pages/predictions.tsx (+9/-2)
 
+Timestamp: 2025-08-08T07:48:27.482Z
+Commit: 4ebec0295d7c37e1bb999696cbb05b42889f0cfd
+Author: Codex
+Message: Stabilize odds join and freeze log timestamps
+Files:
+- __tests__/PredictionDrawer.sse.test.tsx (+3/-0)
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/fixtures/odds.json (+28/-0)
+- __tests__/fixtures/schedule.json (+5/-0)
+- __tests__/llmsLog.test.ts (+7/-16)
+- __tests__/upcomingGamesApi.joinOdds.test.ts (+43/-26)
+- __tests__/utils/freezeTime.ts (+4/-3)
+- jest.setup.ts (+1/-0)
+- pages/api/upcoming-games.ts (+49/-30)
+


### PR DESCRIPTION
## Summary
- ensure upcoming-games API deterministically joins odds and handles missing data
- freeze time and randomness for stable llms log snapshots
- mock Next.js router in PredictionDrawer SSE tests to avoid mounting errors

## Testing
- `npm run lint:fix`
- `npm run typecheck`
- `CI=1 npm test -- __tests__/upcomingGamesApi.joinOdds.test.ts --runInBand`
- `CI=1 npm test -- __tests__/llmsLog.test.ts --runInBand --updateSnapshot`
- `CI=1 npm test -- --runInBand --silent`
- `npm run build` *(fails: Missing env)*


------
https://chatgpt.com/codex/tasks/task_e_6895a5e59bec832389ad913ba5174c6a