### PR TITLE
Add axe-playwright a11y checks for core pages

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,20 @@
+name: Accessibility
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npx -p @playwright/test playwright install --with-deps
+      - run: npm run build
+      - run: npx next start & npx wait-on http://localhost:3000
+      - run: npx -p @playwright/test -p @axe-core/playwright playwright test tests/a11y

--- a/llms.txt
+++ b/llms.txt
@@ -1979,3 +1979,11 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:57:40.238Z
+Commit: 298561b80ef73cca538f91bf8a63d8ef861d626b
+Author: Codex
+Message: test: add axe-playwright accessibility checks
+Files:
+- .github/workflows/a11y.yml (+20/-0)
+- tests/a11y/core-pages.spec.ts (+21/-0)
+

--- a/tests/a11y/core-pages.spec.ts
+++ b/tests/a11y/core-pages.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import fs from 'fs';
+import path from 'path';
+
+const pagesDir = path.join(__dirname, '..', '..', 'pages');
+const routes = fs
+  .readdirSync(pagesDir)
+  .filter((file) => file.endsWith('.tsx') && !file.startsWith('_'))
+  .map((file) => {
+    const name = file.replace(/\.tsx$/, '');
+    return name === 'index' ? '/' : `/${name}`;
+  });
+
+for (const route of routes) {
+  test(`page ${route} has no accessibility violations`, async ({ page }) => {
+    await page.goto(`http://localhost:3000${route}`);
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+}


### PR DESCRIPTION
## Summary
- run axe-playwright accessibility tests in CI
- check core Next.js pages for accessibility violations

## Testing
- `npm test`
- `npx playwright test tests/a11y` *(fails: page /dashboard has accessibility violations)*

------
https://chatgpt.com/codex/tasks/task_e_6895c718918c83238e7d95435e57df1d