### PR TITLE
feat(ui): add matchup form skeleton component

### DIFF
--- a/__tests__/MatchupInputFormSkeleton.test.tsx
+++ b/__tests__/MatchupInputFormSkeleton.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MatchupInputFormSkeleton from '../components/skeletons/MatchupInputFormSkeleton';
+
+describe('MatchupInputFormSkeleton', () => {
+  it('renders skeleton fields and button with aria-busy', () => {
+    render(<MatchupInputFormSkeleton />);
+    expect(screen.getByTestId('matchup-form-skeleton')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByTestId('field-skeleton').length).toBe(3);
+    expect(screen.getByTestId('button-skeleton')).toBeInTheDocument();
+  });
+});

--- a/components/skeletons/MatchupInputFormSkeleton.tsx
+++ b/components/skeletons/MatchupInputFormSkeleton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { matchupCard } from '../../styles/cardStyles';
+
+interface Props {
+  className?: string;
+}
+
+const MatchupInputFormSkeleton: React.FC<Props> = ({ className = '' }) => (
+  <div
+    className={`${matchupCard} grid gap-4 sm:grid-cols-2 lg:grid-cols-4 animate-pulse ${className}`}
+    aria-busy="true"
+    data-testid="matchup-form-skeleton"
+  >
+    {[1, 2, 3].map((key) => (
+      <div key={key} className="flex flex-col gap-1" data-testid="field-skeleton">
+        <div className="h-4 w-20 bg-neutral-200 dark:bg-neutral-700 rounded" />
+        <div className="h-10 w-full bg-neutral-200 dark:bg-neutral-700 rounded" />
+      </div>
+    ))}
+    <div className="sm:self-end" data-testid="button-skeleton">
+      <div className="h-11 w-24 bg-neutral-200 dark:bg-neutral-700 rounded" />
+    </div>
+  </div>
+);
+
+export default MatchupInputFormSkeleton;
+

--- a/stories/MatchupInputFormSkeleton.stories.tsx
+++ b/stories/MatchupInputFormSkeleton.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MatchupInputFormSkeleton from '../components/skeletons/MatchupInputFormSkeleton';
+
+const meta: Meta<typeof MatchupInputFormSkeleton> = {
+  title: 'MatchupInputFormSkeleton',
+  component: MatchupInputFormSkeleton,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MatchupInputFormSkeleton>;
+
+export const Default: Story = {};
+


### PR DESCRIPTION
## Summary
- add standalone skeleton for matchup input form
- document skeleton in storybook and test accessible layout

## Testing
- `npm test` *(fails: Invalid package.json, JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_6895d37e0d9c83239d54273632485703