### PR TITLE
feat(ui): GameInsightsHero shows upcoming games + CTA (tests included)

### DIFF
--- a/__tests__/GameInsightsHero.test.tsx
+++ b/__tests__/GameInsightsHero.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import GameInsightsHero from '../components/GameInsightsHero';
+
+describe('GameInsightsHero', () => {
+  const sampleGames = Array.from({ length: 6 }).map((_, i) => ({
+    id: String(i),
+    home: `Home ${i}`,
+    away: `Away ${i}`,
+    kickoff: new Date().toISOString(),
+    spread: -3.5,
+    total: 42.5,
+  }));
+
+  it('renders with 6 games', () => {
+    render(<GameInsightsHero games={sampleGames} />);
+    expect(screen.getAllByTestId('game-item')).toHaveLength(6);
+  });
+
+  it('loading state shows skeletons and no undefined', () => {
+    render(<GameInsightsHero isLoading />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByText(/undefined/i)).toBeNull();
+  });
+
+  it('shows empty state when no games', () => {
+    render(<GameInsightsHero games={[]} />);
+    expect(screen.getByText('No upcoming games.')).toBeInTheDocument();
+  });
+
+  it('button calls onSeeAgents', () => {
+    const onSeeAgents = jest.fn();
+    render(<GameInsightsHero games={sampleGames} onSeeAgents={onSeeAgents} />);
+    fireEvent.click(screen.getByRole('button', { name: 'See agents in action' }));
+    expect(onSeeAgents).toHaveBeenCalled();
+  });
+});
+

--- a/components/GameInsightsHero.tsx
+++ b/components/GameInsightsHero.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import useSWR from 'swr';
+import LoadingShimmer from './LoadingShimmer';
+
+export type GameInsightsHeroProps = {
+  games?: Array<{
+    id: string;
+    home: string;
+    away: string;
+    kickoff: string; // ISO
+    spread?: number | null;
+    total?: number | null;
+    homeLogoUrl?: string;
+    awayLogoUrl?: string;
+  }>;
+  isLoading?: boolean;
+  onSeeAgents?: () => void; // opens Matchup Insights with Advanced View
+};
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+const GameInsightsHero: React.FC<GameInsightsHeroProps> = ({
+  games: gamesProp,
+  isLoading: loadingProp,
+  onSeeAgents,
+}) => {
+  const { data, isLoading: swrLoading } = useSWR<GameInsightsHeroProps['games']>(
+    gamesProp ? null : '/api/upcoming-games',
+    fetcher,
+    { revalidateOnFocus: false, dedupingInterval: 30000 },
+  );
+
+  const games = gamesProp ?? data ?? [];
+  const isLoading = loadingProp ?? (gamesProp ? false : swrLoading);
+
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+  if (isLoading) {
+    return (
+      <section aria-label="Upcoming games" className="p-4">
+        <LoadingShimmer lines={6} lineClassName="h-16" />
+      </section>
+    );
+  }
+
+  if (!games.length) {
+    return (
+      <section aria-label="Upcoming games" className="p-4 text-center space-y-4">
+        <p>No upcoming games.</p>
+        {onSeeAgents && (
+          <button
+            onClick={onSeeAgents}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            See agents in action
+          </button>
+        )}
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="game-insights-heading"
+      className="p-4 space-y-4"
+    >
+      <h2 id="game-insights-heading" className="text-xl font-semibold">
+        Upcoming Games
+      </h2>
+      <ul role="list" className="space-y-3">
+        {games.slice(0, 6).map((g) => (
+          <li
+            key={g.id}
+            data-testid="game-item"
+            className="flex items-center justify-between gap-4"
+          >
+            <div className="flex items-center gap-2">
+              {g.homeLogoUrl && (
+                <img
+                  src={g.homeLogoUrl}
+                  alt={`${g.home} logo`}
+                  className="w-6 h-6"
+                />
+              )}
+              <span>{g.home}</span>
+              <span className="text-gray-500">vs</span>
+              {g.awayLogoUrl && (
+                <img
+                  src={g.awayLogoUrl}
+                  alt={`${g.away} logo`}
+                  className="w-6 h-6"
+                />
+              )}
+              <span>{g.away}</span>
+            </div>
+            <div className="text-right text-sm">
+              <time dateTime={g.kickoff}>{formatter.format(new Date(g.kickoff))}</time>
+              {(g.spread != null || g.total != null) && (
+                <div>
+                  {g.spread != null && <span>Spread {g.spread}</span>}
+                  {g.spread != null && g.total != null && <span> · </span>}
+                  {g.total != null && <span>Total {g.total}</span>}
+                </div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+      {onSeeAgents && (
+        <div>
+          <button
+            onClick={onSeeAgents}
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            See agents in action
+          </button>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default GameInsightsHero;
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import Head from 'next/head';
 import HeroStrip from '../components/HeroStrip';
 import UpcomingGamesGrid from '../components/UpcomingGamesGrid';
 import PredictionMarquee from '../components/marketing/PredictionMarquee';
+import GameInsightsHero from '../components/GameInsightsHero';
 import type { Game } from '../lib/types';
 
 const PredictionDrawer = dynamic(() => import('../components/PredictionDrawer'), {
@@ -47,6 +48,16 @@ export default function Home() {
     awayLogo: g.awayTeam?.logo,
     odds: g.odds,
     source: g.source,
+  }));
+  const heroGames = games.map((g) => ({
+    id: g.gameId,
+    home: g.homeTeam,
+    away: g.awayTeam,
+    kickoff: g.time,
+    spread: g.odds?.spread ?? null,
+    total: g.odds?.overUnder ?? null,
+    homeLogoUrl: g.homeLogo,
+    awayLogoUrl: g.awayLogo,
   }));
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<Game | null>(null);
@@ -116,6 +127,11 @@ export default function Home() {
         <title>{headTitle}</title>
         <meta name="description" content={headDesc} />
       </Head>
+      <GameInsightsHero
+        games={heroGames}
+        isLoading={isLoading}
+        onSeeAgents={() => router.push('/predictions?view=advanced')}
+      />
       <PredictionMarquee onTryDemo={openDemo} />
       <HeroStrip />
       <main className="min-h-screen px-4 sm:px-6 lg:px-8 py-4 space-y-4 max-w-7xl mx-auto">


### PR DESCRIPTION
## Summary
- add GameInsightsHero component for displaying upcoming matchups with CTA
- mount GameInsightsHero on home page
- test GameInsightsHero rendering, states, and CTA

## Testing
- `npm test` *(fails: Merge conflict marker encountered in existing PredictionMarquee files)*

------
https://chatgpt.com/codex/tasks/task_e_6895c1b6871c8323a21f26a3a3adde46