### PR TITLE
feat(data): add MLB schedule provider module

### DIFF
--- a/__tests__/fixtures/mlb.schedule.json
+++ b/__tests__/fixtures/mlb.schedule.json
@@ -1,0 +1,4 @@
+[
+  {"id":"mlb1","home":"New York Yankees","away":"Boston Red Sox","commence_time":"2024-04-01T17:05:00Z"},
+  {"id":"mlb2","home":"Los Angeles Dodgers","away":"Chicago Cubs","commence_time":"2024-04-02T20:10:00Z"}
+]

--- a/__tests__/schedule.mlb.test.ts
+++ b/__tests__/schedule.mlb.test.ts
@@ -1,0 +1,26 @@
+import rawSchedule from './fixtures/mlb.schedule.json';
+import { normalizeMlbSchedule } from '../lib/data/schedule.mlb';
+
+describe('MLB schedule provider', () => {
+  it('normalizes MLB API data to internal Matchup', () => {
+    const result = normalizeMlbSchedule(rawSchedule);
+    expect(result).toEqual([
+      {
+        homeTeam: 'New York Yankees',
+        awayTeam: 'Boston Red Sox',
+        time: '2024-04-01T17:05:00Z',
+        league: 'MLB',
+        gameId: 'mlb1',
+        source: 'live-mlb-api',
+      },
+      {
+        homeTeam: 'Los Angeles Dodgers',
+        awayTeam: 'Chicago Cubs',
+        time: '2024-04-02T20:10:00Z',
+        league: 'MLB',
+        gameId: 'mlb2',
+        source: 'live-mlb-api',
+      },
+    ]);
+  });
+});

--- a/lib/data/schedule.mlb.ts
+++ b/lib/data/schedule.mlb.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import type { Matchup } from '../types';
+
+// Raw game shape from the MLB schedule API. Mirrors the NFL API response.
+const MlbGameSchema = z.object({
+  id: z.string(),
+  home: z.string(),
+  away: z.string(),
+  commence_time: z.string(),
+});
+
+export type MlbGame = z.infer<typeof MlbGameSchema>;
+
+const MlbScheduleSchema = z.array(MlbGameSchema);
+
+/**
+ * Normalize MLB API schedule data into internal Matchup objects.
+ */
+export function normalizeMlbSchedule(data: unknown): Matchup[] {
+  const games = MlbScheduleSchema.parse(data);
+  return games.map((g) => ({
+    homeTeam: g.home,
+    awayTeam: g.away,
+    time: g.commence_time,
+    league: 'MLB',
+    gameId: g.id,
+    source: 'live-mlb-api',
+  }));
+}


### PR DESCRIPTION
## Summary
- add MLB schedule provider normalizing API games to internal Matchup
- cover MLB schedule normalization with fixture-based unit test

## Testing
- `npm test` *(fails: EJSONPARSE Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d3a2a568832381d7ddf5f09801d7