### PR TITLE
feat: add onboarding progress with resume

### DIFF
--- a/__tests__/ProgressStepper.test.tsx
+++ b/__tests__/ProgressStepper.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import ProgressStepper from '../components/onboarding/ProgressStepper';
+
+describe('ProgressStepper', () => {
+  it('renders steps and highlights current', () => {
+    render(<ProgressStepper total={3} current={1} />);
+    const steps = screen.getAllByTestId('progress-step');
+    expect(steps).toHaveLength(3);
+    expect(steps[1]).toHaveAttribute('aria-current', 'step');
+    expect(steps[0]).not.toHaveAttribute('aria-current');
+  });
+});

--- a/__tests__/onboarding.progress.test.ts
+++ b/__tests__/onboarding.progress.test.ts
@@ -1,0 +1,20 @@
+import { getProgress, setProgress, clearProgress, STORAGE_KEY } from '../lib/onboarding/progress';
+
+describe('onboarding progress storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns 0 when no progress stored', () => {
+    expect(getProgress()).toBe(0);
+  });
+
+  it('persists and clears progress', () => {
+    setProgress(2);
+    expect(getProgress()).toBe(2);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('2');
+    clearProgress();
+    expect(getProgress()).toBe(0);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
+import ProgressStepper from './onboarding/ProgressStepper';
+import {
+  getProgress,
+  setProgress,
+  clearProgress,
+} from '../lib/onboarding/progress';
 
 const STORAGE_KEY = 'onboardingComplete';
 const STEPS = [
@@ -25,17 +31,26 @@ export default function Onboarding() {
           localStorage.setItem(STORAGE_KEY, '1');
         } else {
           setShow(true);
+          setStep(getProgress());
         }
       })
       .catch(() => {
         setShow(true);
+        setStep(getProgress());
       });
   }, [status]);
+
+  const next = () => {
+    const n = step + 1;
+    setStep(n);
+    setProgress(n);
+  };
 
   const finish = () => {
     if (typeof window !== 'undefined') {
       localStorage.setItem(STORAGE_KEY, '1');
     }
+    clearProgress();
     fetch('/api/user/onboarding', { method: 'POST' }).catch(() => {});
     setShow(false);
   };
@@ -47,6 +62,7 @@ export default function Onboarding() {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80 p-4 text-white">
       <div className="bg-gray-900 p-6 rounded max-w-sm w-full space-y-4 text-center">
+        <ProgressStepper total={STEPS.length} current={step} />
         <h2 className="text-2xl font-bold">{title}</h2>
         <p>{text}</p>
         <div className="flex justify-between pt-4">
@@ -54,10 +70,7 @@ export default function Onboarding() {
             Skip
           </button>
           {step < STEPS.length - 1 ? (
-            <button
-              onClick={() => setStep(step + 1)}
-              className="px-4 py-2 bg-blue-600 rounded"
-            >
+            <button onClick={next} className="px-4 py-2 bg-blue-600 rounded">
               Next
             </button>
           ) : (

--- a/components/onboarding/ProgressStepper.tsx
+++ b/components/onboarding/ProgressStepper.tsx
@@ -1,0 +1,19 @@
+interface ProgressStepperProps {
+  total: number;
+  current: number;
+}
+
+export default function ProgressStepper({ total, current }: ProgressStepperProps) {
+  return (
+    <div className="flex gap-2" aria-label="progress">
+      {Array.from({ length: total }, (_, idx) => (
+        <div
+          key={idx}
+          data-testid="progress-step"
+          aria-current={idx === current ? 'step' : undefined}
+          className={`h-2 flex-1 rounded ${idx <= current ? 'bg-blue-600' : 'bg-gray-600'}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/lib/onboarding/progress.ts
+++ b/lib/onboarding/progress.ts
@@ -1,0 +1,22 @@
+const STORAGE_KEY = 'edgepicks.onboarding.step';
+
+export function getProgress(): number {
+  if (typeof window === 'undefined') return 0;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  const step = parseInt(raw ?? '', 10);
+  return Number.isFinite(step) ? step : 0;
+}
+
+export function setProgress(step: number): void {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, String(step));
+  }
+}
+
+export function clearProgress(): void {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+export { STORAGE_KEY };

--- a/llms.txt
+++ b/llms.txt
@@ -2158,3 +2158,14 @@ Files:
 - package.json (+1/-1)
 - scripts/purge-cache.ts (+51/-0)
 
+Timestamp: 2025-08-08T11:12:32.836Z
+Commit: 36a824f069c3c55c68d2e530a8aa614bae3d3482
+Author: Codex
+Message: feat: add onboarding progress with resume
+Files:
+- __tests__/ProgressStepper.test.tsx (+12/-0)
+- __tests__/onboarding.progress.test.ts (+20/-0)
+- components/Onboarding.tsx (+17/-4)
+- components/onboarding/ProgressStepper.tsx (+19/-0)
+- lib/onboarding/progress.ts (+22/-0)
+


### PR DESCRIPTION
## Summary
- track onboarding step in localStorage
- show onboarding progress and resume last step
- cover progress logic with unit tests

## Testing
- `npm test` *(fails: Merge conflict markers in PredictionMarquee, cache.ts; useProfiler expectations)*

------
https://chatgpt.com/codex/tasks/task_e_6895da3c11b0832394b291158a2335a7