### PR TITLE
feat: add agent builder wizard

### DIFF
--- a/__tests__/agent-builder.test.tsx
+++ b/__tests__/agent-builder.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Wizard, { generateSpec } from '../components/agent-builder/Wizard';
+import { agentSpecSchema } from '../lib/agent-builder/schema';
+
+describe('Agent Builder Wizard', () => {
+  it('generates spec from description', () => {
+    const spec = generateSpec('analyze injury and line data');
+    expect(spec.name).toBe('analyzeInjury');
+    expect(spec.inputs).toEqual(['injuryData', 'lineMovement']);
+    expect(spec.weights).toEqual({ injuryData: 0.5, lineMovement: 0.5 });
+    expect(agentSpecSchema.parse(spec)).toEqual(spec);
+  });
+
+  it('renders generated spec', () => {
+    render(<Wizard />);
+    const textarea = screen.getByPlaceholderText('Describe what this agent should do...');
+    fireEvent.change(textarea, { target: { value: 'track stats' } });
+    fireEvent.click(screen.getByText('Generate'));
+    const output = screen.getByLabelText('draft-spec');
+    const data = JSON.parse(output.textContent || '{}');
+    expect(data).toMatchObject({ name: 'trackStats', inputs: ['stats'] });
+  });
+});

--- a/components/agent-builder/Wizard.tsx
+++ b/components/agent-builder/Wizard.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { agentSpecSchema, AgentSpec } from '../../lib/agent-builder/schema';
+
+export const generateSpec = (description: string): AgentSpec => {
+  const words = description.trim().split(/\s+/);
+  const name =
+    words
+      .slice(0, 2)
+      .map((w, i) =>
+        i === 0
+          ? w.toLowerCase()
+          : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase(),
+      )
+      .join('') || 'agent';
+
+  const inputs: string[] = [];
+  if (/injur/i.test(description)) inputs.push('injuryData');
+  if (/line/i.test(description)) inputs.push('lineMovement');
+  if (/stat/i.test(description)) inputs.push('stats');
+  if (inputs.length === 0) inputs.push('general');
+
+  const weight = Number((1 / inputs.length).toFixed(2));
+  const weights = inputs.reduce<Record<string, number>>((acc, input) => {
+    acc[input] = weight;
+    return acc;
+  }, {});
+
+  return { name, inputs, weights };
+};
+
+const Wizard: React.FC = () => {
+  const [useCase, setUseCase] = useState('');
+  const [spec, setSpec] = useState<AgentSpec | null>(null);
+  const [error, setError] = useState('');
+
+  const handleGenerate = () => {
+    const draft = generateSpec(useCase);
+    const result = agentSpecSchema.safeParse(draft);
+    if (result.success) {
+      setSpec(result.data);
+      setError('');
+    } else {
+      setSpec(null);
+      setError('Invalid spec');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <textarea
+        value={useCase}
+        onChange={(e) => setUseCase(e.target.value)}
+        placeholder="Describe what this agent should do..."
+        className="w-full rounded border p-2"
+      />
+      <button
+        type="button"
+        onClick={handleGenerate}
+        className="rounded bg-blue-600 px-4 py-2 text-white"
+      >
+        Generate
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+      {spec && (
+        <pre className="rounded bg-gray-100 p-2 text-sm" aria-label="draft-spec">
+          {JSON.stringify(spec, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default Wizard;

--- a/lib/agent-builder/schema.ts
+++ b/lib/agent-builder/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const agentSpecSchema = z.object({
+  name: z.string().min(1),
+  inputs: z.array(z.string()).nonempty(),
+  weights: z.record(z.number()),
+});
+
+export type AgentSpec = z.infer<typeof agentSpecSchema>;

--- a/llms.txt
+++ b/llms.txt
@@ -2158,3 +2158,12 @@ Files:
 - package.json (+1/-1)
 - scripts/purge-cache.ts (+51/-0)
 
+Timestamp: 2025-08-08T11:15:16.055Z
+Commit: d4af1c627c1083af9b39e0b2d47d56cff42d2939
+Author: Codex
+Message: feat: add agent builder wizard
+Files:
+- __tests__/agent-builder.test.tsx (+23/-0)
+- components/agent-builder/Wizard.tsx (+73/-0)
+- lib/agent-builder/schema.ts (+9/-0)
+


### PR DESCRIPTION
## Summary
- add Agent Builder Wizard that drafts agent specs from free text
- define zod schema for agent specs
- cover spec generation and rendering with tests

## Testing
- `npx jest __tests__/agent-builder.test.tsx --runInBand`
- `npm test` *(fails: merge conflict markers in marketing/PredictionMarquee.tsx and lib/server/cache.ts, failing suite useProfiler)*

------
https://chatgpt.com/codex/tasks/task_e_6895da4ade1c83238d82f2c3c6e05bd4