### PR TITLE
Add static NFL demo route

### DIFF
--- a/__tests__/demo.nfl.page.test.tsx
+++ b/__tests__/demo.nfl.page.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DemoPage, { getStaticProps } from '../pages/demo/nfl';
+import { DemoModeProvider } from '../lib/demoMode';
+
+jest.mock('../lib/logUiEvent', () => ({ logUiEvent: jest.fn() }));
+
+test('NFL demo route loads fixtures and tracker without network', async () => {
+  const { props } = (await getStaticProps({} as any)) as any;
+  const realFetch = global.fetch;
+  const fetchSpy = jest.fn(() => Promise.reject(new Error('network')));
+  global.fetch = fetchSpy as any;
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+  render(
+    <DemoModeProvider>
+      <DemoPage {...props} />
+    </DemoModeProvider>
+  );
+
+  await screen.findByText('Alpha FC');
+  expect(fetchSpy).not.toHaveBeenCalled();
+
+  fireEvent.click(await screen.findByTestId('reveal-cta'));
+  await screen.findByTestId('predictions-list');
+  expect(screen.getByTestId('node-injuryScout')).toBeInTheDocument();
+  expect(screen.getByTestId('node-lineWatcher')).toBeInTheDocument();
+
+  global.fetch = realFetch;
+});

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,12 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:47:24.957Z
+Commit: a55a9f48a805934c78a932c7ebda5d4419e7a97d
+Author: Codex
+Message: Add static NFL demo route
+Files:
+- __tests__/demo.nfl.page.test.tsx (+30/-0)
+- pages/demo/mlb.tsx (+1/-0)
+- pages/demo/nfl.tsx (+76/-0)
+

--- a/pages/demo/mlb.tsx
+++ b/pages/demo/mlb.tsx
@@ -1,0 +1,1 @@
+export { default, getStaticProps } from './nfl';

--- a/pages/demo/nfl.tsx
+++ b/pages/demo/nfl.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { GetStaticProps } from 'next';
+import { SWRConfig } from 'swr';
+import DemoHero from '../../components/demo/DemoHero';
+import MatchupInsights, { AgentEvent } from '../../components/MatchupInsights';
+import { useDemoMode } from '../../lib/demoMode';
+import upcoming from '../../fixtures/demo/upcoming.json';
+import agentEvents from '../../fixtures/demo/agent-events.json';
+import agentsMeta from '../../lib/agents/agents.json';
+
+type Props = {
+  events: AgentEvent[];
+  fallback: Record<string, unknown>;
+};
+
+const DemoNFL: React.FC<Props> = ({ events, fallback }) => {
+  const { enabled, setEnabled } = useDemoMode();
+  const trackerRef = useRef<HTMLDivElement>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setEnabled(true);
+    const t = setTimeout(() => setReady(true), 0);
+    return () => clearTimeout(t);
+  }, [setEnabled]);
+
+  const handleStart = () => {
+    trackerRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  if (!enabled || !ready) return null;
+
+  return (
+    <SWRConfig value={{ fallback }}>
+      <DemoHero onStart={handleStart} />
+      <div ref={trackerRef}>
+        <MatchupInsights events={events} demo />
+      </div>
+    </SWRConfig>
+  );
+};
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const base: AgentEvent[] = (agentEvents.events || [])
+    .filter((e: any) => e.type === 'end')
+    .map((e: any, idx: number) => ({
+      id: String(idx + 1),
+      agent: e.agentId,
+      status: 'completed',
+      ts: String(e.ts),
+    }));
+
+  const seen = new Set(base.map((e) => e.agent));
+  let ts = base.length ? Number(base[base.length - 1].ts) + 1 : 1;
+  for (const agent of agentsMeta as Array<{ name: string }>) {
+    if (!seen.has(agent.name)) {
+      base.push({
+        id: String(base.length + 1),
+        agent: agent.name,
+        status: 'completed',
+        ts: String(ts++),
+      });
+    }
+  }
+  const events = base;
+  return {
+    props: {
+      events,
+      fallback: {
+        '/api/upcoming-games': upcoming,
+      },
+    },
+  };
+};
+
+export default DemoNFL;


### PR DESCRIPTION
## Summary
- add static NFL demo page that preloads fixtures and tracker events
- expose MLB demo path as alias of NFL demo
- test NFL demo route rendering without network calls

## Testing
- `npm test` *(fails: telemetry.events.test.ts, Onboarding.goal.test.tsx, cache.test.ts, supabaseRegistry.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895e1595000832389073bedae4f7ee8