### PR TITLE
feat: add ScenarioExplainer component

### DIFF
--- a/__tests__/ScenarioExplainer.test.tsx
+++ b/__tests__/ScenarioExplainer.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import ScenarioExplainer from '../components/agents/ScenarioExplainer';
+
+describe('ScenarioExplainer', () => {
+  it('renders explanations for injuries, weather, and line moves', () => {
+    render(
+      <ScenarioExplainer
+        injuries={['QB ankle', 'RB out']}
+        weather="Heavy rain expected"
+        lineMove={{ from: -3.5, to: -5 }}
+      />
+    );
+    const container = screen.getByTestId('scenario-explainer');
+    expect(container).toHaveTextContent('Key injuries: QB ankle, RB out');
+    expect(container).toHaveTextContent('Weather forecast: Heavy rain expected');
+    expect(container).toHaveTextContent('Line fell from -3.5 to -5');
+  });
+
+  it('renders nothing when no factors provided', () => {
+    const { container } = render(<ScenarioExplainer />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+

--- a/components/agents/ScenarioExplainer.tsx
+++ b/components/agents/ScenarioExplainer.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+export interface ScenarioExplainerProps {
+  injuries?: string[];
+  weather?: string;
+  lineMove?: {
+    from: number;
+    to: number;
+  };
+}
+
+const ScenarioExplainer: React.FC<ScenarioExplainerProps> = ({
+  injuries,
+  weather,
+  lineMove,
+}) => {
+  const items: string[] = [];
+
+  if (injuries && injuries.length > 0) {
+    items.push(`Key injuries: ${injuries.join(', ')}`);
+  }
+
+  if (weather) {
+    items.push(`Weather forecast: ${weather}`);
+  }
+
+  if (lineMove) {
+    const direction = lineMove.to > lineMove.from ? 'rose' : 'fell';
+    items.push(`Line ${direction} from ${lineMove.from} to ${lineMove.to}`);
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="scenario-explainer">
+      {items.map((text, idx) => (
+        <p key={idx}>{text}</p>
+      ))}
+    </div>
+  );
+};
+
+export default ScenarioExplainer;
+

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,11 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:51:11.450Z
+Commit: b1c625c18ee24bc5aea6dda6c95c8a2b4bc5ae99
+Author: Codex
+Message: feat: add ScenarioExplainer component
+Files:
+- __tests__/ScenarioExplainer.test.tsx (+24/-0)
+- components/agents/ScenarioExplainer.tsx (+46/-0)
+


### PR DESCRIPTION
## Summary
- add `ScenarioExplainer` React component for converting injuries, weather, and line moves into readable text
- test coverage for rendering various factors

## Testing
- `npm test` *(fails: useProfiler, cache, supabaseRegistry, telemetry.events, Onboarding.goal, uiSnapshot, and others)*

------
https://chatgpt.com/codex/tasks/task_e_6895e133e41c8323b52c80b84a756949