### PR TITLE
Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,28 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lhci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - name: Build static site
+        run: |
+          npx next build
+          npx next export
+      - name: Run Lighthouse CI
+        run: npx lhci autorun
+      - name: Upload Lighthouse artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,31 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./out",
+      "settings": {
+        "budgets": [
+          {
+            "path": "/",
+            "resourceSizes": [
+              { "resourceType": "script", "budget": 250 },
+              { "resourceType": "total", "budget": 1500 }
+            ],
+            "resourceCounts": [
+              { "resourceType": "script", "budget": 50 },
+              { "resourceType": "total", "budget": 200 }
+            ]
+          }
+        ]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Lighthouse CI GitHub Action to build and audit static export
- configure lighthouserc with performance budgets and thresholds for accessibility and CLS

## Testing
- `npm test` *(fails: __tests__/llmsLog.test.ts snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6895c64ef6c083239a8dd37fcb7294de