### PR TITLE
Add reusable ErrorBoundary + withBoundary HOC

### DIFF
--- a/__tests__/ErrorBoundary.test.tsx
+++ b/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import ErrorBoundary from '../components/sys/ErrorBoundary';
+import withBoundary from '../components/sys/withBoundary';
+import React from 'react';
+
+describe('ErrorBoundary', () => {
+  const consoleError = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+
+  afterAll(() => {
+    consoleError.mockRestore();
+  });
+
+  it('renders fallback when child throws', () => {
+    const Thrower = () => {
+      throw new Error('boom');
+    };
+
+    render(
+      <ErrorBoundary fallback={<span>fallback</span>}>
+        <Thrower />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+  });
+
+  it('withBoundary HOC renders fallback', () => {
+    const Thrower = () => {
+      throw new Error('explode');
+    };
+
+    const Safe = withBoundary(Thrower, <span>safe</span>);
+
+    render(<Safe />);
+
+    expect(screen.getByText('safe')).toBeInTheDocument();
+  });
+});
+

--- a/components/sys/ErrorBoundary.tsx
+++ b/components/sys/ErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+export type FallbackRender = (error: Error, reset: () => void) => ReactNode;
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode | FallbackRender;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      if (typeof this.props.fallback === 'function') {
+        return (this.props.fallback as FallbackRender)(error, this.reset);
+      }
+      return this.props.fallback ?? null;
+    }
+    return this.props.children;
+  }
+}
+

--- a/components/sys/withBoundary.tsx
+++ b/components/sys/withBoundary.tsx
@@ -1,0 +1,19 @@
+import { ComponentType } from 'react';
+import ErrorBoundary, { FallbackRender } from './ErrorBoundary';
+
+export default function withBoundary<P>(
+  WrappedComponent: ComponentType<P>,
+  fallback?: React.ReactNode | FallbackRender
+) {
+  const ComponentWithBoundary = (props: P) => (
+    <ErrorBoundary fallback={fallback}>
+      <WrappedComponent {...props} />
+    </ErrorBoundary>
+  );
+
+  const name = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+  ComponentWithBoundary.displayName = `withBoundary(${name})`;
+
+  return ComponentWithBoundary;
+}
+


### PR DESCRIPTION
## Summary
- add `ErrorBoundary` component with optional fallback render and error logging
- create `withBoundary` HOC to wrap components in an error boundary
- test direct and HOC usage to ensure fallbacks render when children throw

## Testing
- `npm test` *(fails: 1 snapshot failure in __tests__/llmsLog.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895c6ff727c8323a7109746eed58922