### PR TITLE
Add keyboard-navigable agent heatmap visualization

### DIFF
--- a/__tests__/Heatmap.test.tsx
+++ b/__tests__/Heatmap.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Heatmap from '../components/agents/Heatmap';
+import data from './fixtures/heatmap.json';
+
+describe('Heatmap', () => {
+  it('renders matrix of agents and signals', () => {
+    render(<Heatmap data={data} />);
+    expect(
+      screen.getByRole('grid', { name: /agent signal heatmap/i })
+    ).toBeInTheDocument();
+    // Should render cells for each value
+    expect(screen.getAllByRole('cell')).toHaveLength(
+      data.agents.length * data.signals.length
+    );
+  });
+
+  it('allows arrow key navigation', () => {
+    render(<Heatmap data={data} />);
+    const firstCell = screen.getByLabelText('InjuryScout injuries 0.8');
+    firstCell.focus();
+    fireEvent.keyDown(firstCell, { key: 'ArrowRight' });
+    expect(screen.getByLabelText('InjuryScout lines 0.2')).toHaveFocus();
+    const secondCell = screen.getByLabelText('InjuryScout lines 0.2');
+    fireEvent.keyDown(secondCell, { key: 'ArrowDown' });
+    expect(screen.getByLabelText('LineWatcher lines 0.9')).toHaveFocus();
+  });
+});

--- a/__tests__/fixtures/heatmap.json
+++ b/__tests__/fixtures/heatmap.json
@@ -1,0 +1,8 @@
+{
+  "agents": ["injuryScout", "lineWatcher"],
+  "signals": ["injuries", "lines"],
+  "values": [
+    [0.8, 0.2],
+    [0.4, 0.9]
+  ]
+}

--- a/components/agents/Heatmap.tsx
+++ b/components/agents/Heatmap.tsx
@@ -1,0 +1,98 @@
+import React, { useRef } from 'react';
+import { formatAgentName } from '../../lib/utils';
+
+interface HeatmapData {
+  agents: string[];
+  signals: string[];
+  values: number[][]; // values[agentIndex][signalIndex]
+}
+
+interface Props {
+  data: HeatmapData;
+}
+
+const Heatmap: React.FC<Props> = ({ data }) => {
+  const { agents, signals, values } = data;
+  const cellRefs = useRef<HTMLTableCellElement[][]>([]);
+
+  const focusCell = (r: number, c: number) => {
+    const cell = cellRefs.current[r]?.[c];
+    cell?.focus();
+  };
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLTableCellElement>,
+    r: number,
+    c: number
+  ) => {
+    let nextR = r;
+    let nextC = c;
+    switch (e.key) {
+      case 'ArrowRight':
+        nextC = Math.min(c + 1, signals.length - 1);
+        break;
+      case 'ArrowLeft':
+        nextC = Math.max(c - 1, 0);
+        break;
+      case 'ArrowDown':
+        nextR = Math.min(r + 1, agents.length - 1);
+        break;
+      case 'ArrowUp':
+        nextR = Math.max(r - 1, 0);
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    focusCell(nextR, nextC);
+  };
+
+  return (
+    <table
+      className="border-collapse"
+      role="grid"
+      aria-label="Agent Signal Heatmap"
+    >
+      <thead>
+        <tr>
+          <th></th>
+          {signals.map((signal) => (
+            <th key={signal} scope="col" className="px-2 py-1 text-left">
+              {signal}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {agents.map((agent, r) => (
+          <tr key={agent}>
+            <th scope="row" className="px-2 py-1 text-left">
+              {formatAgentName(agent)}
+            </th>
+            {signals.map((signal, c) => (
+              <td
+                key={signal}
+                ref={(el) => {
+                  cellRefs.current[r] = cellRefs.current[r] || [];
+                  if (el) cellRefs.current[r][c] = el;
+                }}
+                tabIndex={0}
+                aria-label={`${formatAgentName(agent)} ${signal} ${values[r][c]}`}
+                onKeyDown={(e) => handleKeyDown(e, r, c)}
+                style={{
+                  backgroundColor: `rgba(16, 185, 129, ${values[r][c]})`,
+                }}
+                className="w-8 h-8 text-center text-xs"
+              >
+                {values[r][c]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default Heatmap;
+

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,12 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:53:10.506Z
+Commit: 5681e6b42f921e8781df6f946559aae96bc689e1
+Author: Codex
+Message: Add agent heatmap component
+Files:
+- __tests__/Heatmap.test.tsx (+27/-0)
+- __tests__/fixtures/heatmap.json (+8/-0)
+- components/agents/Heatmap.tsx (+98/-0)
+


### PR DESCRIPTION
## Summary
- add Agent Heatmap component rendering a grid of signal intensities per agent
- support keyboard arrow navigation across heatmap cells
- cover rendering and navigation with unit tests

## Testing
- `npm test` *(fails: merge conflict markers in unrelated files such as components/Onboarding.tsx and lib/server/cache.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895e1440f8c83239a6e9f5cec07bb1d