### PR TITLE
feat: add disagreement badge for agent picks

### DIFF
--- a/__tests__/DisagreementBadge.test.tsx
+++ b/__tests__/DisagreementBadge.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DisagreementBadge, { computeDisagreement } from '../components/agents/DisagreementBadge';
+import type { AgentOutputs } from '../lib/types';
+
+describe('computeDisagreement', () => {
+  it('calculates fraction of agents not in majority', () => {
+    const agents: Partial<AgentOutputs> = {
+      injuryScout: { team: 'A', score: 0.7, reason: '' },
+      lineWatcher: { team: 'A', score: 0.6, reason: '' },
+      statCruncher: { team: 'B', score: 0.4, reason: '' },
+    };
+    expect(computeDisagreement(agents)).toBeCloseTo(1 / 3, 5);
+  });
+});
+
+describe('DisagreementBadge component', () => {
+  it('renders badge with disagreement percent', () => {
+    const agents: Partial<AgentOutputs> = {
+      injuryScout: { team: 'A', score: 0.7, reason: '' },
+      lineWatcher: { team: 'A', score: 0.6, reason: '' },
+      statCruncher: { team: 'B', score: 0.4, reason: '' },
+    };
+    render(<DisagreementBadge agents={agents} />);
+    expect(screen.getByText('33% disagree')).toBeInTheDocument();
+  });
+
+  it('shows agent picks in tooltip on hover', () => {
+    const agents: Partial<AgentOutputs> = {
+      injuryScout: { team: 'A', score: 0.7, reason: '' },
+      statCruncher: { team: 'B', score: 0.4, reason: '' },
+    };
+    render(<DisagreementBadge agents={agents} />);
+    const badge = screen.getByText(/disagree/);
+    fireEvent.mouseEnter(badge);
+    expect(screen.getByText('InjuryScout: A')).toBeInTheDocument();
+    expect(screen.getByText('StatCruncher: B')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no disagreement', () => {
+    const agents: Partial<AgentOutputs> = {
+      injuryScout: { team: 'A', score: 0.7, reason: '' },
+      lineWatcher: { team: 'A', score: 0.6, reason: '' },
+    };
+    const { container } = render(<DisagreementBadge agents={agents} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/agents/DisagreementBadge.tsx
+++ b/components/agents/DisagreementBadge.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Tooltip from '../Tooltip';
+import { AgentOutputs } from '../../lib/types';
+import { formatAgentName } from '../../lib/utils';
+
+export const computeDisagreement = (
+  agents: Partial<AgentOutputs>
+): number => {
+  const picks = Object.values(agents)
+    .map((r) => r?.team)
+    .filter((t): t is string => typeof t === 'string');
+  if (picks.length === 0) return 0;
+  const counts = picks.reduce<Record<string, number>>((acc, team) => {
+    acc[team] = (acc[team] || 0) + 1;
+    return acc;
+  }, {});
+  const max = Math.max(...Object.values(counts));
+  return (picks.length - max) / picks.length;
+};
+
+interface Props {
+  agents: Partial<AgentOutputs>;
+  className?: string;
+}
+
+const DisagreementBadge: React.FC<Props> = ({ agents, className }) => {
+  const disagreement = computeDisagreement(agents);
+  if (disagreement <= 0) return null;
+  const percent = Math.round(disagreement * 100);
+
+  const content = (
+    <div>
+      <div className="font-semibold mb-1">{percent}% disagree</div>
+      <ul className="text-xs space-y-0.5">
+        {Object.entries(agents).map(([name, res]) => (
+          <li key={name}>{`${formatAgentName(name)}: ${res?.team ?? '—'}`}</li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  return (
+    <Tooltip content={content} className={className}>
+      <span className="inline-block px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs">
+        {percent}% disagree
+      </span>
+    </Tooltip>
+  );
+};
+
+export default DisagreementBadge;

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,11 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:46:03.808Z
+Commit: 1aa5060a5f0c634d8399286ba5bd484a15850d5b
+Author: Codex
+Message: feat: add disagreement badge for agent picks
+Files:
+- __tests__/DisagreementBadge.test.tsx (+47/-0)
+- components/agents/DisagreementBadge.tsx (+51/-0)
+


### PR DESCRIPTION
## Summary
- add `DisagreementBadge` component to surface agent pick disagreement
- list per-agent selections in tooltip and expose `computeDisagreement`
- add tests for disagreement logic and rendering

## Testing
- `npm test` *(fails: useProfiler.test.tsx, cache.test.ts, telemetry.events.test.ts, Onboarding.goal.test.tsx, uiSnapshot.test.tsx)*
- `npx jest __tests__/DisagreementBadge.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6895e13c567483239c0642b2f64ef6cc