### PR TITLE
test: add accessibility contracts

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,10 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:42:30.248Z
+Commit: 329f2c69043929fb61199204e258c0a586212ae2
+Author: Codex
+Message: test: add accessibility contracts
+Files:
+- tests/a11y/contracts.ts (+51/-0)
+

--- a/tests/a11y/contracts.ts
+++ b/tests/a11y/contracts.ts
@@ -1,0 +1,51 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Ensures tabbing through the page follows the expected focus order.
+ * Provide an array of selectors representing the elements that
+ * should receive focus sequentially when pressing Tab.
+ *
+ * Example:
+ *   await expectFocusOrder(page, ['#nav a', 'main a', 'footer a']);
+ */
+export async function expectFocusOrder(page: Page, selectors: string[]) {
+  for (const selector of selectors) {
+    await page.keyboard.press('Tab');
+    await expect(page.locator(selector)).toBeFocused();
+  }
+}
+
+/**
+ * Verifies that an ARIA live region announces updates.
+ * The `trigger` callback should perform the action that
+ * updates the live region's text content.
+ *
+ * Example:
+ *   await expectLiveRegion(page, '[role="status"]', () => page.click('button'), 'Saved');
+ */
+export async function expectLiveRegion(
+  page: Page,
+  selector: string,
+  trigger: () => Promise<void>,
+  expectedText: string
+) {
+  const region = page.locator(selector);
+  const politeness = await region.getAttribute('aria-live');
+  const role = await region.getAttribute('role');
+  expect(politeness || role === 'status' || role === 'alert').toBeTruthy();
+
+  await trigger();
+  await expect(region).toHaveText(expectedText);
+}
+
+/**
+ * Asserts the presence of landmark roles to aid navigation.
+ *
+ * Example:
+ *   await expectLandmarkRoles(page, ['banner', 'navigation', 'main', 'contentinfo']);
+ */
+export async function expectLandmarkRoles(page: Page, roles: string[]) {
+  for (const role of roles) {
+    await expect(page.locator(`[role="${role}"]`)).toHaveCount(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable accessibility contracts for focus order, live regions, and landmark roles

## Testing
- `npm test` *(fails: useProfiler.test.tsx, cache.test.ts, supabaseRegistry.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895e1a259e48323aacc1ae1c764943f