### PR TITLE
feat: add agent execution tracker component

### DIFF
--- a/__tests__/AgentExecutionTracker.test.tsx
+++ b/__tests__/AgentExecutionTracker.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AgentExecutionTracker, {
+  LifecycleEvent,
+  AgentMeta,
+} from '../components/AgentExecutionTracker';
+
+const agents: AgentMeta[] = [
+  { name: 'injuryScout', label: 'Injury' },
+  { name: 'lineWatcher', label: 'Lines' },
+];
+
+describe('AgentExecutionTracker', () => {
+  it('updates status based on events and handles out-of-order and missing agents', () => {
+    const { rerender } = render(
+      <AgentExecutionTracker agents={agents} events={[]} mode="live" />,
+    );
+    expect(screen.getByTestId('node-injuryScout')).toHaveAttribute(
+      'data-status',
+      'pending',
+    );
+
+    const events1: LifecycleEvent[] = [
+      { name: 'injuryScout', status: 'completed' },
+      { name: 'lineWatcher', status: 'running' },
+      { name: 'unknown', status: 'running' },
+    ];
+    rerender(
+      <AgentExecutionTracker agents={agents} events={events1} mode="live" />,
+    );
+    expect(screen.getByTestId('node-injuryScout')).toHaveAttribute(
+      'data-status',
+      'completed',
+    );
+    expect(screen.getByTestId('node-lineWatcher')).toHaveAttribute(
+      'data-status',
+      'running',
+    );
+
+    const events2: LifecycleEvent[] = [
+      ...events1,
+      { name: 'injuryScout', status: 'running' }, // out of order
+      { name: 'lineWatcher', status: 'error' },
+    ];
+    rerender(
+      <AgentExecutionTracker agents={agents} events={events2} mode="live" />,
+    );
+    expect(screen.getByTestId('node-injuryScout')).toHaveAttribute(
+      'data-status',
+      'completed',
+    );
+    expect(screen.getByTestId('node-lineWatcher')).toHaveAttribute(
+      'data-status',
+      'error',
+    );
+  });
+
+  it('matches initial snapshot', () => {
+    const { container } = render(
+      <AgentExecutionTracker agents={agents} events={[]} mode="live" />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('matches final snapshot', () => {
+    const { container } = render(
+      <AgentExecutionTracker
+        agents={agents}
+        events={[
+          { name: 'injuryScout', status: 'completed' },
+          { name: 'lineWatcher', status: 'completed' },
+        ]}
+        mode="live"
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});
+

--- a/__tests__/__snapshots__/AgentExecutionTracker.test.tsx.snap
+++ b/__tests__/__snapshots__/AgentExecutionTracker.test.tsx.snap
@@ -1,0 +1,215 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AgentExecutionTracker matches final snapshot 1`] = `
+<div>
+  <div
+    class="w-full text-white"
+    data-testid="agent-tracker"
+  >
+    <div
+      class="text-center mb-4"
+    >
+      <h3
+        class="text-lg font-semibold"
+      >
+        Live Agent Execution
+      </h3>
+      <p
+        class="text-xs text-slate-400"
+      >
+        Powered by Modular AI Agents
+      </p>
+    </div>
+    <div
+      class="flex items-center justify-center gap-4 flex-wrap"
+    >
+      <div
+        class="flex flex-col items-center"
+      >
+        <div
+          class="relative w-12 h-12 flex items-center justify-center rounded-full border-2 transition-colors border-green-500"
+          data-status="completed"
+          data-testid="node-injuryScout"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-check w-6 h-6"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="m9 12 2 2 4-4"
+            />
+          </svg>
+        </div>
+        <span
+          class="mt-2 text-xs text-center w-16 truncate"
+        >
+          Injury
+        </span>
+        <span
+          class="hidden sm:block absolute top-6 left-full w-8 h-px bg-slate-600"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center"
+      >
+        <div
+          class="relative w-12 h-12 flex items-center justify-center rounded-full border-2 transition-colors border-green-500"
+          data-status="completed"
+          data-testid="node-lineWatcher"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-check w-6 h-6"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="m9 12 2 2 4-4"
+            />
+          </svg>
+        </div>
+        <span
+          class="mt-2 text-xs text-center w-16 truncate"
+        >
+          Lines
+        </span>
+      </div>
+    </div>
+    <div
+      class="text-center mt-4"
+      data-testid="flow-complete"
+    >
+      <div
+        class="inline-block px-3 py-1 bg-green-600/20 text-green-400 rounded"
+      >
+        Flow Complete
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AgentExecutionTracker matches initial snapshot 1`] = `
+<div>
+  <div
+    class="w-full text-white"
+    data-testid="agent-tracker"
+  >
+    <div
+      class="text-center mb-4"
+    >
+      <h3
+        class="text-lg font-semibold"
+      >
+        Live Agent Execution
+      </h3>
+      <p
+        class="text-xs text-slate-400"
+      >
+        Powered by Modular AI Agents
+      </p>
+    </div>
+    <div
+      class="flex items-center justify-center gap-4 flex-wrap"
+    >
+      <div
+        class="flex flex-col items-center"
+      >
+        <div
+          class="relative w-12 h-12 flex items-center justify-center rounded-full border-2 transition-colors border-slate-600"
+          data-status="pending"
+          data-testid="node-injuryScout"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle w-6 h-6"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+          </svg>
+        </div>
+        <span
+          class="mt-2 text-xs text-center w-16 truncate"
+        >
+          Injury
+        </span>
+        <span
+          class="hidden sm:block absolute top-6 left-full w-8 h-px bg-slate-600"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center"
+      >
+        <div
+          class="relative w-12 h-12 flex items-center justify-center rounded-full border-2 transition-colors border-slate-600"
+          data-status="pending"
+          data-testid="node-lineWatcher"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle w-6 h-6"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+          </svg>
+        </div>
+        <span
+          class="mt-2 text-xs text-center w-16 truncate"
+        >
+          Lines
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/AgentExecutionTracker.tsx
+++ b/components/AgentExecutionTracker.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, AlertTriangle, Circle } from 'lucide-react';
+
+export type AgentStatus = 'pending' | 'running' | 'completed' | 'error';
+
+export interface AgentMeta {
+  name: string;
+  label?: string;
+  icon?: React.ReactNode;
+}
+
+export interface LifecycleEvent {
+  name: string;
+  status: AgentStatus;
+  timestamp?: number;
+}
+
+interface Props {
+  agents: AgentMeta[];
+  events?: LifecycleEvent[];
+  mode?: 'live' | 'demo';
+}
+
+const statusRank: Record<AgentStatus, number> = {
+  pending: 0,
+  running: 1,
+  completed: 2,
+  error: 2,
+};
+
+const mergeStatus = (prev: AgentStatus, next: AgentStatus): AgentStatus => {
+  return statusRank[next] >= statusRank[prev] ? next : prev;
+};
+
+const AgentExecutionTracker: React.FC<Props> = ({
+  agents,
+  events = [],
+  mode = 'live',
+}) => {
+  const [runId, setRunId] = useState(0);
+  const base = useMemo(
+    () => Object.fromEntries(agents.map((a) => [a.name, 'pending' as AgentStatus])),
+    [agents, runId],
+  );
+
+  const [statuses, setStatuses] = useState<Record<string, AgentStatus>>(base);
+
+  // apply events
+  useEffect(() => {
+    setStatuses((prev) => {
+      const next = { ...base };
+      for (const e of events) {
+        if (!(e.name in next)) continue;
+        next[e.name] = mergeStatus(next[e.name], e.status);
+      }
+      return next;
+    });
+  }, [events, base]);
+
+  // demo mode simulation
+  useEffect(() => {
+    if (mode !== 'demo') return;
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+    agents.forEach((agent, i) => {
+      const start = setTimeout(() => {
+        setStatuses((s) => ({ ...s, [agent.name]: 'running' }));
+      }, i * 1000);
+      const end = setTimeout(() => {
+        setStatuses((s) => ({ ...s, [agent.name]: 'completed' }));
+      }, i * 1000 + 800);
+      timeouts.push(start, end);
+    });
+    return () => {
+      timeouts.forEach(clearTimeout);
+    };
+  }, [mode, agents, runId]);
+
+  const allDone = useMemo(
+    () =>
+      agents.every(
+        (a) => statuses[a.name] === 'completed' || statuses[a.name] === 'error',
+      ),
+    [agents, statuses],
+  );
+
+  const replay = () => {
+    setRunId((r) => r + 1);
+    setStatuses(base);
+  };
+
+  return (
+    <div className="w-full text-white" data-testid="agent-tracker">
+      <div className="text-center mb-4">
+        <h3 className="text-lg font-semibold">Live Agent Execution</h3>
+        <p className="text-xs text-slate-400">Powered by Modular AI Agents</p>
+      </div>
+      <div className="flex items-center justify-center gap-4 flex-wrap">
+        {agents.map((agent, idx) => {
+          const status = statuses[agent.name];
+          const Icon =
+            status === 'completed'
+              ? CheckCircle2
+              : status === 'error'
+              ? AlertTriangle
+              : Circle;
+          return (
+            <div key={agent.name} className="flex flex-col items-center">
+              <div
+                data-testid={`node-${agent.name}`}
+                data-status={status}
+                className={`relative w-12 h-12 flex items-center justify-center rounded-full border-2 transition-colors ${
+                  status === 'running'
+                    ? 'border-blue-500 animate-pulse shadow-[0_0_8px_rgba(59,130,246,0.7)]'
+                    : status === 'completed'
+                    ? 'border-green-500'
+                    : status === 'error'
+                    ? 'border-red-500'
+                    : 'border-slate-600'
+                }`}
+              >
+                {agent.icon || <Icon className="w-6 h-6" />}
+              </div>
+              <span className="mt-2 text-xs text-center w-16 truncate">
+                {agent.label || agent.name}
+              </span>
+              {idx < agents.length - 1 && (
+                <span className="hidden sm:block absolute top-6 left-full w-8 h-px bg-slate-600" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {allDone && (
+        <div className="text-center mt-4" data-testid="flow-complete">
+          <div className="inline-block px-3 py-1 bg-green-600/20 text-green-400 rounded">
+            Flow Complete
+          </div>
+          {mode === 'demo' && (
+            <div>
+              <button
+                className="mt-2 text-sm underline text-blue-400"
+                onClick={replay}
+              >
+                Replay
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AgentExecutionTracker;
+

--- a/llms.txt
+++ b/llms.txt
@@ -1897,3 +1897,12 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:07:29.837Z
+Commit: 02f6f499e9fe9eaf9471f4966a2f4c2926077538
+Author: Codex
+Message: feat: add agent execution tracker
+Files:
+- __tests__/AgentExecutionTracker.test.tsx (+79/-0)
+- __tests__/__snapshots__/AgentExecutionTracker.test.tsx.snap (+215/-0)
+- components/AgentExecutionTracker.tsx (+155/-0)
+


### PR DESCRIPTION
## Summary
- add `<AgentExecutionTracker />` for live and demo agent lifecycle visualization
- simulate agent progress in demo mode and show completion banner with replay
- unit and snapshot tests for tracker lifecycle and rendering

## Testing
- `npm test __tests__/AgentExecutionTracker.test.tsx`
- `npm test` *(fails to exit cleanly; shows "Cannot log after tests are done" from existing code but all suites including new tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_6895bbdef21883238fa26982b1bdf041