### PR TITLE
docs: explain prediction cache design

### DIFF
--- a/docs/prediction-cache.md
+++ b/docs/prediction-cache.md
@@ -1,0 +1,69 @@
+# Prediction Cache
+
+The prediction API uses a two-layer cache to avoid recomputation and reduce latency.
+
+## Cache Keys
+
+Keys combine the league, game, and agent list:
+
+```ts
+// lib/server/cache.ts
+export function buildCacheKey(league: string, gameId: string, agents: string[]) {
+  return `${league}:${gameId}:${agents.sort().join(',')}`;
+}
+```
+
+Example: `NFL:g1:injuryScout,lineWatcher`.
+
+## Time to Live (TTL)
+
+Entries default to a configurable TTL (`PREDICTION_CACHE_TTL_SEC` or 60s). When a
+request arrives, the in-memory map is checked first. If the entry is fresh, the
+request takes the **warm path** and returns immediately. Otherwise, the request
+falls back to Supabase and, if still missing or expired, recomputes the prediction
+(the **cold path**).
+
+## Local vs Supabase
+
+- **Memory**: fast, process-local Map for current Node instance.
+- **Supabase**: persistent store shared across instances via the
+  `prediction_cache` table.
+
+```ts
+// lib/server/cache.ts
+export async function getCachedPrediction(key: string) {
+  const now = Date.now();
+  const entry = memoryCache.get(key);
+  if (entry && entry.expiresAt > now) {
+    return { value: entry.value, cached: true };
+  }
+  const { data } = await supabase
+    .from('prediction_cache')
+    .select('value, expires_at')
+    .eq('key', key)
+    .single();
+  if (!data) return { value: null, cached: false };
+  const exp = new Date(data.expires_at).getTime();
+  if (exp < now) return { value: null, cached: false };
+  memoryCache.set(key, { value: data.value, expiresAt: exp });
+  return { value: data.value, cached: true };
+}
+```
+
+## Invalidation
+
+Cache entries expire automatically via TTL. Manual invalidation is available via
+`purgeCache`, which accepts a specific key or prefix:
+
+```ts
+// lib/server/cache.ts
+export function purgeCache({ key, prefix }: { key?: string; prefix?: string } = {}) {
+  for (const k of Array.from(memoryCache.keys())) {
+    if (key && k !== key) continue;
+    if (prefix && !k.startsWith(prefix)) continue;
+    memoryCache.delete(k);
+  }
+}
+```
+
+This enables targeted clears (single matchup) or full wipes (by league).

--- a/lib/server/cache.ts
+++ b/lib/server/cache.ts
@@ -1,0 +1,57 @@
+import { supabase } from '../supabaseClient';
+
+interface CacheEntry {
+  value: any;
+  expiresAt: number;
+}
+
+const memoryCache = new Map<string, CacheEntry>();
+const DEFAULT_TTL = parseInt(process.env.PREDICTION_CACHE_TTL_SEC || '60', 10);
+
+export function buildCacheKey(league: string, gameId: string, agents: string[]) {
+  return `${league}:${gameId}:${agents.sort().join(',')}`;
+}
+
+export async function getCachedPrediction(key: string) {
+  const now = Date.now();
+  const entry = memoryCache.get(key);
+  if (entry && entry.expiresAt > now) {
+    return { value: entry.value, cached: true };
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('prediction_cache')
+      .select('value, expires_at')
+      .eq('key', key)
+      .single();
+    if (!data || error) return { value: null, cached: false };
+    const exp = new Date(data.expires_at).getTime();
+    if (exp < now) return { value: null, cached: false };
+    memoryCache.set(key, { value: data.value, expiresAt: exp });
+    return { value: data.value, cached: true };
+  } catch (err) {
+    console.error('cache fetch error', err);
+    return { value: null, cached: false };
+  }
+}
+
+export async function setCachedPrediction(key: string, value: any, ttl = DEFAULT_TTL) {
+  const expiresAt = Date.now() + ttl * 1000;
+  memoryCache.set(key, { value, expiresAt });
+  try {
+    await supabase
+      .from('prediction_cache')
+      .upsert({ key, value, expires_at: new Date(expiresAt).toISOString() });
+  } catch (err) {
+    console.error('cache store error', err);
+  }
+}
+
+export function purgeCache({ key, prefix }: { key?: string; prefix?: string } = {}) {
+  for (const k of Array.from(memoryCache.keys())) {
+    if (key && k !== key) continue;
+    if (prefix && !k.startsWith(prefix)) continue;
+    memoryCache.delete(k);
+  }
+}


### PR DESCRIPTION
## Summary
- document prediction caching strategy and API usage
- add server-side cache helpers with build, get, set, and purge utilities

## Testing
- `npm test` *(fails: Invalid package.json: Expected double-quoted property name)*

------
https://chatgpt.com/codex/tasks/task_e_6895d3644cb08323823dad1fbf86fbe8