### PR TITLE
feat(server): add generic rate limiter utility

### DIFF
--- a/__tests__/rateLimit.test.ts
+++ b/__tests__/rateLimit.test.ts
@@ -1,0 +1,32 @@
+import { createRateLimiter } from '../lib/server/rateLimit';
+
+describe('rate limiter', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('allows under limit', () => {
+    const check = createRateLimiter({ windowMs: 1000, max: 2 });
+    expect(check('1.1.1.1', 'foo')).toBe(true);
+    expect(check('1.1.1.1', 'foo')).toBe(true);
+  });
+
+  test('blocks over limit', () => {
+    const check = createRateLimiter({ windowMs: 1000, max: 2 });
+    check('1.1.1.1', 'foo');
+    check('1.1.1.1', 'foo');
+    expect(check('1.1.1.1', 'foo')).toBe(false);
+  });
+
+  test('resets after window', () => {
+    const check = createRateLimiter({ windowMs: 1000, max: 1 });
+    expect(check('1.1.1.1', 'foo')).toBe(true);
+    expect(check('1.1.1.1', 'foo')).toBe(false);
+    jest.advanceTimersByTime(1000);
+    expect(check('1.1.1.1', 'foo')).toBe(true);
+  });
+});

--- a/lib/server/rateLimit.ts
+++ b/lib/server/rateLimit.ts
@@ -1,0 +1,33 @@
+interface RateLimiterOptions {
+  windowMs: number;
+  max: number;
+}
+
+interface Entry {
+  count: number;
+  expiresAt: number;
+}
+
+export function createRateLimiter({ windowMs, max }: RateLimiterOptions) {
+  const hits = new Map<string, Entry>();
+
+  return function check(ip: string, key = 'global'): boolean {
+    const id = `${ip}:${key}`;
+    const now = Date.now();
+    const entry = hits.get(id);
+
+    if (!entry || entry.expiresAt <= now) {
+      hits.set(id, { count: 1, expiresAt: now + windowMs });
+      return true;
+    }
+
+    if (entry.count >= max) {
+      return false;
+    }
+
+    entry.count += 1;
+    return true;
+  };
+}
+
+export type RateLimiter = ReturnType<typeof createRateLimiter>;


### PR DESCRIPTION
## Summary
- implement in-memory rate limiter for per-IP and key checks
- add unit tests covering allowed, blocked, and reset behaviors

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d34a47008323914de315b417fb85