### PR TITLE
Add prediction provenance tag component

### DIFF
--- a/__tests__/ProvenanceTag.test.tsx
+++ b/__tests__/ProvenanceTag.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import ProvenanceTag from '../components/predictions/ProvenanceTag';
+
+describe('ProvenanceTag', () => {
+  it('displays prediction provenance info', () => {
+    render(
+      <ProvenanceTag mode="demo" freshness="cached" dataAge="5m" />
+    );
+    expect(screen.getByText(/demo/i)).toBeInTheDocument();
+    expect(screen.getByText(/cached/i)).toBeInTheDocument();
+    expect(screen.getByText(/5m/i)).toBeInTheDocument();
+  });
+});
+

--- a/components/predictions/ProvenanceTag.tsx
+++ b/components/predictions/ProvenanceTag.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export interface ProvenanceTagProps {
+  /** environment where prediction was generated */
+  mode: 'live' | 'demo';
+  /** whether the prediction data was freshly computed or served from cache */
+  freshness: 'cached' | 'fresh';
+  /** human-readable age of the data, e.g. `5m`, `2h`, `2024-03-01` */
+  dataAge: string;
+  className?: string;
+}
+
+const ProvenanceTag: React.FC<ProvenanceTagProps> = ({
+  mode,
+  freshness,
+  dataAge,
+  className = '',
+}) => {
+  return (
+    <span
+      className={`inline-block rounded bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 ${className}`}
+    >
+      {mode} · {freshness} · {dataAge}
+    </span>
+  );
+};
+
+export default ProvenanceTag;
+

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,11 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T11:57:04.845Z
+Commit: 9e5c9915bd47a71dc1d20eff853f73418dfcc706
+Author: Codex
+Message: Add prediction provenance tag component
+Files:
+- __tests__/ProvenanceTag.test.tsx (+14/-0)
+- components/predictions/ProvenanceTag.tsx (+29/-0)
+


### PR DESCRIPTION
## Summary
- add tiny provenance label showing env, cache status, and data age
- test rendering of new provenance tag

## Testing
- `npm test` *(fails: useProfiler, cache, supabaseRegistry, telemetry.events, Onboarding.goal, uiSnapshot)*

------
https://chatgpt.com/codex/tasks/task_e_6895e14b13cc8323aec77f2eb472687f