### PR TITLE
feat(agents): add Supabase-backed registry module

### DIFF
--- a/__tests__/supabaseRegistry.test.ts
+++ b/__tests__/supabaseRegistry.test.ts
@@ -1,0 +1,38 @@
+/** @jest-environment node */
+
+const sample = [
+  { id: 'a1', name: 'test', weight: 1, enabled: true, desc: 'demo' },
+];
+
+const selectMock = jest.fn().mockResolvedValue({ data: sample, error: null });
+const fromMock = jest.fn(() => ({ select: selectMock }));
+
+jest.mock('../lib/supabaseClient', () => ({
+  supabase: { from: fromMock },
+}));
+
+const cacheMock = jest.fn((fn: any) => {
+  let value: any;
+  return async (...args: any[]) => {
+    if (value === undefined) {
+      value = await fn(...args);
+    }
+    return value;
+  };
+});
+
+jest.mock('../lib/server/cache', () => ({ cache: cacheMock }), { virtual: true });
+
+import { getSupabaseAgentRegistry } from '../lib/agents/supabaseRegistry';
+
+describe('getSupabaseAgentRegistry', () => {
+  it('fetches agent metadata with caching', async () => {
+    const first = await getSupabaseAgentRegistry();
+    const second = await getSupabaseAgentRegistry();
+
+    expect(first).toEqual(sample);
+    expect(second).toBe(first);
+    expect(fromMock).toHaveBeenCalledTimes(1);
+    expect(cacheMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/agents/supabaseRegistry.ts
+++ b/lib/agents/supabaseRegistry.ts
@@ -1,0 +1,30 @@
+import { supabase } from '../supabaseClient';
+import { cache } from '../server/cache';
+
+export interface SupabaseAgentMeta {
+  id: string;
+  name: string;
+  weight: number;
+  enabled: boolean;
+  desc: string | null;
+}
+
+async function fetchAgents(): Promise<SupabaseAgentMeta[]> {
+  try {
+    const { data, error } = await supabase
+      .from('agents')
+      .select('id, name, weight, enabled, desc');
+
+    if (error) {
+      console.error('agent registry fetch error', error);
+      return [];
+    }
+
+    return data ?? [];
+  } catch (err) {
+    console.error('agent registry fetch error', err);
+    return [];
+  }
+}
+
+export const getSupabaseAgentRegistry = cache(fetchAgents);


### PR DESCRIPTION
## Summary
- fetch agent registry from Supabase with server-side caching
- add test covering Supabase registry caching behavior

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d3b100b48323a3c0afbd4b7edd09