### PR TITLE
Add /api/health and /api/version endpoints

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"25506e0389baf55ca32a971ec2f279f790773f4d9eab09756ee81e59d0fd7625"`;
+exports[`llms log writes entry (stable time) 1`] = `"163d2dcb9ab3a504cb4e5117a24abf416496104c0aeee9eba639ed25aa6bfcd0"`;

--- a/__tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap
+++ b/__tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap
@@ -5,6 +5,7 @@ exports[`docs refresh snapshots generates docs 1`] = `
 
 - /api/accuracy
 - /api/dev-login
+- /api/health
 - /api/log-status
 - /api/logs
 - /api/reflections
@@ -13,6 +14,7 @@ exports[`docs refresh snapshots generates docs 1`] = `
 - /api/sports-webhook
 - /api/trends
 - /api/upcoming-games
+- /api/version
 "
 `;
 

--- a/__tests__/health.test.ts
+++ b/__tests__/health.test.ts
@@ -1,0 +1,21 @@
+/** @jest-environment node */
+import handler from '../pages/api/health';
+
+const mockRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('health API', () => {
+  it('returns ok', async () => {
+    const req: any = {};
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'ok' });
+  });
+});

--- a/__tests__/version.test.ts
+++ b/__tests__/version.test.ts
@@ -1,0 +1,22 @@
+/** @jest-environment node */
+import handler from '../pages/api/version';
+import packageJson from '../package.json';
+
+const mockRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('version API', () => {
+  it('returns version from package.json', async () => {
+    const req: any = {};
+    const res = mockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ version: packageJson.version });
+  });
+});

--- a/llms.txt
+++ b/llms.txt
@@ -1979,3 +1979,15 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:50:01.141Z
+Commit: ed82d9c24b9a4a344fe3bf21d3dc33f6d3d4862a
+Author: Codex
+Message: feat(api): add health and version endpoints
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap (+2/-0)
+- __tests__/health.test.ts (+21/-0)
+- __tests__/version.test.ts (+22/-0)
+- pages/api/health.ts (+8/-0)
+- pages/api/version.ts (+9/-0)
+

--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.status(200).json({ status: 'ok' });
+}

--- a/pages/api/version.ts
+++ b/pages/api/version.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import packageJson from '../../package.json';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.status(200).json({ version: packageJson.version });
+}


### PR DESCRIPTION
## Summary
- expose simple health check at `/api/health`
- add `/api/version` to report package version
- cover endpoints with unit tests and update snapshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895c709a0c083239135bbe7bec7df13