### PR TITLE
Add Agent Card mini stories and docs

### DIFF
--- a/docs/agents/mini.md
+++ b/docs/agents/mini.md
@@ -1,0 +1,10 @@
+# Agent Mini Stories
+
+Quick reference narratives for how each agent aids decision making. These are used in Storybook demos for sales and education and do not affect runtime logic.
+
+- **injuryScout** – Scans injury reports and depth charts to surface roster edges.
+- **lineWatcher** – Tracks line movement to identify sharp market signals.
+- **statCruncher** – Compares efficiency metrics to uncover statistical mismatches.
+- **trendsAgent** – Reviews historical trends and momentum for added context.
+- **guardianAgent** – Warns on risky picks or missing information.
+

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,11 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:43:22.503Z
+Commit: 3f07fffcc182f3a2af0511848cbb3ea3220a6868
+Author: Codex
+Message: Add Agent Card mini stories and docs
+Files:
+- docs/agents/mini.md (+10/-0)
+- stories/agents/AgentMini.stories.tsx (+110/-0)
+

--- a/stories/agents/AgentMini.stories.tsx
+++ b/stories/agents/AgentMini.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import AgentCard from '../../components/AgentCard';
+
+const meta: Meta<typeof AgentCard> = {
+  title: 'Agents/Agent Mini',
+  component: AgentCard,
+};
+export default meta;
+
+type Story = StoryObj<typeof AgentCard>;
+
+export const InjuryScout: Story = {
+  args: {
+    name: 'injuryScout',
+    result: {
+      team: 'NYK',
+      score: 0.82,
+      reason: 'Scans injury reports to expose roster gaps.',
+    },
+    weight: 0.5,
+    showWeight: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Flags depth-chart issues before the market adjusts.',
+      },
+    },
+  },
+};
+
+export const LineWatcher: Story = {
+  args: {
+    name: 'lineWatcher',
+    result: {
+      team: 'BOS',
+      score: 0.76,
+      reason: 'Monitors sharp line moves across books.',
+    },
+    weight: 0.3,
+    showWeight: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Spots sudden market movement for actionable intel.',
+      },
+    },
+  },
+};
+
+export const StatCruncher: Story = {
+  args: {
+    name: 'statCruncher',
+    result: {
+      team: 'GSW',
+      score: 0.71,
+      reason: 'Compares efficiency numbers to find statistical edges.',
+    },
+    weight: 0.2,
+    showWeight: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Runs the numbers to surface underlying trends.',
+      },
+    },
+  },
+};
+
+export const TrendsAgent: Story = {
+  args: {
+    name: 'trendsAgent',
+    result: {
+      team: 'MIA',
+      score: 0.64,
+      reason: 'Evaluates recent matchups for momentum shifts.',
+    },
+    showWeight: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Adds historical context and momentum notes.',
+      },
+    },
+  },
+};
+
+export const GuardianAgent: Story = {
+  args: {
+    name: 'guardianAgent',
+    result: {
+      team: 'DEN',
+      score: 0.5,
+      reason: 'Raises warnings on inconsistent inputs.',
+      warnings: ['Missing weather data'],
+    },
+    showWeight: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Keeps picks honest by flagging risky logic.',
+      },
+    },
+  },
+};
+


### PR DESCRIPTION
## Summary
- add Agent Mini Storybook narratives for each agent
- document agent mini stories for sales/education

## Testing
- `npm test` *(fails: merge conflict marker encountered in repository)*

------
https://chatgpt.com/codex/tasks/task_e_6895e1696ac083238b008a578040d203