### PR TITLE
feat: add agent builder templates

### DIFF
--- a/__tests__/agent-builder.templates.test.ts
+++ b/__tests__/agent-builder.templates.test.ts
@@ -1,0 +1,15 @@
+import { templates } from '../lib/agent-builder/templates';
+import { agentSpecSchema } from '../lib/agent-builder/schema';
+
+describe('agent builder templates', () => {
+  it('includes expected presets', () => {
+    const ids = templates.map((t) => t.id);
+    expect(ids).toEqual(expect.arrayContaining(['parlayFinder', 'injuryAware']));
+  });
+
+  it('provides valid agent specs', () => {
+    for (const tpl of templates) {
+      expect(agentSpecSchema.parse(tpl.spec)).toEqual(tpl.spec);
+    }
+  });
+});

--- a/lib/agent-builder/templates.ts
+++ b/lib/agent-builder/templates.ts
@@ -1,0 +1,33 @@
+import { AgentSpec } from './schema';
+
+export interface AgentTemplate {
+  id: string;
+  title: string;
+  description: string;
+  spec: AgentSpec;
+}
+
+export const templates: AgentTemplate[] = [
+  {
+    id: 'parlayFinder',
+    title: 'Parlay finder',
+    description:
+      'Identifies favorable multi-leg opportunities by comparing odds across games.',
+    spec: {
+      name: 'parlayFinder',
+      inputs: ['odds', 'lineMovement'],
+      weights: { odds: 0.6, lineMovement: 0.4 },
+    },
+  },
+  {
+    id: 'injuryAware',
+    title: 'Injury-aware picks',
+    description:
+      'Highlights matchups where injuries create betting edges.',
+    spec: {
+      name: 'injuryAware',
+      inputs: ['injuryReports', 'depthCharts'],
+      weights: { injuryReports: 0.7, depthCharts: 0.3 },
+    },
+  },
+];

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,11 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:45:51.107Z
+Commit: 2058c519c38770d8c79061b658fc583f1805db25
+Author: Codex
+Message: feat: add agent builder templates
+Files:
+- __tests__/agent-builder.templates.test.ts (+15/-0)
+- lib/agent-builder/templates.ts (+33/-0)
+


### PR DESCRIPTION
## Summary
- add preset agent specs for Parlay finder and Injury-aware picks
- cover templates with schema validation tests

## Testing
- `npm test` *(fails: Merge conflict marker encountered in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6895e16185bc8323a4149055a72eeda7