### PR TITLE
feat(demo): Matchup carousel with tracker and compact predictions

### DIFF
--- a/__tests__/DemoMatchupCarousel.test.tsx
+++ b/__tests__/DemoMatchupCarousel.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import DemoMatchupCarousel, { DEMO_CAROUSEL_INTERVAL } from '../components/DemoMatchupCarousel';
+
+describe('DemoMatchupCarousel', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  it('autoplay advances slides', () => {
+    const { container } = render(<DemoMatchupCarousel />);
+    const first = container.querySelector('#demo-slide-0');
+    const second = container.querySelector('#demo-slide-1');
+    expect(first).toHaveAttribute('aria-hidden', 'false');
+    act(() => {
+      jest.advanceTimersByTime(DEMO_CAROUSEL_INTERVAL);
+    });
+    expect(second).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('manual navigation resumes autoplay', () => {
+    const { container } = render(<DemoMatchupCarousel />);
+    const next = screen.getByRole('button', { name: '›' });
+    fireEvent.click(next);
+    const second = container.querySelector('#demo-slide-1');
+    expect(second).toHaveAttribute('aria-hidden', 'false');
+    act(() => {
+      jest.advanceTimersByTime(DEMO_CAROUSEL_INTERVAL);
+    });
+    const third = container.querySelector('#demo-slide-2');
+    expect(third).toHaveAttribute('aria-hidden', 'false');
+  });
+});

--- a/components/DemoMatchupCarousel.tsx
+++ b/components/DemoMatchupCarousel.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PredictionTracker from './PredictionTracker';
+import matchups from '../mock/demo-matchups.json';
+
+export const DEMO_CAROUSEL_INTERVAL = 6000; // 6s autoplay
+
+const DemoMatchupCarousel: React.FC = () => {
+  const [index, setIndex] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const total = matchups.length;
+
+  const next = () => setIndex((i) => (i + 1) % total);
+  const prev = () => setIndex((i) => (i - 1 + total) % total);
+
+  const start = () => {
+    timerRef.current = setInterval(() => {
+      setIndex((i) => (i + 1) % total);
+    }, DEMO_CAROUSEL_INTERVAL);
+  };
+
+  const reset = () => {
+    if (timerRef.current) clearInterval(timerRef.current);
+    start();
+  };
+
+  useEffect(() => {
+    start();
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, []);
+
+  const handleNext = () => {
+    next();
+    reset();
+  };
+
+  const handlePrev = () => {
+    prev();
+    reset();
+  };
+
+  return (
+    <div className="relative" role="region" aria-label="Demo matchups">
+      <div className="overflow-hidden">
+        <div
+          className="flex transition-transform duration-500 ease-out"
+          style={{ transform: `translateX(-${index * 100}%)` }}
+        >
+          {matchups.map((m, i) => (
+            <div
+              key={i}
+              id={`demo-slide-${i}`}
+              className="w-full flex-shrink-0 p-4 flex flex-col items-center gap-2"
+              aria-hidden={index !== i}
+            >
+              {index === i && <PredictionTracker onReveal={() => {}} />}
+              <div className="text-center">
+                <p className="font-semibold">
+                  {m.awayTeam} @ {m.homeTeam}
+                </p>
+                <p className="text-sm text-gray-600">
+                  Pick: {m.prediction.winner} ({Math.round(m.prediction.confidence * 100)}%)
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={handlePrev}
+        aria-controls={`demo-slide-${(index - 1 + total) % total}`}
+        className="absolute left-2 top-1/2 -translate-y-1/2 p-2 bg-white/80 rounded-full"
+      >
+        ‹
+      </button>
+      <button
+        onClick={handleNext}
+        aria-controls={`demo-slide-${(index + 1) % total}`}
+        className="absolute right-2 top-1/2 -translate-y-1/2 p-2 bg-white/80 rounded-full"
+      >
+        ›
+      </button>
+    </div>
+  );
+};
+
+export default DemoMatchupCarousel;
+

--- a/llms.txt
+++ b/llms.txt
@@ -1971,3 +1971,12 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:49:09.752Z
+Commit: 20e831f174cd0dd1e0e8a9249853cc42ac26bea5
+Author: Codex
+Message: feat(demo): Matchup carousel with tracker and compact predictions
+Files:
+- __tests__/DemoMatchupCarousel.test.tsx (+33/-0)
+- components/DemoMatchupCarousel.tsx (+89/-0)
+- mock/demo-matchups.json (+17/-0)
+

--- a/mock/demo-matchups.json
+++ b/mock/demo-matchups.json
@@ -1,0 +1,17 @@
+[
+  {
+    "homeTeam": "A",
+    "awayTeam": "B",
+    "prediction": { "winner": "A", "confidence": 0.68 }
+  },
+  {
+    "homeTeam": "C",
+    "awayTeam": "D",
+    "prediction": { "winner": "D", "confidence": 0.57 }
+  },
+  {
+    "homeTeam": "E",
+    "awayTeam": "F",
+    "prediction": { "winner": "E", "confidence": 0.61 }
+  }
+]


### PR DESCRIPTION
## Summary
- add demo matchup carousel with autoplay, tracker, and compact predictions
- provide fixture data for demo games
- test autoplay progression and manual navigation resume

## Testing
- `npm test __tests__/DemoMatchupCarousel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6895c642e45c8323ba8f5a334741870a