### PR TITLE
feat: add weight calibration script

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1828,3 +1828,11 @@ Files:
 - pages/_app.tsx (+13/-0)
 - scripts/dev/commit-helper.ts (+27/-0)
 
+Timestamp: 2025-08-08T08:23:33.830Z
+Commit: 1a0cee181dec62e1b6b5b90412a6437a91c9bbf7
+Author: Codex
+Message: feat: add weight calibration script
+Files:
+- package.json (+2/-1)
+- scripts/calibrateWeights.ts (+54/-0)
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "docs:refresh": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/refreshDocs.ts",
     "docs:self-reflect": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/agentSelfReflection.ts",
     "docs:sops": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/generateSOPs.ts",
-    "dev:commit": "ts-node scripts/dev/commit-helper.ts"
+    "dev:commit": "ts-node scripts/dev/commit-helper.ts",
+    "weights:calibrate": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/calibrateWeights.ts"
   },
   "dependencies": {
     "@octokit/rest": "^20.1.0",

--- a/scripts/calibrateWeights.ts
+++ b/scripts/calibrateWeights.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+import { supabase } from '../lib/supabaseClient';
+import { computeWeight } from '../lib/weights';
+
+interface OutcomeRow {
+  agent: string;
+  correct: boolean | null;
+}
+
+async function run(): Promise<void> {
+  const { data, error } = await supabase
+    .from('agent_outcomes')
+    .select('agent, correct')
+    .order('ts', { ascending: false })
+    .limit(50);
+
+  if (error || !data) {
+    console.error('Failed to fetch agent_outcomes', error?.message);
+    return;
+  }
+
+  const tallies: Record<string, { wins: number; losses: number }> = {};
+  (data as OutcomeRow[]).forEach((row) => {
+    if (!tallies[row.agent]) {
+      tallies[row.agent] = { wins: 0, losses: 0 };
+    }
+    if (row.correct) {
+      tallies[row.agent].wins += 1;
+    } else {
+      tallies[row.agent].losses += 1;
+    }
+  });
+
+  const registryPath = path.join(__dirname, '../lib/agents/agents.json');
+  const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+
+  registry.forEach((agent: any) => {
+    if (agent.weight === 0) return;
+    const stats = tallies[agent.name] || { wins: 0, losses: 0 };
+    const newWeight = computeWeight(stats);
+    console.log(
+      `${agent.name}: ${agent.weight.toFixed(3)} -> ${newWeight.toFixed(3)} (W:${stats.wins} L:${stats.losses})`,
+    );
+    agent.weight = newWeight;
+  });
+
+  fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+  console.log('Agent weights updated in registry.');
+}
+
+if (require.main === module) {
+  run();
+}


### PR DESCRIPTION
## Summary
- add `weights:calibrate` script to tune agent weights from the last 50 outcomes and persist to registry
- expose script via npm run target

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b17198288323b191fe40a0e064a9