### PR TITLE
feat(ui): AgentDetailsModal component with tests + story

### DIFF
--- a/__tests__/AgentDetailsModal.test.tsx
+++ b/__tests__/AgentDetailsModal.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AgentDetailsModal from '../components/AgentDetailsModal';
+
+describe('AgentDetailsModal', () => {
+  const agent = {
+    name: 'injuryScout',
+    purpose: 'Tracks player injuries',
+    inputs: ['roster', 'injury reports'],
+    outputs: ['score', 'reasoning'],
+    weight: 0.5,
+    accuracy: 91,
+  };
+
+  it('renders agent details', () => {
+    render(<AgentDetailsModal isOpen onClose={() => {}} agent={agent} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(agent.name)).toBeInTheDocument();
+    expect(screen.getByText(/Tracks player injuries/i)).toBeInTheDocument();
+    expect(screen.getByText(/roster, injury reports/)).toBeInTheDocument();
+    expect(screen.getByText(/score, reasoning/)).toBeInTheDocument();
+    expect(screen.getByText(/0.5/)).toBeInTheDocument();
+    expect(screen.getByText(/91%/)).toBeInTheDocument();
+  });
+
+  it('closes on Escape key press', () => {
+    const onClose = jest.fn();
+    render(<AgentDetailsModal isOpen onClose={onClose} agent={agent} />);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('traps focus within the modal', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button>outside</button>
+        <AgentDetailsModal isOpen onClose={() => {}} agent={agent} />
+      </>
+    );
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    expect(closeButton).toHaveFocus();
+    await user.tab();
+    expect(closeButton).toHaveFocus();
+  });
+});
+

--- a/components/AgentDetailsModal.tsx
+++ b/components/AgentDetailsModal.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useRef } from 'react';
+import { Button } from './ui/button';
+
+interface AgentDetails {
+  name: string;
+  purpose: string;
+  inputs: string[];
+  outputs: string[];
+  weight: number;
+  accuracy: number;
+}
+
+interface AgentDetailsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  agent: AgentDetails;
+}
+
+const focusableSelectors =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const AgentDetailsModal: React.FC<AgentDetailsModalProps> = ({ isOpen, onClose, agent }) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      closeButtonRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      onClose();
+      return;
+    }
+    if (e.key !== 'Tab') return;
+
+    const focusable = modalRef.current?.querySelectorAll<HTMLElement>(focusableSelectors);
+    if (!focusable || focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else if (document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = () => onClose();
+  const stopPropagation = (e: React.MouseEvent) => e.stopPropagation();
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={handleOverlayClick}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="agent-details-title"
+        className="bg-white w-full max-w-md rounded p-4 shadow-md text-gray-900"
+        ref={modalRef}
+        onClick={stopPropagation}
+        onKeyDown={handleKeyDown}
+        tabIndex={-1}
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2 id="agent-details-title" className="text-lg font-semibold">
+            {agent.name}
+          </h2>
+          <Button ref={closeButtonRef} onClick={onClose} aria-label="Close" className="px-2 py-1">
+            Close
+          </Button>
+        </div>
+        <div className="space-y-2 text-sm">
+          <p>
+            <span className="font-semibold">Purpose:</span> {agent.purpose}
+          </p>
+          <p>
+            <span className="font-semibold">Inputs:</span> {agent.inputs.join(', ')}
+          </p>
+          <p>
+            <span className="font-semibold">Outputs:</span> {agent.outputs.join(', ')}
+          </p>
+          <p>
+            <span className="font-semibold">Weight:</span> {agent.weight}
+          </p>
+          <p>
+            <span className="font-semibold">Last Accuracy:</span> {agent.accuracy}%
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AgentDetailsModal;
+

--- a/stories/AgentDetailsModal.stories.tsx
+++ b/stories/AgentDetailsModal.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import AgentDetailsModal from '../components/AgentDetailsModal';
+
+const meta: Meta<typeof AgentDetailsModal> = {
+  title: 'AgentDetailsModal',
+  component: AgentDetailsModal,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AgentDetailsModal>;
+
+const agent = {
+  name: 'injuryScout',
+  purpose: 'Tracks player injuries',
+  inputs: ['roster', 'injury reports'],
+  outputs: ['score', 'reasoning'],
+  weight: 0.5,
+  accuracy: 91,
+};
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    agent,
+  },
+};
+


### PR DESCRIPTION
## Summary
- add accessible AgentDetailsModal for viewing agent metadata
- cover AgentDetailsModal with unit tests
- add Storybook story for AgentDetailsModal

## Testing
- `npm test` *(fails: Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_6895d37680008323a0d0917e7052e309