### PR TITLE
feat: add agent comparator component

### DIFF
--- a/__tests__/Comparator.test.tsx
+++ b/__tests__/Comparator.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import Comparator from '../components/agents/Comparator';
+
+describe('Comparator', () => {
+  it('renders two agents side by side with weights and reasoning', () => {
+    render(
+      <Comparator
+        left={{ name: 'injuryScout', weight: 0.5, reasoning: 'Player injuries affect matchup.' }}
+        right={{ name: 'lineWatcher', weight: 0.3, reasoning: 'Betting lines are moving.' }}
+      />
+    );
+
+    expect(screen.getByText('InjuryScout')).toBeInTheDocument();
+    expect(screen.getByText('LineWatcher')).toBeInTheDocument();
+    expect(screen.getByText(/Weight: 0.5/)).toBeInTheDocument();
+    expect(screen.getByText(/Weight: 0.3/)).toBeInTheDocument();
+    expect(screen.getByText('Player injuries affect matchup.')).toBeInTheDocument();
+    expect(screen.getByText('Betting lines are moving.')).toBeInTheDocument();
+  });
+});

--- a/components/agents/Comparator.tsx
+++ b/components/agents/Comparator.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { formatAgentName } from '../../lib/utils';
+import type { AgentName } from '../../lib/agents/registry';
+
+interface AgentComparison {
+  name: AgentName;
+  weight: number;
+  reasoning: string;
+}
+
+interface Props {
+  left: AgentComparison;
+  right: AgentComparison;
+}
+
+const Comparator: React.FC<Props> = ({ left, right }) => {
+  const agents = [left, right];
+  return (
+    <div className="grid grid-cols-2 gap-4" data-testid="agent-comparator">
+      {agents.map((agent, idx) => (
+        <div key={idx} className="border rounded p-4">
+          <h3 className="font-semibold mb-1">{formatAgentName(agent.name)}</h3>
+          <p className="text-sm text-gray-700 mb-1">Weight: {agent.weight}</p>
+          <p className="text-xs text-gray-500">{agent.reasoning}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Comparator;


### PR DESCRIPTION
## Summary
- add Comparator component to display two agents' weights and reasoning side by side
- test Comparator renders agent details from props

## Testing
- `npm test` *(fails: useProfiler, cache, telemetry.events, supabaseRegistry, Onboarding.goal, uiSnapshot)*

------
https://chatgpt.com/codex/tasks/task_e_6895e17acb8c832389c240429cbf70e1