### PR TITLE
ci(eslint): enforce no-console in CI with separate config

### DIFF
--- a/.eslintrc.no-console.ci.json
+++ b/.eslintrc.no-console.ci.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./.eslintrc.json",
+  "rules": {
+    "no-console": ["error", { "allow": ["warn", "error"] }]
+  }
+}

--- a/.github/workflows/eslint-no-console.yml
+++ b/.github/workflows/eslint-no-console.yml
@@ -1,0 +1,19 @@
+name: ESLint no-console
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  no-console:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npx eslint -c .eslintrc.no-console.ci.json .


### PR DESCRIPTION
## Summary
- add CI-only ESLint config enforcing no-console except warn and error
- run dedicated GitHub Action to apply the no-console rule

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npx eslint -c .eslintrc.no-console.ci.json .` *(fails: needs an import attribute of type "json")*

------
https://chatgpt.com/codex/tasks/task_e_6895d3c94d2883238be371d97014038d