### PR TITLE
Add mock /api/accuracy-history (demo only)

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"25506e0389baf55ca32a971ec2f279f790773f4d9eab09756ee81e59d0fd7625"`;
+exports[`llms log writes entry (stable time) 1`] = `"ccafa8bd05bc8a8f7d961b8e54736cbc67e1f45324583e9768a8742c4fa7268b"`;

--- a/__tests__/api/accuracy-history.test.ts
+++ b/__tests__/api/accuracy-history.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment node */
+import { createClient } from '@supabase/supabase-js';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}));
+
+describe('GET /api/accuracy-history', () => {
+  beforeEach(() => {
+    (createClient as jest.Mock).mockReset();
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_KEY;
+  });
+
+  it('returns fixture data when Supabase env is missing', async () => {
+    let handler: any, MOCK_ACCURACY_HISTORY: any;
+    await jest.isolateModulesAsync(async () => {
+      const mod = await import('../../pages/api/accuracy-history');
+      handler = mod.default;
+      MOCK_ACCURACY_HISTORY = mod.MOCK_ACCURACY_HISTORY;
+    });
+    const json = jest.fn();
+    const res: any = { status: jest.fn().mockReturnThis(), json };
+    await handler({} as any, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ data: MOCK_ACCURACY_HISTORY });
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('fetches data from Supabase when env is present', async () => {
+    process.env.SUPABASE_URL = 'url';
+    process.env.SUPABASE_KEY = 'key';
+
+    const order = jest
+      .fn()
+      .mockResolvedValue({
+        data: [{ week: '2024-02-01', accuracy: 0.75 }],
+        error: null,
+      });
+    const select = jest.fn().mockReturnValue({ order });
+    const from = jest.fn().mockReturnValue({ select });
+    (createClient as jest.Mock).mockReturnValue({ from });
+
+    let handler: any;
+    await jest.isolateModulesAsync(async () => {
+      handler = (await import('../../pages/api/accuracy-history')).default;
+    });
+    const json = jest.fn();
+    const res: any = { status: jest.fn().mockReturnThis(), json };
+    await handler({} as any, res);
+
+    expect(createClient).toHaveBeenCalledWith('url', 'key');
+    expect(from).toHaveBeenCalledWith('accuracy_history');
+    expect(select).toHaveBeenCalledWith('week, accuracy');
+    expect(order).toHaveBeenCalledWith('week', { ascending: true });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({
+      data: [{ week: '2024-02-01', accuracy: 0.75 }],
+    });
+  });
+});
+

--- a/__tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap
+++ b/__tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`docs refresh snapshots generates docs 1`] = `
 "# API Routes
 
+- /api/accuracy-history
 - /api/accuracy
 - /api/dev-login
 - /api/log-status

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,6 @@
 # API Routes
 
+- /api/accuracy-history
 - /api/accuracy
 - /api/dev-login
 - /api/log-status
@@ -7,5 +8,6 @@
 - /api/reflections
 - /api/run-agents
 - /api/run-predictions
+- /api/sports-webhook
 - /api/trends
 - /api/upcoming-games

--- a/llms.txt
+++ b/llms.txt
@@ -1971,3 +1971,14 @@ Files:
 
 
 
+Timestamp: 2025-08-08T09:50:57.629Z
+Commit: b0ed9a00acaa6de93651301227f87e3895dbaa02
+Author: Codex
+Message: feat(api): add accuracy history endpoint
+Files:
+- __tests__/__snapshots__/llmsLog.test.ts.snap (+1/-1)
+- __tests__/api/accuracy-history.test.ts (+62/-0)
+- __tests__/docs/__snapshots__/refreshDocs.snap.test.ts.snap (+1/-0)
+- docs/api.md (+2/-0)
+- pages/api/accuracy-history.ts (+40/-0)
+

--- a/pages/api/accuracy-history.ts
+++ b/pages/api/accuracy-history.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+export interface WeeklyAccuracy {
+  week: string;
+  accuracy: number;
+}
+
+export const MOCK_ACCURACY_HISTORY: WeeklyAccuracy[] = [
+  { week: '2024-01-01', accuracy: 0.6 },
+  { week: '2024-01-08', accuracy: 0.65 },
+  { week: '2024-01-15', accuracy: 0.63 },
+  { week: '2024-01-22', accuracy: 0.68 },
+];
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { SUPABASE_URL, SUPABASE_KEY } = process.env;
+
+  if (SUPABASE_URL && SUPABASE_KEY) {
+    const client = createClient(SUPABASE_URL, SUPABASE_KEY);
+    const { data, error } = await client
+      .from('accuracy_history')
+      .select('week, accuracy')
+      .order('week', { ascending: true });
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    res.status(200).json({ data: data as WeeklyAccuracy[] });
+    return;
+  }
+
+  res.status(200).json({ data: MOCK_ACCURACY_HISTORY });
+}
+


### PR DESCRIPTION
## Summary
- expose `/api/accuracy-history` that serves weekly accuracy data from Supabase when configured or from a fixture otherwise
- cover both Supabase and fixture paths with unit tests
- document the new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895c67138988323a5b0d92c045a5739