### PR TITLE
feat: add prediction marquee component

### DIFF
--- a/__tests__/marketing/PredictionMarquee.test.tsx
+++ b/__tests__/marketing/PredictionMarquee.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import PredictionMarquee from '../../components/marketing/PredictionMarquee';
+
+describe('PredictionMarquee', () => {
+  it('renders demo predictions by default', () => {
+    render(<PredictionMarquee />);
+    expect(screen.getAllByText(/Jets \+3\.5/).length).toBeGreaterThan(0);
+  });
+
+  it('renders provided predictions', () => {
+    const predictions = [
+      { matchup: 'A vs B', pick: 'Pick A', confidence: 55 },
+      { matchup: 'C vs D', pick: 'Pick B', confidence: 60 },
+    ];
+    render(<PredictionMarquee predictions={predictions} />);
+    expect(screen.getAllByText('Pick A').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Pick B').length).toBeGreaterThan(0);
+  });
+});

--- a/components/marketing/PredictionMarquee.tsx
+++ b/components/marketing/PredictionMarquee.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+type DemoPrediction = {
+  matchup: string;
+  pick: string;
+  confidence: number;
+};
+
+export interface PredictionMarqueeProps {
+  predictions?: DemoPrediction[];
+}
+
+const demoPredictions: DemoPrediction[] = [
+  { matchup: 'NYJ @ BUF', pick: 'Jets +3.5', confidence: 68 },
+  { matchup: 'LAL @ BOS', pick: 'Over 218.5', confidence: 62 },
+  { matchup: 'DAL @ PHI', pick: 'Cowboys -2.5', confidence: 71 },
+];
+
+export default function PredictionMarquee({ predictions = demoPredictions }: PredictionMarqueeProps) {
+  const items = [...predictions, ...predictions];
+  return (
+    <div className="overflow-hidden bg-white dark:bg-gray-900 text-sm" data-testid="prediction-marquee">
+      <div className="flex whitespace-nowrap animate-marquee">
+        {items.map((p, idx) => (
+          <div key={idx} className="px-4 py-2 flex items-center space-x-2">
+            <span className="font-semibold">{p.pick}</span>
+            <span className="text-gray-500">{p.matchup}</span>
+            <span className="text-emerald-600">{p.confidence}%</span>
+          </div>
+        ))}
+      </div>
+      <style>{`
+        @keyframes marquee {
+          0% { transform: translateX(0); }
+          100% { transform: translateX(-50%); }
+        }
+        .animate-marquee {
+          width: fit-content;
+          animation: marquee 30s linear infinite;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1979,3 +1979,11 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:49:54.019Z
+Commit: 0ea587e571b4f3037132c25b6b91a4fcb38875f9
+Author: Codex
+Message: feat: add prediction marquee component
+Files:
+- __tests__/marketing/PredictionMarquee.test.tsx (+19/-0)
+- components/marketing/PredictionMarquee.tsx (+44/-0)
+


### PR DESCRIPTION
## Summary
- add marketing PredictionMarquee component for landing page demo
- cover PredictionMarquee with tests

## Testing
- `npm test`
- `npm test __tests__/marketing/PredictionMarquee.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6895c6f6a86c8323b162a5bfd1069247