### PR TITLE
feat: add agent gallery

### DIFF
--- a/__tests__/AgentTile.test.tsx
+++ b/__tests__/AgentTile.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import AgentTile from '../components/agents/AgentTile';
+import type { AccuracyPoint } from '../components/AccuracyTrend';
+
+describe('AgentTile', () => {
+  it('renders agent info and sparkline', () => {
+    const history: AccuracyPoint[] = [
+      { date: '2024-01-01', injuryScout: 50, overall: 55 },
+      { date: '2024-01-02', injuryScout: 60, overall: 58 },
+    ];
+    render(
+      <AgentTile
+        name="injuryScout"
+        purpose="Tracks player injuries"
+        sampleReasoning="Players injured."
+        history={history}
+      />
+    );
+    expect(screen.getByText('InjuryScout')).toBeInTheDocument();
+    expect(screen.getByText('Tracks player injuries')).toBeInTheDocument();
+    expect(screen.getByText('Players injured.')).toBeInTheDocument();
+    expect(screen.getByTestId('accuracy-sparkline')).toBeInTheDocument();
+  });
+});

--- a/__tests__/AgentsPage.test.tsx
+++ b/__tests__/AgentsPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import AgentsPage from '../pages/agents';
+import { registry } from '../lib/agents/registry';
+
+describe('AgentsPage', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          history: [
+            {
+              date: '2024-01-01',
+              injuryScout: 50,
+              lineWatcher: 60,
+              statCruncher: 40,
+              trendsAgent: 70,
+              guardianAgent: 80,
+              overall: 60,
+            },
+          ],
+        }),
+    });
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  it('renders a tile for each agent', async () => {
+    render(<AgentsPage />);
+    const tiles = await screen.findAllByTestId('agent-tile');
+    expect(tiles).toHaveLength(registry.length);
+    expect(screen.getByText('InjuryScout')).toBeInTheDocument();
+  });
+});

--- a/components/agents/AgentTile.tsx
+++ b/components/agents/AgentTile.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { LineChart, Line } from 'recharts';
+import { formatAgentName } from '../../lib/utils';
+import type { AgentName } from '../../lib/agents/registry';
+import type { AccuracyPoint } from '../../components/AccuracyTrend';
+
+interface Props {
+  name: AgentName;
+  purpose: string;
+  sampleReasoning: string;
+  history: AccuracyPoint[];
+}
+
+const AgentTile: React.FC<Props> = ({
+  name,
+  purpose,
+  sampleReasoning,
+  history,
+}) => {
+  const data = history
+    .map((p) => ({ date: p.date, value: p[name] as number }))
+    .filter((d) => typeof d.value === 'number');
+
+  return (
+    <div className="border rounded p-4" data-testid="agent-tile">
+      <h3 className="font-semibold mb-1">{formatAgentName(name)}</h3>
+      <p className="text-sm text-gray-700 mb-2">{purpose}</p>
+      <p className="text-xs text-gray-500 mb-2">{sampleReasoning}</p>
+      <LineChart
+        width={120}
+        height={40}
+        data={data}
+        aria-label={`Accuracy sparkline for ${name}`}
+        data-testid="accuracy-sparkline"
+      >
+        <Line type="monotone" dataKey="value" stroke="#8884d8" dot={false} />
+      </LineChart>
+    </div>
+  );
+};
+
+export default AgentTile;

--- a/llms.txt
+++ b/llms.txt
@@ -2158,3 +2158,13 @@ Files:
 - package.json (+1/-1)
 - scripts/purge-cache.ts (+51/-0)
 
+Timestamp: 2025-08-08T11:11:29.359Z
+Commit: 15887453a2ab063e50fe11a9863deff16be227d8
+Author: Codex
+Message: feat: add agent gallery
+Files:
+- __tests__/AgentTile.test.tsx (+24/-0)
+- __tests__/AgentsPage.test.tsx (+36/-0)
+- components/agents/AgentTile.tsx (+42/-0)
+- pages/agents/index.tsx (+45/-0)
+

--- a/pages/agents/index.tsx
+++ b/pages/agents/index.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import AgentTile from '../../components/agents/AgentTile';
+import { registry, type AgentName } from '../../lib/agents/registry';
+import type { AccuracyPoint } from '../../components/AccuracyTrend';
+
+interface AccuracyHistory {
+  history: AccuracyPoint[];
+}
+
+const sampleReasoning: Record<AgentName, string> = {
+  injuryScout:
+    "Multiple starters on defense are out, weakening the team's run defense. Moderate concern flagged.",
+  lineWatcher:
+    'Line moved from -3 to -1 despite majority bets on Team A, indicating sharp money on Team B.',
+  statCruncher:
+    'Over the last 5 matchups, Team A has averaged 12% more rushing yards and allowed 15% fewer 3rd-down conversions.',
+  trendsAgent:
+    'Team A has lost 3 straight road games, trending downward.',
+  guardianAgent: 'Outputs are consistent with no contradictions.',
+};
+
+export default function AgentsPage() {
+  const [history, setHistory] = useState<AccuracyPoint[]>([]);
+
+  useEffect(() => {
+    fetch('/api/accuracy-history')
+      .then((r) => r.json())
+      .then((d: AccuracyHistory) => setHistory(d.history || []))
+      .catch(() => setHistory([]));
+  }, []);
+
+  return (
+    <main className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {registry.map((agent) => (
+        <AgentTile
+          key={agent.name}
+          name={agent.name}
+          purpose={agent.description}
+          sampleReasoning={sampleReasoning[agent.name]}
+          history={history}
+        />
+      ))}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AgentTile` component with accuracy sparkline
- create agents gallery page using tile grid
- test agent tile and page rendering

## Testing
- `npm test -- -i __tests__/AgentTile.test.tsx __tests__/AgentsPage.test.tsx`
- `npx jest __tests__/AgentTile.test.tsx __tests__/AgentsPage.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6895da0cdd408323911450906331c309