### PR TITLE
docs: add agent model cards and viewer

### DIFF
--- a/components/agents/ModelCardViewer.tsx
+++ b/components/agents/ModelCardViewer.tsx
@@ -1,0 +1,19 @@
+import dynamic from 'next/dynamic';
+import { useMemo } from 'react';
+
+interface ModelCardViewerProps {
+  agent: string;
+}
+
+export default function ModelCardViewer({ agent }: ModelCardViewerProps) {
+  const MDXContent = useMemo(
+    () => dynamic(() => import(`../../docs/model-cards/${agent}.md`)),
+    [agent]
+  );
+
+  return (
+    <div className="prose">
+      <MDXContent />
+    </div>
+  );
+}

--- a/docs/model-cards/guardianAgent.md
+++ b/docs/model-cards/guardianAgent.md
@@ -1,0 +1,16 @@
+# guardianAgent Model Card
+
+## Purpose
+Reviews agent outputs for inconsistent logic or missing context.
+
+## Inputs
+- Draft agent rationales
+- Final suggested picks
+
+## Limitations
+- Relies on heuristics and may miss subtle flaws
+- Cannot guarantee completeness of external sources
+
+## Ethical Considerations
+- Encourages transparency about uncertainties
+- Designed to flag, not censor, divergent opinions

--- a/docs/model-cards/injuryScout.md
+++ b/docs/model-cards/injuryScout.md
@@ -1,0 +1,16 @@
+# injuryScout Model Card
+
+## Purpose
+Evaluates player availability to surface injury-driven advantages.
+
+## Inputs
+- Official injury reports
+- Team depth charts
+
+## Limitations
+- Injury reports may lag real-time changes
+- Does not account for coaching adjustments
+
+## Ethical Considerations
+- Avoids speculation on unreported injuries
+- Respects athlete privacy beyond public reports

--- a/docs/model-cards/lineWatcher.md
+++ b/docs/model-cards/lineWatcher.md
@@ -1,0 +1,16 @@
+# lineWatcher Model Card
+
+## Purpose
+Tracks betting line movement to highlight sharp market shifts.
+
+## Inputs
+- Sportsbook opening and live lines
+- Market odds APIs
+
+## Limitations
+- May miss off-market bookmakers
+- Line delays can produce stale alerts
+
+## Ethical Considerations
+- Avoids encouraging irresponsible betting
+- Provides transparent sourcing for line data

--- a/docs/model-cards/statCruncher.md
+++ b/docs/model-cards/statCruncher.md
@@ -1,0 +1,16 @@
+# statCruncher Model Card
+
+## Purpose
+Compares team efficiency metrics to surface statistical edges.
+
+## Inputs
+- Historical box scores
+- Advanced efficiency ratings
+
+## Limitations
+- Past performance may not predict future results
+- Data gaps for lower-tier leagues
+
+## Ethical Considerations
+- Aims for fair comparisons across teams
+- Notes when stats could reinforce biased narratives

--- a/docs/model-cards/trendsAgent.md
+++ b/docs/model-cards/trendsAgent.md
@@ -1,0 +1,16 @@
+# trendsAgent Model Card
+
+## Purpose
+Analyzes recent matchups to track popularity trends and agent hit rates.
+
+## Inputs
+- Recent game outcomes
+- Agent performance logs
+
+## Limitations
+- Purely descriptive; does not predict future outcomes
+- Sensitive to short-term variability
+
+## Ethical Considerations
+- Highlights data limitations to avoid overconfidence
+- Uses aggregated stats without personal identifiers

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,15 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:47:11.905Z
+Commit: 0bc1963a672a743efe359540df0889f92092a8bf
+Author: Codex
+Message: docs: add agent model cards and viewer
+Files:
+- components/agents/ModelCardViewer.tsx (+19/-0)
+- docs/model-cards/guardianAgent.md (+16/-0)
+- docs/model-cards/injuryScout.md (+16/-0)
+- docs/model-cards/lineWatcher.md (+16/-0)
+- docs/model-cards/statCruncher.md (+16/-0)
+- docs/model-cards/trendsAgent.md (+16/-0)
+


### PR DESCRIPTION
## Summary
- add model card markdown files for injuryScout, lineWatcher, statCruncher, trendsAgent, and guardianAgent
- introduce ModelCardViewer component for rendering agent model cards as MDX

## Testing
- `npm test` *(fails: merge conflict markers and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895e1aaefe48323a4874788a54328e2