### PR TITLE
feat: add governance audit log and tooling

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,25 @@
+name: Lighthouse CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lhci:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - run: npx lhci autorun --config=./lighthouserc.json
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+      - name: Upload Lighthouse artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,0 +1,19 @@
+name: Percy Snapshots
+
+on:
+  pull_request:
+
+jobs:
+  percy:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npx percy exec -- npx playwright test tests/visual/percy.spec.ts
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/__tests__/AuditLogList.test.tsx
+++ b/__tests__/AuditLogList.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import AuditLogList from '../components/AuditLogList';
+
+describe('AuditLogList', () => {
+  const logs = {
+    logs: [
+      {
+        id: '1',
+        timestamp: '2025-01-01',
+        type: 'policy',
+        severity: 'info',
+        message: 'test message',
+        details: 'more info',
+      },
+    ],
+    total: 1,
+  };
+
+  function setup() {
+    const fetchMock = jest.fn().mockResolvedValue({ json: () => Promise.resolve(logs) });
+    (global as any).fetch = fetchMock;
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <AuditLogList />
+      </SWRConfig>
+    );
+    return fetchMock;
+  }
+
+  it('renders logs and opens modal', async () => {
+    setup();
+    expect(await screen.findByText('test message')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('test message'));
+    expect(screen.getByRole('dialog')).toHaveTextContent('more info');
+  });
+
+  it('updates query when type filter changes', async () => {
+    const fetchMock = setup();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(logs) });
+    fireEvent.change(screen.getByLabelText(/filter by type/i), { target: { value: 'action' } });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenLastCalledWith('/api/audit-logs?page=1&type=action');
+    });
+  });
+});
+

--- a/components/AuditLogList.tsx
+++ b/components/AuditLogList.tsx
@@ -1,0 +1,148 @@
+import React, { useState } from 'react';
+import useSWR from 'swr';
+
+interface AuditLog {
+  id: string;
+  timestamp: string;
+  type: string;
+  severity: string;
+  message: string;
+  details?: string;
+}
+
+interface ApiResponse {
+  logs: AuditLog[];
+  total: number;
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+const AuditLogList: React.FC = () => {
+  const [page, setPage] = useState(1);
+  const [type, setType] = useState('all');
+  const [timeframe, setTimeframe] = useState('all');
+  const [severity, setSeverity] = useState('all');
+  const [selected, setSelected] = useState<AuditLog | null>(null);
+
+  const params = new URLSearchParams();
+  params.set('page', String(page));
+  if (type !== 'all') params.set('type', type);
+  if (timeframe !== 'all') params.set('timeframe', timeframe);
+  if (severity !== 'all') params.set('severity', severity);
+
+  const { data } = useSWR<ApiResponse>(
+    `/api/audit-logs?${params.toString()}`,
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+
+  const logs = data?.logs || [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <select
+          aria-label="Filter by type"
+          value={type}
+          onChange={(e) => {
+            setPage(1);
+            setType(e.target.value);
+          }}
+          className="border px-2 py-1 rounded"
+        >
+          <option value="all">All Types</option>
+          <option value="policy">Policy</option>
+          <option value="action">Action</option>
+        </select>
+        <select
+          aria-label="Filter by timeframe"
+          value={timeframe}
+          onChange={(e) => {
+            setPage(1);
+            setTimeframe(e.target.value);
+          }}
+          className="border px-2 py-1 rounded"
+        >
+          <option value="all">All Time</option>
+          <option value="24h">Last 24h</option>
+          <option value="7d">Last 7d</option>
+          <option value="30d">Last 30d</option>
+        </select>
+        <select
+          aria-label="Filter by severity"
+          value={severity}
+          onChange={(e) => {
+            setPage(1);
+            setSeverity(e.target.value);
+          }}
+          className="border px-2 py-1 rounded"
+        >
+          <option value="all">All Severity</option>
+          <option value="info">Info</option>
+          <option value="warn">Warning</option>
+          <option value="error">Error</option>
+        </select>
+      </div>
+      <ul className="space-y-2">
+        {logs.map((log) => (
+          <li
+            key={log.id}
+            className="border rounded p-2 cursor-pointer"
+            onClick={() => setSelected(log)}
+          >
+            <div className="text-xs text-gray-500">
+              {log.timestamp} · {log.type} · {log.severity}
+            </div>
+            <div className="text-sm truncate">{log.message}</div>
+          </li>
+        ))}
+      </ul>
+      <div className="flex justify-between">
+        <button
+          className="px-3 py-1 border rounded disabled:opacity-50"
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page === 1}
+        >
+          Previous
+        </button>
+        <button
+          className="px-3 py-1 border rounded disabled:opacity-50"
+          onClick={() => setPage((p) => p + 1)}
+          disabled={logs.length === 0}
+        >
+          Next
+        </button>
+      </div>
+      {selected && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+          onClick={() => setSelected(null)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="bg-white rounded p-4 max-w-md w-full"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold mb-2">Log Detail</h2>
+            <p className="text-xs text-gray-500 mb-2">
+              {selected.timestamp} · {selected.type} · {selected.severity}
+            </p>
+            <p className="text-sm whitespace-pre-wrap">{selected.details || selected.message}</p>
+            <div className="text-right mt-4">
+              <button
+                className="px-3 py-1 border rounded"
+                onClick={() => setSelected(null)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AuditLogList;
+

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,30 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["http://localhost:3000/"],
+      "startServerCommand": "npm run start",
+      "numberOfRuns": 1,
+      "settings": {
+        "budgets": [
+          {
+            "resourceSizes": [
+              { "resourceType": "script", "budget": 5000 }
+            ],
+            "timings": [
+              { "metric": "interactive", "budget": 10000 }
+            ]
+          }
+        ]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1, "aggregationMethod": "optimistic" }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1971,3 +1971,16 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:43:55.171Z
+Commit: 94f2d773f66888028f02869d8d8e07b538fb7701
+Author: Codex
+Message: feat: add governance audit log and tooling
+Files:
+- .github/workflows/lighthouse-ci.yml (+25/-0)
+- .github/workflows/percy.yml (+19/-0)
+- __tests__/AuditLogList.test.tsx (+48/-0)
+- components/AuditLogList.tsx (+148/-0)
+- lighthouserc.json (+30/-0)
+- pages/governance/audit.tsx (+17/-0)
+- tests/visual/percy.spec.ts (+13/-0)
+

--- a/pages/governance/audit.tsx
+++ b/pages/governance/audit.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+import AuditLogList from '../../components/AuditLogList';
+
+const AuditPage = () => (
+  <>
+    <Head>
+      <title>Governance Audit Log</title>
+    </Head>
+    <main className="min-h-screen bg-gray-50 p-6">
+      <h1 className="text-3xl font-bold mb-4">Governance Audit Log</h1>
+      <AuditLogList />
+    </main>
+  </>
+);
+
+export default AuditPage;
+

--- a/tests/visual/percy.spec.ts
+++ b/tests/visual/percy.spec.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+import { test } from '@playwright/test';
+import percySnapshot from '@percy/playwright';
+
+const routes = ['/', '/predictions', '/public', '/logs/agents'];
+
+for (const route of routes) {
+  test(`snapshot ${route}`, async ({ page }) => {
+    const res = await page.goto(route);
+    if (res && res.status() >= 400) return;
+    await percySnapshot(page, route || 'home');
+  });
+}


### PR DESCRIPTION
## Summary
- add Governance Audit Log page with paginated, filterable log list and details modal
- introduce Lighthouse CI workflow with accessibility and CLS assertions
- add Percy snapshot workflow for core routes

## Testing
- `npm test __tests__/AuditLogList.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6895c5cae6108323bcf1f4a81de6aaf8