### PR TITLE
feat: secure sports webhooks with HMAC verification

### DIFF
--- a/__tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap
+++ b/__tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap
@@ -10,6 +10,7 @@ exports[`docs refresh snapshots generates docs 1`] = `
 - /api/reflections
 - /api/run-agents
 - /api/run-predictions
+- /api/sports-webhook
 - /api/trends
 - /api/upcoming-games
 "

--- a/__tests__/sportsWebhook.hmac.test.ts
+++ b/__tests__/sportsWebhook.hmac.test.ts
@@ -1,0 +1,53 @@
+/** @jest-environment node */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Readable } from 'stream';
+import { createHmac } from 'crypto';
+
+jest.mock('../lib/logToSupabase', () => ({ logToSupabase: jest.fn() }));
+
+const secret = 'test-secret';
+process.env.SPORTS_WEBHOOK_SECRET = secret;
+
+const handler = require('../pages/api/sports-webhook').default;
+const { logToSupabase } = require('../lib/logToSupabase');
+
+function createReqRes(body: string, signature: string) {
+  const req = new Readable() as NextApiRequest;
+  req.headers = { 'x-sports-signature': signature } as any;
+  req.method = 'POST';
+  req.push(body);
+  req.push(null);
+
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const res = { status } as unknown as NextApiResponse;
+  return { req, res, json, status };
+}
+
+describe('sports webhook signature verification', () => {
+  it('accepts requests with valid signature', async () => {
+    const body = JSON.stringify({ hello: 'world' });
+    const sig = createHmac('sha256', secret).update(body).digest('hex');
+    const { req, res, status, json } = createReqRes(body, sig);
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ received: true });
+  });
+
+  it('rejects requests with invalid signature and logs attempt', async () => {
+    const body = JSON.stringify({ hello: 'world' });
+    const { req, res, status, json } = createReqRes(body, 'bad-signature');
+
+    await handler(req, res);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: 'invalid_signature' });
+    expect(logToSupabase).toHaveBeenCalledWith(
+      'webhook_events',
+      expect.objectContaining({ event: 'invalid_signature' })
+    );
+  });
+});

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -8,6 +8,7 @@ const envSchema = z.object({
   NEXTAUTH_SECRET: z.string().nonempty(),
   NEXTAUTH_URL: z.string().url(),
   SPORTS_API_KEY: z.string().nonempty(),
+  SPORTS_WEBHOOK_SECRET: z.string().optional(),
   LIVE_MODE: z.enum(['on', 'off']).default('off'),
   WEIGHTS_DYNAMIC: z.enum(['on', 'off']).default('off'),
   PREDICTION_CACHE_TTL_SEC: z.coerce.number().int().positive().default(120),

--- a/lib/utils/verifyWebhookSignature.ts
+++ b/lib/utils/verifyWebhookSignature.ts
@@ -1,0 +1,8 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export function verifyWebhookSignature(payload: string, signature: string, secret: string): boolean {
+  const expected = createHmac('sha256', secret).update(payload).digest('hex');
+  const sigBuffer = Buffer.from(signature, 'hex');
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  return sigBuffer.length === expectedBuffer.length && timingSafeEqual(sigBuffer, expectedBuffer);
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1897,3 +1897,20 @@ Files:
 
 
 
+Timestamp: 2025-08-08T08:57:39.268Z
+Commit: 3311552a202e83adf54ba7007eb9d8a117badd87
+Author: Codex
+Message: feat: add sports webhook HMAC verification
+Files:
+- __tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap (+1/-0)
+- lib/env.ts (+1/-0)
+
+Timestamp: 2025-08-08T08:58:09.636Z
+Commit: 67241f0551102c14b6f40c391ab31e43791d478c
+Author: Codex
+Message: test: add sports webhook signature tests
+Files:
+- __tests__/sportsWebhook.hmac.test.ts (+53/-0)
+- lib/utils/verifyWebhookSignature.ts (+8/-0)
+- pages/api/sports-webhook.ts (+46/-0)
+

--- a/pages/api/sports-webhook.ts
+++ b/pages/api/sports-webhook.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { verifyWebhookSignature } from '../../lib/utils/verifyWebhookSignature';
+import { logToSupabase } from '../../lib/logToSupabase';
+import { ENV } from '../../lib/env';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function getRawBody(req: NextApiRequest): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of req as any) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const secret = ENV.SPORTS_WEBHOOK_SECRET;
+  if (!secret) {
+    console.error('SPORTS_WEBHOOK_SECRET not configured');
+    return res.status(500).json({ error: 'server_error' });
+  }
+
+  const rawBody = await getRawBody(req);
+  const signature = req.headers['x-sports-signature'];
+
+  if (typeof signature !== 'string' || !verifyWebhookSignature(rawBody, signature, secret)) {
+    console.warn('Invalid webhook signature');
+    logToSupabase('webhook_events', {
+      event: 'invalid_signature',
+      signature: typeof signature === 'string' ? signature : undefined,
+      payload: rawBody,
+    });
+    return res.status(401).json({ error: 'invalid_signature' });
+  }
+
+  return res.status(200).json({ received: true });
+}


### PR DESCRIPTION
## Summary
- add optional `SPORTS_WEBHOOK_SECRET` env var
- implement `/api/sports-webhook` endpoint with HMAC signature verification and tamper logging
- test webhook signature handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895b8dd65c883239b205856641f5a49