### PR TITLE
feat(landing): Prediction marquee with demo tracker and accessible CTAs

### DIFF
--- a/__tests__/__snapshots__/llmsLog.test.ts.snap
+++ b/__tests__/__snapshots__/llmsLog.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`llms log writes entry (stable time) 1`] = `"25506e0389baf55ca32a971ec2f279f790773f4d9eab09756ee81e59d0fd7625"`;
+exports[`llms log writes entry (stable time) 1`] = `"d144ad8122fb0dcc83480f01ecdb1767f35db85180505d0d120c1a1a1281bd12"`;

--- a/__tests__/marketing/PredictionMarquee.test.tsx
+++ b/__tests__/marketing/PredictionMarquee.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import PredictionMarquee from '../../components/marketing/PredictionMarquee';
+
+describe('PredictionMarquee', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders tracker in demo mode', async () => {
+    render(<PredictionMarquee />);
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(screen.getByTestId('node-injuryScout')).toHaveAttribute(
+      'data-status',
+      'completed',
+    );
+    expect(screen.getByTestId('node-lineWatcher')).toHaveAttribute(
+      'data-status',
+      'completed',
+    );
+  });
+
+  it('buttons fire callbacks and scroll', () => {
+    const onDemo = jest.fn();
+    render(<PredictionMarquee onTryDemo={onDemo} />);
+    fireEvent.click(screen.getByRole('button', { name: /try the demo/i }));
+    expect(onDemo).toHaveBeenCalled();
+
+    const target = document.createElement('div');
+    target.id = 'live-games';
+    target.scrollIntoView = jest.fn();
+    document.body.appendChild(target);
+    fireEvent.click(screen.getByRole('button', { name: /see upcoming games/i }));
+    expect(target.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('does not shift layout significantly', () => {
+    const { getByTestId } = render(<PredictionMarquee />);
+    const marquee = getByTestId('prediction-marquee');
+    const before = marquee.getBoundingClientRect().height;
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    const after = marquee.getBoundingClientRect().height;
+    expect(Math.abs(after - before)).toBeLessThan(0.1);
+  });
+});

--- a/components/marketing/PredictionMarquee.tsx
+++ b/components/marketing/PredictionMarquee.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import AgentExecutionTracker, { AgentMeta } from '../AgentExecutionTracker';
+
+const agents: AgentMeta[] = [
+  { name: 'injuryScout', label: 'Injury' },
+  { name: 'lineWatcher', label: 'Lines' },
+];
+
+function scrollToId(id: string) {
+  const el = document.getElementById(id);
+  if (el) {
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setTimeout(() => {
+      if (typeof (el as HTMLElement).focus === 'function') {
+        (el as HTMLElement).focus();
+      }
+    }, 300);
+  }
+}
+
+interface Props {
+  onTryDemo?: () => void;
+  onSeeUpcoming?: () => void;
+}
+
+const PredictionMarquee: React.FC<Props> = ({ onTryDemo, onSeeUpcoming }) => {
+  const prefersReduced =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const handleSeeUpcoming = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (onSeeUpcoming) {
+      onSeeUpcoming();
+    } else {
+      scrollToId('live-games');
+    }
+  };
+
+  return (
+    <section className="bg-slate-900 text-white text-center py-8 px-4 space-y-6" data-testid="prediction-marquee">
+      <div className="max-w-md mx-auto" style={{ minHeight: 200 }}>
+        <AgentExecutionTracker agents={agents} mode={prefersReduced ? 'live' : 'demo'} />
+      </div>
+      <p className="text-xl font-medium">Modular AI agents. Transparent picks.</p>
+      <div className="flex flex-col sm:flex-row justify-center gap-4">
+        <button
+          onClick={onTryDemo}
+          className="px-6 py-3 rounded-full bg-blue-600 text-white hover:opacity-90 transition focus:outline-none focus:ring-2 focus:ring-blue-400"
+        >
+          Try the Demo
+        </button>
+        <button
+          onClick={handleSeeUpcoming}
+          className="px-6 py-3 rounded-full border border-white hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-white"
+        >
+          See Upcoming Games
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default PredictionMarquee;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import HeroStrip from '../components/HeroStrip';
 import UpcomingGamesGrid from '../components/UpcomingGamesGrid';
+import PredictionMarquee from '../components/marketing/PredictionMarquee';
 import type { Game } from '../lib/types';
 
 const PredictionDrawer = dynamic(() => import('../components/PredictionDrawer'), {
@@ -97,6 +98,10 @@ export default function Home() {
     });
   };
 
+  const openDemo = () => {
+    router.push('/codex/prompts');
+  };
+
 
   const headTitle = selected
     ? `Win more pick'em: ${selected.homeTeam} vs ${selected.awayTeam} live AI prediction`
@@ -111,6 +116,7 @@ export default function Home() {
         <title>{headTitle}</title>
         <meta name="description" content={headDesc} />
       </Head>
+      <PredictionMarquee onTryDemo={openDemo} />
       <HeroStrip />
       <main className="min-h-screen px-4 sm:px-6 lg:px-8 py-4 space-y-4 max-w-7xl mx-auto">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">


### PR DESCRIPTION
## Summary
- add PredictionMarquee hero with demo AgentExecutionTracker, tagline, and CTAs
- display marquee on landing page with demo callback handler
- cover marquee behavior with unit tests and update llms log snapshot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895c7c5e18c832399e7a2a078b6d400