### PR TITLE
feat(logging): error context + formatter

### DIFF
--- a/__tests__/errContext.test.ts
+++ b/__tests__/errContext.test.ts
@@ -1,0 +1,30 @@
+import { withErrContext, formatErrForLog } from '../lib/logging/errContext';
+
+describe('errContext', () => {
+  test('preserves stack', () => {
+    const err = new Error('boom');
+    const stack = err.stack;
+    const wrapped = withErrContext(err, { foo: 'bar' });
+    expect(wrapped.stack).toBe(stack);
+  });
+
+  test('merges context', () => {
+    const err = withErrContext(new Error('oops'), { foo: 'bar' });
+    const merged = withErrContext(err, { bar: 'baz' });
+    expect(merged.context).toEqual({ foo: 'bar', bar: 'baz' });
+  });
+
+  test('redacts secrets', () => {
+    const err = withErrContext(new Error('nope'), {
+      password: 'p',
+      token: 't',
+      nested: { secret: 's' },
+      safe: 'ok',
+    });
+    const out = JSON.parse(formatErrForLog(err));
+    expect(out.context.password).toBe('[REDACTED]');
+    expect(out.context.token).toBe('[REDACTED]');
+    expect(out.context.nested.secret).toBe('[REDACTED]');
+    expect(out.context.safe).toBe('ok');
+  });
+});

--- a/lib/logging/errContext.ts
+++ b/lib/logging/errContext.ts
@@ -1,0 +1,46 @@
+export type ErrorWithContext = Error & { context?: Record<string, unknown> };
+
+function safeClone<T>(value: T): T {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return {} as T;
+  }
+}
+
+const SECRET_KEYS = ['password', 'secret', 'token', 'apikey', 'apiKey'];
+
+function redactSecrets(obj: any): any {
+  if (obj && typeof obj === 'object') {
+    if (Array.isArray(obj)) {
+      return obj.map(redactSecrets);
+    }
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, val]) => {
+        if (SECRET_KEYS.some((s) => key.toLowerCase().includes(s))) {
+          return [key, '[REDACTED]'];
+        }
+        return [key, redactSecrets(val)];
+      }),
+    );
+  }
+  return obj;
+}
+
+export function withErrContext(err: unknown, ctx: Record<string, unknown>): ErrorWithContext {
+  const e: ErrorWithContext = err instanceof Error ? err : new Error(String(err));
+  const existing = e.context && typeof e.context === 'object' ? e.context : {};
+  e.context = { ...existing, ...safeClone(ctx) };
+  return e;
+}
+
+export function formatErrForLog(err: ErrorWithContext): string {
+  const base: Record<string, unknown> = {
+    message: err.message,
+    stack: err.stack,
+  };
+  if (err.context) {
+    base.context = redactSecrets(err.context);
+  }
+  return JSON.stringify(base);
+}


### PR DESCRIPTION
## Summary
- add helper to attach structured context to errors and format them for logs
- cover error context utilities with tests for merging, stack preservation, and secret redaction

## Testing
- `npm test` *(fails: Merge conflict marker encountered in PredictionMarquee.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6895d358d3188323924010afafc49575