### PR TITLE
feat: enhance run-agents cache and admin purge

### DIFF
--- a/__tests__/PredictionDrawer.sse.test.tsx
+++ b/__tests__/PredictionDrawer.sse.test.tsx
@@ -7,6 +7,16 @@ jest.mock('../components/PickSummary', () => () => <div />);
 jest.mock('../components/AgentNodeGraph', () => () => <div />);
 jest.mock('../components/AgentRationalePanel', () => () => <div />);
 jest.mock('../components/ConfidenceMeter', () => () => <div />);
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
 
 class MockEventSource {
   onmessage: ((ev: any) => void) | null = null;

--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"b5849e57e1ce630cd8c5eda54e6b5c7d21fc10a4e7f679e0e24ee24e111c8531"`;
+exports[`llms log writes entry (stable time) 1`] = `"02236530d265792f1345cddab369ea871a01382171130999aa5859e49c22b5d2"`;

--- a/__tests__/runAgents.cache.admin.test.ts
+++ b/__tests__/runAgents.cache.admin.test.ts
@@ -1,0 +1,197 @@
+/** @jest-environment node */
+jest.mock('next-auth/next');
+jest.mock('../lib/flow/runFlow');
+jest.mock('../lib/flow/loadFlow');
+jest.mock('../lib/data/schedule');
+jest.mock('../lib/logUiEvent', () => ({ logUiEvent: jest.fn() }));
+jest.mock('../lib/agents/registry', () => ({
+  registry: [{ name: 'injuryScout', weight: 1 }],
+}));
+jest.mock('../lib/supabaseClient', () => {
+  const store = new Map<string, any>();
+  return {
+    supabase: {
+      from: () => ({
+        select: () => ({
+          eq: (_col: string, key: string) => ({
+            single: async () => ({ data: store.get(key) || null, error: null }),
+          }),
+        }),
+        upsert: async (row: any) => {
+          store.set(row.key, row);
+          return { data: row, error: null };
+        },
+        delete: () => {
+          let keyFilter: string | undefined;
+          let prefixFilter: string | undefined;
+          const builder: any = {
+            eq: (_c: string, k: string) => {
+              keyFilter = k;
+              return builder;
+            },
+            like: (_c: string, pattern: string) => {
+              prefixFilter = pattern.replace('%', '');
+              return builder;
+            },
+            async then(resolve: any) {
+              for (const k of Array.from(store.keys())) {
+                if (keyFilter && k !== keyFilter) continue;
+                if (prefixFilter && !k.startsWith(prefixFilter)) continue;
+                store.delete(k);
+              }
+              resolve({ data: null, error: null });
+            },
+          };
+          return builder;
+        },
+      }),
+    },
+    __store: store,
+  };
+});
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
+
+const handler = require('../pages/api/run-agents').default;
+const {
+  __clearRunAgentsCache,
+  __setRunAgentsCacheTtl,
+} = require('../pages/api/run-agents');
+const purge = require('../pages/api/admin/purge-cache').default;
+const { __store } = require('../lib/supabaseClient');
+const mockedSession =
+  require('next-auth/next').getServerSession as jest.Mock;
+const mockedRunFlow = require('../lib/flow/runFlow').runFlow as jest.Mock;
+const mockedLoadFlow = require('../lib/flow/loadFlow').loadFlow as jest.Mock;
+const mockedSchedule =
+  require('../lib/data/schedule').fetchSchedule as jest.Mock;
+
+function createReqRes() {
+  const req: any = { method: 'POST', body: { league: 'NFL', gameId: 'g1' } };
+  const json = jest.fn();
+  const res: any = {
+    status: jest.fn().mockReturnThis(),
+    json,
+    setHeader: jest.fn(),
+    end: jest.fn(),
+  };
+  return { req, res, json };
+}
+
+function createPurgeReqRes(params: any, headers: any = {}) {
+  const req: any = { method: 'POST', query: params, headers };
+  const json = jest.fn();
+  const res: any = {
+    status: jest.fn().mockReturnThis(),
+    json,
+    setHeader: jest.fn(),
+    end: jest.fn(),
+  };
+  return { req, res, json };
+}
+
+beforeEach(() => {
+  __clearRunAgentsCache();
+  __store.clear();
+  mockedSession.mockReset().mockResolvedValue({ user: { id: '1' } });
+  mockedLoadFlow.mockReset().mockResolvedValue({
+    name: 'flow',
+    agents: ['injuryScout'],
+  });
+  mockedSchedule.mockReset().mockResolvedValue([
+    { gameId: 'g1', homeTeam: 'A', awayTeam: 'B', matchDay: 1 },
+  ]);
+  let runId = 0;
+  mockedRunFlow.mockReset().mockImplementation(async () => {
+    runId += 1;
+    return {
+      outputs: { injuryScout: { team: 'A', score: runId, reasoning: 'ok' } },
+      executions: [],
+    };
+  });
+  __setRunAgentsCacheTtl(60);
+  delete process.env.RUN_AGENTS_CACHE_TTL_SECONDS;
+  delete process.env.ADMIN_API_KEY;
+  process.env.NODE_ENV = 'test';
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('TTL respects env override', async () => {
+  jest.useFakeTimers();
+  process.env.RUN_AGENTS_CACHE_TTL_SECONDS = '120';
+  __setRunAgentsCacheTtl(120);
+  const { req, res } = createReqRes();
+  await handler(req, res);
+  jest.advanceTimersByTime(60000);
+  const { req: req2, res: res2 } = createReqRes();
+  await handler(req2, res2);
+  expect(mockedRunFlow).toHaveBeenCalledTimes(1);
+  jest.advanceTimersByTime(60000);
+  jest.advanceTimersByTime(1);
+  const { req: req3, res: res3 } = createReqRes();
+  await handler(req3, res3);
+  expect(mockedRunFlow).toHaveBeenCalledTimes(2);
+  jest.useRealTimers();
+});
+
+test('purge removes matching entries in both caches', async () => {
+  process.env.ADMIN_API_KEY = 'secret';
+  const { req, res } = createReqRes();
+  await handler(req, res);
+  expect(mockedRunFlow).toHaveBeenCalledTimes(1);
+  expect(__store.size).toBe(1);
+  const { req: preq, res: pres } = createPurgeReqRes(
+    { prefix: 'NFL' },
+    { admin_api_key: 'secret' },
+  );
+  await purge(preq, pres);
+  expect(pres.status).toHaveBeenCalledWith(200);
+  expect(__store.size).toBe(0);
+  const { req: req2, res: res2 } = createReqRes();
+  await handler(req2, res2);
+  expect(mockedRunFlow).toHaveBeenCalledTimes(2);
+});
+
+test('400 error when no filters provided', async () => {
+  process.env.ADMIN_API_KEY = 'secret';
+  const { req: preq, res: pres, json } = createPurgeReqRes(
+    {},
+    { admin_api_key: 'secret' },
+  );
+  await purge(preq, pres);
+  expect(pres.status).toHaveBeenCalledWith(400);
+  expect(json).toHaveBeenCalledWith({ error: 'Must provide key or prefix' });
+});
+
+test('admin key required', async () => {
+  process.env.ADMIN_API_KEY = 'secret';
+  const { req: preq, res: pres } = createPurgeReqRes({ prefix: 'NFL' }, {});
+  await purge(preq, pres);
+  expect(pres.status).toHaveBeenCalledWith(401);
+});
+
+test('_cached flag appears only in dev mode and only on cache hits', async () => {
+  process.env.NODE_ENV = 'development';
+  const { req, res, json } = createReqRes();
+  await handler(req, res);
+  expect(json.mock.calls[0][0]._cached).toBeUndefined();
+  const { req: req2, res: res2, json: json2 } = createReqRes();
+  await handler(req2, res2);
+  expect(json2.mock.calls[0][0]._cached).toBe(true);
+  process.env.NODE_ENV = 'production';
+  const { req: req3, res: res3, json: json3 } = createReqRes();
+  await handler(req3, res3);
+  expect(json3.mock.calls[0][0]._cached).toBeUndefined();
+});
+

--- a/__tests__/useEventSource.test.ts
+++ b/__tests__/useEventSource.test.ts
@@ -1,5 +1,15 @@
 import { renderHook, act } from '@testing-library/react';
 import useEventSource from '../lib/hooks/useEventSource';
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
 
 describe('useEventSource', () => {
   beforeEach(() => {

--- a/components/PredictionsPanel.tsx
+++ b/components/PredictionsPanel.tsx
@@ -9,6 +9,7 @@ interface Props {
   statuses: Record<AgentName, { status: AgentLifecycle['status'] | 'idle'; durationMs?: number }>;
   nodes: FlowNode[];
   edges: FlowEdge[];
+  cached?: boolean;
 }
 
 const PredictionsPanel: React.FC<Props> = ({
@@ -17,6 +18,7 @@ const PredictionsPanel: React.FC<Props> = ({
   statuses,
   nodes,
   edges,
+  cached,
 }) => {
   const [advanced, setAdvanced] = useState(false);
   const agentNames = Object.keys(agents) as AgentName[];
@@ -33,7 +35,12 @@ const PredictionsPanel: React.FC<Props> = ({
       </div>
       {advanced && <AgentNodeGraph nodes={nodes} edges={edges} />}
       {pick && (
-        <div className="p-4 bg-white/10 rounded">
+        <div className="p-4 bg-white/10 rounded relative">
+          {process.env.NODE_ENV === 'development' && cached && (
+            <span className="absolute top-1 right-1 px-2 py-0.5 text-xs rounded bg-green-600 text-white">
+              Cached
+            </span>
+          )}
           <h2 className="text-xl font-semibold">Prediction: {pick.winner}</h2>
           <p className="text-sm text-gray-300">
             Confidence: {(pick.confidence * 100).toFixed(0)}%

--- a/llms.txt
+++ b/llms.txt
@@ -1782,3 +1782,16 @@ Files:
 - pages/predictions.tsx (+9/-2)
 
 
+Timestamp: 2025-08-08T07:49:58.149Z
+Commit: 325d675e052ccbab6e0f2b8aee8518919d67856b
+Author: Codex
+Message: feat: enhance run-agents cache and admin purge
+Files:
+- __tests__/PredictionDrawer.sse.test.tsx (+10/-0)
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/runAgents.cache.admin.test.ts (+197/-0)
+- __tests__/useEventSource.test.ts (+10/-0)
+- components/PredictionsPanel.tsx (+8/-1)
+- pages/api/admin/purge-cache.ts (+44/-0)
+- pages/api/run-agents.ts (+50/-9)
+

--- a/pages/api/admin/purge-cache.ts
+++ b/pages/api/admin/purge-cache.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '../../../lib/supabaseClient';
+import { purgeRunAgentsCache } from '../run-agents';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  const adminKey = process.env.ADMIN_API_KEY;
+  const provided = req.headers['admin_api_key'];
+  if (!adminKey || provided !== adminKey) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const key = typeof req.query.key === 'string' ? req.query.key : undefined;
+  const prefix =
+    typeof req.query.prefix === 'string' ? req.query.prefix : undefined;
+
+  if (!key && !prefix) {
+    res.status(400).json({ error: 'Must provide key or prefix' });
+    return;
+  }
+
+  purgeRunAgentsCache({ key, prefix });
+
+  try {
+    let query: any = supabase.from('prediction_cache').delete();
+    if (key) query = query.eq('key', key);
+    if (prefix) query = query.like('key', `${prefix}%`);
+    await query;
+  } catch (err) {
+    console.error('cache purge error', err);
+  }
+
+  res.status(200).json({ success: true });
+}
+


### PR DESCRIPTION
## Summary
- make run-agents cache TTL configurable and add metrics logging
- add admin endpoint to purge cache entries
- surface dev-only cache badge in predictions panel and track cache hits in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895a7b9aa7883239e3d1a60b8600016