### PR TITLE
Add no-op TelemetryProvider with event queue

### DIFF
--- a/__tests__/TelemetryProvider.test.tsx
+++ b/__tests__/TelemetryProvider.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+  TelemetryProvider,
+  useTelemetry,
+  flushTelemetryQueue,
+} from '../lib/telemetry';
+
+describe('TelemetryProvider', () => {
+  beforeEach(() => {
+    flushTelemetryQueue();
+  });
+
+  it('queues events when no provider is mounted', () => {
+    const { result } = renderHook(() => useTelemetry());
+    act(() => {
+      result.current({ type: 'test' });
+    });
+    expect(flushTelemetryQueue()).toEqual([{ type: 'test' }]);
+  });
+
+  it('flushes queued events and forwards new ones when provider is mounted', () => {
+    const handler = jest.fn();
+    const { result: initial } = renderHook(() => useTelemetry());
+    act(() => {
+      initial.current({ type: 'queued' });
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TelemetryProvider onEvent={handler}>{children}</TelemetryProvider>
+    );
+
+    const { result } = renderHook(() => useTelemetry(), { wrapper });
+
+    expect(handler).toHaveBeenCalledWith({ type: 'queued' });
+
+    act(() => {
+      result.current({ type: 'new' });
+    });
+
+    expect(handler).toHaveBeenCalledWith({ type: 'new' });
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(flushTelemetryQueue()).toHaveLength(0);
+  });
+});

--- a/lib/telemetry/TelemetryProvider.tsx
+++ b/lib/telemetry/TelemetryProvider.tsx
@@ -1,0 +1,64 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  ReactNode,
+} from 'react';
+
+export interface TelemetryEvent {
+  type: string;
+  [key: string]: any;
+}
+
+type TelemetryHandler = (event: TelemetryEvent) => void;
+
+const queue: TelemetryEvent[] = [];
+
+const TelemetryContext = createContext<TelemetryHandler>((event) => {
+  queue.push(event);
+});
+
+interface Props {
+  children: ReactNode;
+  onEvent?: TelemetryHandler;
+}
+
+export const TelemetryProvider = ({ children, onEvent }: Props) => {
+  const handler = useCallback<TelemetryHandler>(
+    (event) => {
+      if (onEvent) {
+        onEvent(event);
+      } else {
+        queue.push(event);
+      }
+    },
+    [onEvent]
+  );
+
+  useEffect(() => {
+    if (onEvent && queue.length > 0) {
+      const pending = queue.splice(0);
+      pending.forEach((e) => onEvent(e));
+    }
+  }, [onEvent]);
+
+  return (
+    <TelemetryContext.Provider value={handler}>
+      {children}
+    </TelemetryContext.Provider>
+  );
+};
+
+export const useTelemetry = () => useContext(TelemetryContext);
+
+export function flushTelemetryQueue(): TelemetryEvent[] {
+  const pending = queue.splice(0);
+  return pending;
+}
+
+export function getTelemetryQueue(): TelemetryEvent[] {
+  return queue;
+}
+
+export type { TelemetryHandler };

--- a/lib/telemetry/index.ts
+++ b/lib/telemetry/index.ts
@@ -1,0 +1,1 @@
+export * from './TelemetryProvider';

--- a/llms.txt
+++ b/llms.txt
@@ -1979,3 +1979,12 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:53:27.387Z
+Commit: 4d6ed3fe3d1e2ca8e75d2b73ea70772ccebe92b0
+Author: Codex
+Message: Add no-op TelemetryProvider with event queue
+Files:
+- __tests__/TelemetryProvider.test.tsx (+44/-0)
+- lib/telemetry/TelemetryProvider.tsx (+64/-0)
+- lib/telemetry/index.ts (+1/-0)
+


### PR DESCRIPTION
## Summary
- add TelemetryProvider context that queues events until a handler is supplied
- export telemetry utilities
- test queuing and flushing behavior

## Testing
- `npm test` *(fails: snapshot mismatch in llms log)*
- `npx jest __tests__/TelemetryProvider.test.tsx __tests__/llmsLog.test.ts` *(fails: snapshot mismatch in llms log)*

------
https://chatgpt.com/codex/tasks/task_e_6895c7274824832386f16954840ad511