### PR TITLE
feat: add guest conversion panel

### DIFF
--- a/__tests__/marketing/ConversionPanel.test.tsx
+++ b/__tests__/marketing/ConversionPanel.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConversionPanel from '../../components/marketing/ConversionPanel';
+
+describe('ConversionPanel', () => {
+  it('renders value props and CTA', () => {
+    render(<ConversionPanel />);
+    expect(
+      screen.getByText(/ready to keep your settings/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /keep my demo settings/i })
+    ).toBeInTheDocument();
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+  });
+
+  it('fires callback when CTA clicked', () => {
+    const onKeep = jest.fn();
+    render(<ConversionPanel onKeepSettings={onKeep} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /keep my demo settings/i })
+    );
+    expect(onKeep).toHaveBeenCalled();
+  });
+});

--- a/components/marketing/ConversionPanel.tsx
+++ b/components/marketing/ConversionPanel.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface Props {
+  onKeepSettings?: () => void;
+}
+
+const valueProps = [
+  'Save your demo matchups and preferences',
+  'Track picks across devices',
+  'Sign up later with one click',
+];
+
+const ConversionPanel: React.FC<Props> = ({ onKeepSettings }) => {
+  return (
+    <div
+      className="bg-white border rounded-lg p-6 space-y-4"
+      data-testid="conversion-panel"
+    >
+      <h2 className="text-xl font-semibold">Ready to keep your settings?</h2>
+      <ul className="list-disc pl-5 space-y-2 text-slate-700 text-sm">
+        {valueProps.map((prop) => (
+          <li key={prop}>{prop}</li>
+        ))}
+      </ul>
+      <button
+        onClick={onKeepSettings}
+        className="w-full px-4 py-2 rounded bg-blue-600 text-white hover:opacity-90 transition focus:outline-none focus:ring-2 focus:ring-blue-400"
+      >
+        Keep my demo settings
+      </button>
+    </div>
+  );
+};
+
+export default ConversionPanel;

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,11 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:43:16.706Z
+Commit: b12c12531658ffd771b992fd8448eabb3ecdf87c
+Author: Codex
+Message: feat: add guest conversion panel
+Files:
+- __tests__/marketing/ConversionPanel.test.tsx (+26/-0)
+- components/marketing/ConversionPanel.tsx (+35/-0)
+


### PR DESCRIPTION
## Summary
- add ConversionPanel marketing component for guests with value props and CTA
- add tests for ConversionPanel rendering and callbacks

## Testing
- `npm test` *(fails: cache.test.ts, supabaseRegistry.test.ts, telemetry.events.test.ts, Onboarding.goal.test.tsx, uiSnapshot.test.tsx)*
- `npm test -- --runTestsByPath __tests__/marketing/ConversionPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6895e15208dc8323958ead0a8a5f26cc