### PR TITLE
feat: add fuzzy game search

### DIFF
--- a/__tests__/GameFuzzySearch.test.tsx
+++ b/__tests__/GameFuzzySearch.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import GameFuzzySearch from '../components/search/GameFuzzySearch';
+import type { Game } from '../lib/types';
+
+const games: Game[] = [
+  {
+    gameId: '1',
+    league: 'NBA',
+    homeTeam: 'Lakers',
+    awayTeam: 'Celtics',
+    time: new Date().toISOString(),
+  },
+  {
+    gameId: '2',
+    league: 'NBA',
+    homeTeam: 'Bulls',
+    awayTeam: 'Heat',
+    time: new Date().toISOString(),
+  },
+];
+
+describe('GameFuzzySearch', () => {
+  it('filters and selects games', () => {
+    const onSelect = jest.fn();
+    render(<GameFuzzySearch games={games} onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText('Search games...');
+    fireEvent.change(input, { target: { value: 'lkr' } });
+    const item = screen.getByText('Lakers vs Celtics');
+    fireEvent.click(item);
+    expect(onSelect).toHaveBeenCalledWith(games[0]);
+  });
+
+  it('shows no results message', () => {
+    render(<GameFuzzySearch games={games} onSelect={jest.fn()} />);
+    const input = screen.getByPlaceholderText('Search games...');
+    fireEvent.change(input, { target: { value: 'xyz' } });
+    expect(screen.getByText('No matches')).toBeInTheDocument();
+  });
+});

--- a/__tests__/fuzzy.test.ts
+++ b/__tests__/fuzzy.test.ts
@@ -1,0 +1,33 @@
+import { createFuzzySearch } from '../lib/search/fuzzy';
+import type { Game } from '../lib/types';
+
+describe('createFuzzySearch', () => {
+  const games: Game[] = [
+    {
+      gameId: '1',
+      league: 'NBA',
+      homeTeam: 'Lakers',
+      awayTeam: 'Celtics',
+      time: new Date().toISOString(),
+    },
+    {
+      gameId: '2',
+      league: 'NBA',
+      homeTeam: 'Bulls',
+      awayTeam: 'Heat',
+      time: new Date().toISOString(),
+    },
+  ];
+
+  it('matches even with typos', () => {
+    const search = createFuzzySearch(games, { keys: ['homeTeam', 'awayTeam'] });
+    const res = search('lkr');
+    expect(res[0].homeTeam).toBe('Lakers');
+  });
+
+  it('returns empty when no match', () => {
+    const search = createFuzzySearch(games, { keys: ['homeTeam', 'awayTeam'] });
+    const res = search('xyz');
+    expect(res).toHaveLength(0);
+  });
+});

--- a/components/search/GameFuzzySearch.tsx
+++ b/components/search/GameFuzzySearch.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo, useState } from 'react';
+import type { Game } from '../../lib/types';
+import { createFuzzySearch } from '../../lib/search/fuzzy';
+
+interface Props {
+  games: Game[];
+  onSelect: (game: Game) => void;
+  placeholder?: string;
+}
+
+const GameFuzzySearch: React.FC<Props> = ({
+  games,
+  onSelect,
+  placeholder = 'Search games...',
+}) => {
+  const [query, setQuery] = useState('');
+  const search = useMemo(
+    () => createFuzzySearch(games, { keys: ['homeTeam', 'awayTeam'] }),
+    [games]
+  );
+  const results = useMemo(() => search(query), [search, query]);
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder={placeholder}
+        className="w-full px-2 py-1 border rounded text-slate-900"
+        data-testid="game-search-input"
+      />
+      {query && (
+        <ul
+          className="mt-2 border rounded bg-white text-slate-900 divide-y"
+          data-testid="results-list"
+        >
+          {results.length === 0 && (
+            <li className="px-2 py-1 text-slate-500" data-testid="no-results">
+              No matches
+            </li>
+          )}
+          {results.map((game) => (
+            <li key={game.gameId}>
+              <button
+                type="button"
+                onClick={() => onSelect(game)}
+                className="block w-full text-left px-2 py-1 hover:bg-slate-100"
+                data-testid="result-item"
+              >
+                {game.homeTeam} vs {game.awayTeam}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default GameFuzzySearch;

--- a/lib/search/fuzzy.ts
+++ b/lib/search/fuzzy.ts
@@ -1,0 +1,42 @@
+export interface FuzzyOptions<T> {
+  keys: (keyof T)[];
+}
+
+interface Scored<T> {
+  item: T;
+  score: number;
+}
+
+function scoreText(text: string, query: string): number {
+  let tIndex = 0;
+  let score = 0;
+  for (const char of query) {
+    const idx = text.indexOf(char, tIndex);
+    if (idx === -1) return Infinity;
+    score += idx - tIndex;
+    tIndex = idx + 1;
+  }
+  return score;
+}
+
+export function createFuzzySearch<T>(items: T[], options: FuzzyOptions<T>) {
+  const { keys } = options;
+  return (query: string): T[] => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+
+    const scored: Scored<T>[] = items.map((item) => {
+      const text = keys
+        .map((k) => String(item[k]).toLowerCase())
+        .join(' ');
+      return { item, score: scoreText(text, q) };
+    });
+
+    return scored
+      .filter((s) => s.score !== Infinity)
+      .sort((a, b) => a.score - b.score)
+      .map((s) => s.item);
+  };
+}
+
+export default createFuzzySearch;

--- a/llms.txt
+++ b/llms.txt
@@ -2158,3 +2158,13 @@ Files:
 - package.json (+1/-1)
 - scripts/purge-cache.ts (+51/-0)
 
+Timestamp: 2025-08-08T11:10:12.452Z
+Commit: 437141caff9fb1bc44082a142eda94d8e3d13a56
+Author: Codex
+Message: feat: add fuzzy game search
+Files:
+- __tests__/GameFuzzySearch.test.tsx (+40/-0)
+- __tests__/fuzzy.test.ts (+33/-0)
+- components/search/GameFuzzySearch.tsx (+61/-0)
+- lib/search/fuzzy.ts (+42/-0)
+


### PR DESCRIPTION
## Summary
- add generic fuzzy search helper
- introduce GameFuzzySearch component with results list
- cover fuzzy search and component with tests

## Testing
- `npm test` *(fails: merge conflict marker encountered in several existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6895da02dd0c8323bff74e89a668a820