### PR TITLE
feat: add agent node popover

### DIFF
--- a/components/AgentVizCanvas.tsx
+++ b/components/AgentVizCanvas.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import AgentNodeGraph from './AgentNodeGraph';
 import { AgentEvent } from '../lib/events/agentEvents';
 import type { AgentName, AgentLifecycle } from '../lib/types';
 import type { FlowNode, FlowEdge } from '../lib/dashboard/useFlowVisualizer';
+import AgentNodePopover from './agents/AgentNodePopover';
 
 interface Props {
   events: AgentEvent[];
@@ -17,6 +18,61 @@ const AgentVizCanvas: React.FC<Props> = ({ events, skipAnimations }) => {
     });
     return map;
   }, [events]);
+
+  const metricsMap = useMemo(() => {
+    const map: Record<
+      string,
+      { score?: number; start?: number; end?: number }
+    > = {};
+    events.forEach((e) => {
+      const id = e.agentId;
+      if (!map[id]) map[id] = {};
+      if (e.type === 'start') map[id].start = e.ts;
+      if (e.type === 'end') map[id].end = e.ts;
+      if (e.type === 'result' && e.payload?.score !== undefined)
+        map[id].score = e.payload.score;
+    });
+    const res: Record<
+      string,
+      { score?: number; durationMs?: number; status: string }
+    > = {};
+    Object.entries(map).forEach(([id, m]) => {
+      res[id] = {
+        score: m.score,
+        durationMs:
+          m.start !== undefined && m.end !== undefined
+            ? m.end - m.start
+            : undefined,
+        status: stateMap[id] || 'pending',
+      };
+    });
+    return res;
+  }, [events, stateMap]);
+
+  const [popover, setPopover] = useState<{
+    id: string;
+    top: number;
+    left: number;
+  } | null>(null);
+  const nodeRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const handleNodeClick = (
+    e: React.MouseEvent<HTMLDivElement>,
+    id: string,
+  ) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    setPopover({
+      id,
+      top: rect.bottom + window.scrollY,
+      left: rect.left + rect.width / 2 + window.scrollX,
+    });
+  };
+
+  const handleRunSolo = (id: string) => {
+    // Placeholder for solo run action
+    // eslint-disable-next-line no-console
+    console.log('Run solo', id);
+  };
 
   const { nodes, edges } = useMemo(() => {
     const order: AgentName[] = [];
@@ -55,11 +111,15 @@ const AgentVizCanvas: React.FC<Props> = ({ events, skipAnimations }) => {
         {Object.entries(stateMap).map(([id, state]) => (
           <div
             key={id}
+            ref={(el) => {
+              nodeRefs.current[id] = el;
+            }}
+            onClick={(e) => handleNodeClick(e, id)}
             data-testid={`node-${id}`}
             data-agent-id={id}
             data-state={state}
             tabIndex={0}
-            className={`px-2 py-1 rounded border text-xs ${
+            className={`px-2 py-1 rounded border text-xs cursor-pointer ${
               skipAnimations ? 'no-anim' : 'anim transition-colors'
             } ${state === 'error' ? 'bg-red-200' : state === 'result' ? 'bg-green-200' : 'bg-blue-200'}`}
           >
@@ -67,6 +127,19 @@ const AgentVizCanvas: React.FC<Props> = ({ events, skipAnimations }) => {
           </div>
         ))}
       </div>
+      {popover && (
+        <AgentNodePopover
+          agentId={popover.id}
+          metrics={metricsMap[popover.id] || { status: stateMap[popover.id] }}
+          onRunSolo={handleRunSolo}
+          onClose={() => setPopover(null)}
+          style={{
+            top: popover.top,
+            left: popover.left,
+            transform: 'translate(-50%, 0)',
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/components/agents/AgentNodePopover.tsx
+++ b/components/agents/AgentNodePopover.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useRef } from 'react';
+import { Button } from '../ui/button';
+
+interface Metrics {
+  status: string;
+  score?: number;
+  durationMs?: number;
+}
+
+interface Props {
+  agentId: string;
+  metrics: Metrics;
+  onRunSolo: (id: string) => void;
+  onClose: () => void;
+  style: React.CSSProperties;
+}
+
+const AgentNodePopover: React.FC<Props> = ({
+  agentId,
+  metrics,
+  onRunSolo,
+  onClose,
+  style,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      style={style}
+      className="fixed z-50 bg-white border rounded shadow-md p-3 text-sm"
+    >
+      <div className="flex justify-between items-center mb-2">
+        <span className="font-semibold">{agentId}</span>
+        <button
+          aria-label="Close"
+          onClick={onClose}
+          className="text-gray-500 hover:text-gray-700"
+        >
+          &times;
+        </button>
+      </div>
+      <div className="space-y-1 mb-2">
+        <div>Status: {metrics.status}</div>
+        {metrics.score !== undefined && <div>Score: {metrics.score}</div>}
+        {metrics.durationMs !== undefined && (
+          <div>Duration: {metrics.durationMs}ms</div>
+        )}
+      </div>
+      <Button onClick={() => onRunSolo(agentId)} className="w-full">
+        Run Solo
+      </Button>
+    </div>
+  );
+};
+
+export default AgentNodePopover;

--- a/llms.txt
+++ b/llms.txt
@@ -2158,3 +2158,11 @@ Files:
 - package.json (+1/-1)
 - scripts/purge-cache.ts (+51/-0)
 
+Timestamp: 2025-08-08T11:11:05.639Z
+Commit: 9d28656713e70bddd795495936152f2f40aedbb5
+Author: Codex
+Message: feat: add agent node popover
+Files:
+- components/AgentVizCanvas.tsx (+75/-2)
+- components/agents/AgentNodePopover.tsx (+67/-0)
+


### PR DESCRIPTION
## Summary
- add popover component for agent nodes with metrics and Run Solo CTA
- wire AgentVizCanvas nodes to open the popover on click

## Testing
- `npm test` *(fails: Merge conflict marker encountered in marketing/PredictionMarquee.test.tsx and cache.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895da1ee8788323a0266bb4dd6c957b