### PR TITLE
feat(insights): integrate AgentExecutionTracker with smooth reveal

### DIFF
--- a/__tests__/MatchupInsights.tracker.integration.test.tsx
+++ b/__tests__/MatchupInsights.tracker.integration.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MatchupInsights, { AgentEvent } from '../components/MatchupInsights';
+
+const baseEvents: AgentEvent[] = [
+  { id: '1', agent: 'injuryScout', status: 'completed', ts: '' },
+  { id: '2', agent: 'lineWatcher', status: 'completed', ts: '' },
+  { id: '3', agent: 'statCruncher', status: 'completed', ts: '' },
+  { id: '4', agent: 'trendsAgent', status: 'completed', ts: '' },
+  { id: '5', agent: 'guardianAgent', status: 'completed', ts: '' },
+];
+
+describe('MatchupInsights AgentExecutionTracker integration', () => {
+  it('shows flow complete after events progress and reveals predictions on click', () => {
+    const partial: AgentEvent[] = baseEvents.slice(0, 2);
+    const { rerender } = render(<MatchupInsights events={partial} demo />);
+    expect(screen.queryByTestId('flow-complete')).not.toBeInTheDocument();
+    rerender(<MatchupInsights events={baseEvents} demo />);
+    expect(screen.getByTestId('flow-complete')).toBeInTheDocument();
+    const scroll = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scroll;
+    fireEvent.click(screen.getByTestId('reveal-cta'));
+    expect(scroll).toHaveBeenCalled();
+    expect(screen.getByTestId('predictions-list')).toBeInTheDocument();
+  });
+
+  it('makes no network calls in demo mode', () => {
+    const fetchMock = jest.fn();
+    (global as any).fetch = fetchMock;
+    const esMock = jest.fn();
+    (global as any).EventSource = esMock;
+    render(<MatchupInsights events={baseEvents} demo />);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(esMock).not.toHaveBeenCalled();
+  });
+});

--- a/components/MatchupInsights.tsx
+++ b/components/MatchupInsights.tsx
@@ -1,0 +1,126 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import MatchupInputForm from './MatchupInputForm';
+import PredictionsPanel from './PredictionsPanel';
+import AgentExecutionTracker, {
+  LifecycleEvent,
+  AgentStatus,
+} from './AgentExecutionTracker';
+import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
+import type { AgentOutputs, PickSummary } from '../lib/types';
+import type { AgentExecution } from '../lib/flow/runFlow';
+import agentsMeta from '../lib/agents/agents.json';
+
+export type AgentEvent = {
+  id: string;
+  agent: string;
+  status: 'pending' | 'running' | 'completed' | 'error';
+  ts: string;
+  detail?: any;
+};
+
+export type TrackerProps = {
+  events?: AgentEvent[];
+  demo?: boolean;
+};
+
+const MatchupInsights: React.FC<TrackerProps> = ({ events: propEvents, demo }) => {
+  const [agents, setAgents] = useState<AgentOutputs>({});
+  const [pick, setPick] = useState<PickSummary | null>(null);
+  const { statuses, handleLifecycleEvent, reset, nodes, edges } =
+    useFlowVisualizer();
+  const [liveEvents, setLiveEvents] = useState<LifecycleEvent[]>([]);
+  const [revealed, setRevealed] = useState(false);
+  const anchorRef = useRef<HTMLDivElement>(null);
+
+  const allAgents = useMemo(
+    () => agentsMeta.map((a) => ({ name: a.name, label: a.name })),
+    [],
+  );
+
+  const eventList: LifecycleEvent[] = propEvents
+    ? propEvents.map((e) => ({ name: e.agent, status: e.status as AgentStatus }))
+    : liveEvents;
+
+  const flowComplete = useMemo(() => {
+    return allAgents.every((a) => {
+      const last = eventList
+        .filter((e) => e.name === a.name)
+        .map((e) => e.status)
+        .pop();
+      return last === 'completed' || last === 'error';
+    });
+  }, [eventList, allAgents]);
+
+  const onLifecycle = useCallback(
+    (e: { name: string; status: string }) => {
+      handleLifecycleEvent(e as any);
+      const mapped: AgentStatus =
+        e.status === 'started'
+          ? 'running'
+          : e.status === 'errored'
+          ? 'error'
+          : 'completed';
+      setLiveEvents((prev) => [...prev, { name: e.name, status: mapped }]);
+    },
+    [handleLifecycleEvent],
+  );
+
+  const onReveal = () => {
+    setRevealed(true);
+    anchorRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <main className="min-h-screen p-6 space-y-6 bg-neutral-100 dark:bg-neutral-900">
+      {!propEvents && !demo && (
+        <MatchupInputForm
+          onStart={(
+            _info: { homeTeam: string; awayTeam: string; week: number },
+          ) => {
+            setAgents({});
+            setPick(null);
+            reset();
+            setLiveEvents([]);
+            setRevealed(false);
+          }}
+          onAgent={(exec: AgentExecution) => {
+            if (exec.result) {
+              setAgents((prev) => ({ ...prev, [exec.name]: exec.result }));
+            }
+          }}
+          onComplete={(data: { pick: PickSummary }) => setPick(data.pick)}
+          onLifecycle={onLifecycle}
+        />
+      )}
+      <AgentExecutionTracker
+        agents={allAgents}
+        events={eventList}
+        mode={demo ? 'demo' : 'live'}
+      />
+      {flowComplete && !revealed && (
+        <button
+          onClick={onReveal}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+          data-testid="reveal-cta"
+        >
+          Reveal Predictions
+        </button>
+      )}
+      <div ref={anchorRef} data-testid="predictions-anchor" />
+      {revealed && !propEvents && !demo && (
+        <PredictionsPanel
+          agents={agents}
+          pick={pick}
+          statuses={statuses}
+          nodes={nodes}
+          edges={edges}
+        />
+      )}
+      {revealed && (propEvents || demo) && (
+        <div data-testid="predictions-list">Demo Predictions</div>
+      )}
+    </main>
+  );
+};
+
+export default MatchupInsights;

--- a/llms.txt
+++ b/llms.txt
@@ -1940,3 +1940,12 @@ Files:
 - __tests__/__snapshots__/AgentExecutionTracker.test.tsx.snap (+215/-0)
 - components/AgentExecutionTracker.tsx (+155/-0)
 
+Timestamp: 2025-08-08T09:31:00.153Z
+Commit: c0fd43fb192cb56f387557e784588b1fa65192fd
+Author: Codex
+Message: feat(insights): integrate AgentExecutionTracker with smooth reveal
+Files:
+- __tests__/MatchupInsights.tracker.integration.test.tsx (+36/-0)
+- components/MatchupInsights.tsx (+126/-0)
+- pages/predictions.tsx (+3/-38)
+

--- a/pages/predictions.tsx
+++ b/pages/predictions.tsx
@@ -1,43 +1,8 @@
-import React, { useState } from 'react';
-import MatchupInputForm from '../components/MatchupInputForm';
-import PredictionsPanel from '../components/PredictionsPanel';
-import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
-import type { AgentOutputs, PickSummary } from '../lib/types';
-import type { AgentExecution } from '../lib/flow/runFlow';
+import React from 'react';
+import MatchupInsights from '../components/MatchupInsights';
 
 const PredictionsPage: React.FC = () => {
-  const [agents, setAgents] = useState<AgentOutputs>({});
-  const [pick, setPick] = useState<PickSummary | null>(null);
-  const { statuses, handleLifecycleEvent, reset, nodes, edges } =
-    useFlowVisualizer();
-
-  return (
-    <main className="min-h-screen p-6 space-y-6 bg-neutral-100 dark:bg-neutral-900">
-      <MatchupInputForm
-        onStart={(
-          _info: { homeTeam: string; awayTeam: string; week: number }
-        ) => {
-          setAgents({});
-          setPick(null);
-          reset();
-        }}
-        onAgent={(exec: AgentExecution) => {
-          if (exec.result) {
-            setAgents((prev) => ({ ...prev, [exec.name]: exec.result }));
-          }
-        }}
-        onComplete={(data: { pick: PickSummary }) => setPick(data.pick)}
-        onLifecycle={handleLifecycleEvent}
-      />
-      <PredictionsPanel
-        agents={agents}
-        pick={pick}
-        statuses={statuses}
-        nodes={nodes}
-        edges={edges}
-      />
-    </main>
-  );
+  return <MatchupInsights />;
 };
 
 export default PredictionsPage;


### PR DESCRIPTION
## Summary
- add MatchupInsights page component with embedded AgentExecutionTracker and reveal CTA
- replace predictions page to use MatchupInsights container
- cover tracker integration with scroll-to-anchor and demo no-network tests

## Testing
- `npm test __tests__/MatchupInsights.tracker.integration.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6895c1c182e8832386763b1add6d753a