### PR TITLE
Add zod schemas for public API contracts

### DIFF
--- a/__tests__/__snapshots__/publicApiSchemas.test.ts.snap
+++ b/__tests__/__snapshots__/publicApiSchemas.test.ts.snap
@@ -1,0 +1,298 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`public API schema snapshots accuracy schema 1`] = `
+{
+  "$ref": "#/definitions/Accuracy",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Accuracy": {
+      "additionalProperties": false,
+      "properties": {
+        "agents": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "accuracy": {
+                "type": "number",
+              },
+              "losses": {
+                "type": "number",
+              },
+              "name": {
+                "type": "string",
+              },
+              "wins": {
+                "type": "number",
+              },
+            },
+            "required": [
+              "name",
+              "wins",
+              "losses",
+              "accuracy",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+        "flows": {
+          "items": {
+            "$ref": "#/definitions/Accuracy/properties/agents/items",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "agents",
+        "flows",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`public API schema snapshots predictions schema 1`] = `
+{
+  "$ref": "#/definitions/Predictions",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Predictions": {
+      "additionalProperties": false,
+      "properties": {
+        "agentScores": {
+          "additionalProperties": {
+            "type": "number",
+          },
+          "type": "object",
+        },
+        "cacheVersion": {
+          "type": "string",
+        },
+        "predictions": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "agentScores": {
+                "additionalProperties": {
+                  "type": "number",
+                },
+                "type": "object",
+              },
+              "agents": {
+                "additionalProperties": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "confidenceEstimate": {
+                      "type": "number",
+                    },
+                    "description": {
+                      "type": "string",
+                    },
+                    "reason": {
+                      "type": "string",
+                    },
+                    "reflection": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "whatCouldImprove": {
+                          "type": "string",
+                        },
+                        "whatIChose": {
+                          "type": "string",
+                        },
+                        "whatIObserved": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "whatIObserved",
+                        "whatIChose",
+                        "whatCouldImprove",
+                      ],
+                      "type": "object",
+                    },
+                    "score": {
+                      "type": "number",
+                    },
+                    "scoreTotal": {
+                      "type": "number",
+                    },
+                    "team": {
+                      "type": "string",
+                    },
+                    "warnings": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "weight": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "team",
+                    "score",
+                  ],
+                  "type": "object",
+                },
+                "type": "object",
+              },
+              "confidence": {
+                "type": "number",
+              },
+              "executions": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "agentDurationMs": {
+                      "type": "number",
+                    },
+                    "confidenceEstimate": {
+                      "type": "number",
+                    },
+                    "error": {
+                      "const": true,
+                      "type": "boolean",
+                    },
+                    "errorInfo": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "stack": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "result": {
+                      "$ref": "#/definitions/Predictions/properties/predictions/items/properties/agents/additionalProperties",
+                    },
+                    "scoreTotal": {
+                      "type": "number",
+                    },
+                    "sessionId": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "game": {
+                "additionalProperties": false,
+                "properties": {
+                  "awayTeam": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                    ],
+                    "type": "object",
+                  },
+                  "homeTeam": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                    ],
+                    "type": "object",
+                  },
+                  "time": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "homeTeam",
+                  "awayTeam",
+                  "time",
+                ],
+                "type": "object",
+              },
+              "winner": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "game",
+              "winner",
+              "confidence",
+              "agents",
+              "agentScores",
+              "executions",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+        "timestamp": {
+          "type": "string",
+        },
+        "weightsUsed": {
+          "additionalProperties": {
+            "type": "number",
+          },
+          "type": "object",
+        },
+      },
+      "required": [
+        "predictions",
+        "agentScores",
+        "weightsUsed",
+        "timestamp",
+        "cacheVersion",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`public API schema snapshots reflections schema 1`] = `
+{
+  "$ref": "#/definitions/Reflections",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Reflections": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "whatCouldImprove": {
+            "type": "string",
+          },
+          "whatIChose": {
+            "type": "string",
+          },
+          "whatIObserved": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "whatIObserved",
+          "whatIChose",
+          "whatCouldImprove",
+        ],
+        "type": "object",
+      },
+      "type": "object",
+    },
+  },
+}
+`;

--- a/__tests__/publicApiSchemas.test.ts
+++ b/__tests__/publicApiSchemas.test.ts
@@ -1,0 +1,22 @@
+/** @jest-environment node */
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { accuracySchema } from '../lib/schemas/accuracy';
+import { reflectionsSchema } from '../lib/schemas/reflections';
+import { predictionsSchema } from '../lib/schemas/predictions';
+
+describe('public API schema snapshots', () => {
+  test('accuracy schema', () => {
+    const schema = zodToJsonSchema(accuracySchema, 'Accuracy');
+    expect(schema).toMatchSnapshot();
+  });
+
+  test('reflections schema', () => {
+    const schema = zodToJsonSchema(reflectionsSchema, 'Reflections');
+    expect(schema).toMatchSnapshot();
+  });
+
+  test('predictions schema', () => {
+    const schema = zodToJsonSchema(predictionsSchema, 'Predictions');
+    expect(schema).toMatchSnapshot();
+  });
+});

--- a/lib/schemas/accuracy.ts
+++ b/lib/schemas/accuracy.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const accuracyEntrySchema = z.object({
+  name: z.string(),
+  wins: z.number(),
+  losses: z.number(),
+  accuracy: z.number(),
+});
+
+export const accuracySchema = z.object({
+  agents: z.array(accuracyEntrySchema),
+  flows: z.array(accuracyEntrySchema),
+});
+
+export type AccuracyResponse = z.infer<typeof accuracySchema>;

--- a/lib/schemas/predictions.ts
+++ b/lib/schemas/predictions.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { agentReflectionSchema } from './reflections';
+
+const agentResultSchema = z.object({
+  team: z.string(),
+  score: z.number(),
+  reason: z.string().optional(),
+  warnings: z.array(z.string()).optional(),
+  reflection: agentReflectionSchema.optional(),
+  weight: z.number().optional(),
+  scoreTotal: z.number().optional(),
+  confidenceEstimate: z.number().optional(),
+  description: z.string().optional(),
+});
+
+const agentExecutionSchema = z.object({
+  name: z.string(),
+  result: agentResultSchema.optional(),
+  error: z.literal(true).optional(),
+  errorInfo: z
+    .object({ message: z.string().optional(), stack: z.string().optional() })
+    .optional(),
+  scoreTotal: z.number().optional(),
+  confidenceEstimate: z.number().optional(),
+  agentDurationMs: z.number().optional(),
+  sessionId: z.string().optional(),
+});
+
+const gameSchema = z.object({
+  homeTeam: z.object({ name: z.string() }),
+  awayTeam: z.object({ name: z.string() }),
+  time: z.string(),
+});
+
+const predictionSchema = z.object({
+  game: gameSchema,
+  winner: z.string(),
+  confidence: z.number(),
+  agents: z.record(agentResultSchema),
+  agentScores: z.record(z.number()),
+  executions: z.array(agentExecutionSchema),
+});
+
+export const predictionsSchema = z.object({
+  predictions: z.array(predictionSchema),
+  agentScores: z.record(z.number()),
+  weightsUsed: z.record(z.number()),
+  timestamp: z.string(),
+  cacheVersion: z.string(),
+});
+
+export type PredictionsResponse = z.infer<typeof predictionsSchema>;

--- a/lib/schemas/reflections.ts
+++ b/lib/schemas/reflections.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const agentReflectionSchema = z.object({
+  whatIObserved: z.string(),
+  whatIChose: z.string(),
+  whatCouldImprove: z.string(),
+});
+
+export const reflectionsSchema = z.record(agentReflectionSchema);
+
+export type ReflectionsResponse = z.infer<typeof reflectionsSchema>;

--- a/llms.txt
+++ b/llms.txt
@@ -1979,3 +1979,14 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:54:18.061Z
+Commit: e5b4c051fc8a5f80feb7430be976c6ce52d3a0d5
+Author: Codex
+Message: feat: add public API zod schemas
+Files:
+- __tests__/__snapshots__/publicApiSchemas.test.ts.snap (+298/-0)
+- __tests__/publicApiSchemas.test.ts (+22/-0)
+- lib/schemas/accuracy.ts (+15/-0)
+- lib/schemas/predictions.ts (+52/-0)
+- lib/schemas/reflections.ts (+11/-0)
+


### PR DESCRIPTION
## Summary
- add zod schema for accuracy API contract
- add zod schema for reflections API contract
- add zod schema for predictions API contract
- snapshot tests for new public API schemas

## Testing
- `npm test -- -u`
- `npx jest __tests__/publicApiSchemas.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6895c734cef08323a4ac76a49b9d0f6a