### PR TITLE
feat(api): add run-agents request schema + tests

### DIFF
--- a/__tests__/runAgents.schema.test.ts
+++ b/__tests__/runAgents.schema.test.ts
@@ -1,0 +1,28 @@
+import { parseRunAgentsBody } from '../lib/api/validation/runAgents.schema';
+
+describe('run-agents request body schema', () => {
+  test('valid body parses', () => {
+    const body = { league: 'NFL', gameId: 'game-1', agents: ['injuryScout'] };
+    expect(parseRunAgentsBody(body)).toEqual(body);
+  });
+
+  test('league is required', () => {
+    expect(() => parseRunAgentsBody({ gameId: 'game-1' })).toThrow(/league required/);
+  });
+
+  test('gameId is required', () => {
+    expect(() => parseRunAgentsBody({ league: 'NFL' })).toThrow(/gameId required/);
+  });
+
+  test('invalid league rejected', () => {
+    expect(() => parseRunAgentsBody({ league: 'MLS', gameId: 'game-1' })).toThrow(
+      /Invalid enum value/,
+    );
+  });
+
+  test('invalid agent rejected', () => {
+    expect(() =>
+      parseRunAgentsBody({ league: 'NFL', gameId: 'game-1', agents: ['badAgent'] }),
+    ).toThrow(/Invalid enum value/);
+  });
+});

--- a/lib/api/validation/runAgents.schema.ts
+++ b/lib/api/validation/runAgents.schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { registry, type AgentName } from '../../agents/registry';
+
+const leagueSchema = z.enum(['NFL', 'MLB', 'NBA', 'NHL'], {
+  required_error: 'league required',
+});
+
+const agentNames = registry.map((a) => a.name) as [AgentName, ...AgentName[]];
+const agentNameSchema = z.enum(agentNames);
+
+export const runAgentsBodySchema = z.object({
+  league: leagueSchema,
+  gameId: z.string({
+    required_error: 'gameId required',
+    invalid_type_error: 'gameId must be a string',
+  }),
+  agents: z
+    .array(agentNameSchema, {
+      invalid_type_error: 'agents must be an array',
+    })
+    .optional(),
+});
+
+export type RunAgentsBody = z.infer<typeof runAgentsBodySchema>;
+
+export function parseRunAgentsBody(json: unknown): RunAgentsBody {
+  return runAgentsBodySchema.parse(json);
+}


### PR DESCRIPTION
## Summary
- add zod schema for run-agents request body and parsing helper
- test valid and invalid bodies for helpful errors

## Testing
- `npm test __tests__/runAgents.schema.test.ts` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d34295d88323bc204b7bc2d7fe0e