### PR TITLE
feat: add onboarding goal capture

### DIFF
--- a/__tests__/Onboarding.goal.test.tsx
+++ b/__tests__/Onboarding.goal.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useSession } from 'next-auth/react';
+import Onboarding from '../components/Onboarding';
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}));
+
+describe('Onboarding goal capture', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (useSession as jest.Mock).mockReturnValue({ data: {}, status: 'authenticated' });
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ hasSeen: false }),
+    }) as any;
+  });
+
+  it('stores selected goal locally', async () => {
+    render(<Onboarding />);
+    const btn = await screen.findByRole('button', { name: 'Sports Betting' });
+    fireEvent.click(btn);
+    expect(localStorage.getItem('userGoal')).toBe('Sports Betting');
+    expect(await screen.findByText('Welcome')).toBeInTheDocument();
+  });
+});

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
+import GoalPicker from './onboarding/GoalPicker';
 
 const STORAGE_KEY = 'onboardingComplete';
+const GOAL_KEY = 'userGoal';
 const STEPS = [
   { title: 'Welcome', text: 'Thanks for joining the EdgePicks beta.' },
   { title: 'Smart Picks', text: 'Our agents help you make data-driven choices.' },
@@ -11,7 +13,7 @@ const STEPS = [
 export default function Onboarding() {
   const { status } = useSession();
   const [show, setShow] = useState(false);
-  const [step, setStep] = useState(0);
+  const [step, setStep] = useState(-1);
 
   useEffect(() => {
     if (status !== 'authenticated') return;
@@ -32,6 +34,13 @@ export default function Onboarding() {
       });
   }, [status]);
 
+  const handleGoalSelect = (goal: string) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(GOAL_KEY, goal);
+    }
+    setStep(0);
+  };
+
   const finish = () => {
     if (typeof window !== 'undefined') {
       localStorage.setItem(STORAGE_KEY, '1');
@@ -41,6 +50,21 @@ export default function Onboarding() {
   };
 
   if (!show) return null;
+
+  if (step === -1) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80 p-4 text-white">
+        <div className="bg-gray-900 p-6 rounded max-w-sm w-full space-y-4 text-center">
+          <GoalPicker onSelect={handleGoalSelect} />
+          <div className="flex justify-end pt-4">
+            <button onClick={finish} className="px-4 py-2 border rounded">
+              Skip
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const { title, text } = STEPS[step];
 

--- a/components/onboarding/GoalPicker.tsx
+++ b/components/onboarding/GoalPicker.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const OPTIONS = ['Sports Betting', 'Fantasy Sports', 'Other'];
+
+export default function GoalPicker({ onSelect }: { onSelect: (goal: string) => void }) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold">What will you use the agent for?</h2>
+      <div className="space-y-2">
+        {OPTIONS.map((opt) => (
+          <button
+            key={opt}
+            onClick={() => onSelect(opt)}
+            className="w-full px-4 py-2 border rounded hover:bg-blue-600"
+          >
+            {opt}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/llms.txt
+++ b/llms.txt
@@ -2158,3 +2158,12 @@ Files:
 - package.json (+1/-1)
 - scripts/purge-cache.ts (+51/-0)
 
+Timestamp: 2025-08-08T11:13:14.884Z
+Commit: f5994c41cafcf7b93c715285d944b6ce1d2e0452
+Author: Codex
+Message: feat: add onboarding goal capture
+Files:
+- __tests__/Onboarding.goal.test.tsx (+25/-0)
+- components/Onboarding.tsx (+25/-1)
+- components/onboarding/GoalPicker.tsx (+22/-0)
+


### PR DESCRIPTION
## Summary
- add GoalPicker component to gather user intentions during onboarding
- store selected goal in localStorage and integrate step into onboarding flow
- test onboarding goal selection persists locally

## Testing
- `npm test` *(fails: merge conflict markers in existing files, useProfiler, cache, a11y, supabaseRegistry tests)*

------
https://chatgpt.com/codex/tasks/task_e_6895da327c748323a4b90414ebe3f217