### PR TITLE
feat: add guest funnel dashboard

### DIFF
--- a/__tests__/FunnelChart.test.tsx
+++ b/__tests__/FunnelChart.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import FunnelChart, { FunnelDatum } from '../components/analytics/FunnelChart';
+
+const data: FunnelDatum[] = [
+  { name: 'Demo', value: 10 },
+  { name: 'Replay', value: 5 },
+  { name: 'Onboarding 1', value: 3 },
+];
+
+beforeAll(() => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver;
+});
+
+describe('FunnelChart', () => {
+  it('renders labels for steps', () => {
+    render(<FunnelChart data={data} />);
+    expect(screen.getByText('Demo')).toBeInTheDocument();
+    expect(screen.getByText('Replay')).toBeInTheDocument();
+  });
+});

--- a/components/analytics/FunnelChart.tsx
+++ b/components/analytics/FunnelChart.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { FunnelChart as ReFunnelChart, Funnel, Tooltip, LabelList } from 'recharts';
+
+export interface FunnelDatum {
+  name: string;
+  value: number;
+}
+
+interface Props {
+  data: FunnelDatum[];
+}
+
+const FunnelChart: React.FC<Props> = ({ data }) => {
+  return (
+    <ReFunnelChart width={600} height={400}>
+      <Tooltip />
+      <Funnel dataKey="value" data={data} isAnimationActive={false}>
+        <LabelList position="right" dataKey="name" />
+      </Funnel>
+    </ReFunnelChart>
+  );
+};
+
+export default FunnelChart;

--- a/fixtures/funnels.json
+++ b/fixtures/funnels.json
@@ -1,0 +1,7 @@
+[
+  { "name": "Demo", "value": 120 },
+  { "name": "Replay", "value": 90 },
+  { "name": "Onboarding 1", "value": 50 },
+  { "name": "Onboarding 2", "value": 30 },
+  { "name": "Onboarding 3", "value": 15 }
+]

--- a/llms.txt
+++ b/llms.txt
@@ -2393,3 +2393,13 @@ Files:
 =======
 
 
+Timestamp: 2025-08-08T12:03:40.344Z
+Commit: cc2b7fd9475ab3c9c83ae46a524d638efda08a68
+Author: Codex
+Message: feat: add guest funnel dashboard
+Files:
+- __tests__/FunnelChart.test.tsx (+26/-0)
+- components/analytics/FunnelChart.tsx (+24/-0)
+- fixtures/funnels.json (+7/-0)
+- pages/admin/funnels.tsx (+67/-0)
+

--- a/pages/admin/funnels.tsx
+++ b/pages/admin/funnels.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type { GetServerSideProps } from 'next';
+import { getSession } from 'next-auth/react';
+import { createClient } from '@supabase/supabase-js';
+import FunnelChart, { FunnelDatum } from '../../components/analytics/FunnelChart';
+
+interface Props {
+  data: FunnelDatum[];
+}
+
+const FunnelsPage: React.FC<Props> = ({ data }) => (
+  <div className="p-4">
+    <h1 className="text-xl font-bold mb-4">Guest Funnel</h1>
+    <FunnelChart data={data} />
+  </div>
+);
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await getSession(ctx);
+  if (!session) {
+    return { redirect: { destination: '/auth/signin', permanent: false } };
+  }
+
+  const { SUPABASE_URL, SUPABASE_KEY } = process.env;
+  let funnelData: FunnelDatum[] = [];
+
+  try {
+    if (SUPABASE_URL && SUPABASE_KEY) {
+      const client = createClient(SUPABASE_URL, SUPABASE_KEY);
+      const { data } = await client
+        .from('ui_events')
+        .select('event, metadata')
+        .in('event', ['demoStart', 'replayStart', 'onboardingStep']);
+      if (data) {
+        let demo = 0;
+        let replay = 0;
+        const steps: Record<number, number> = {};
+        data.forEach((row: any) => {
+          if (row.event === 'demoStart') demo += 1;
+          else if (row.event === 'replayStart') replay += 1;
+          else if (row.event === 'onboardingStep') {
+            const step = Number(row.metadata?.step ?? 0);
+            steps[step] = (steps[step] || 0) + 1;
+          }
+        });
+        funnelData = [
+          { name: 'Demo', value: demo },
+          { name: 'Replay', value: replay },
+          ...Object.keys(steps)
+            .sort((a, b) => Number(a) - Number(b))
+            .map((s) => ({ name: `Onboarding ${s}`, value: steps[Number(s)] })),
+        ];
+      }
+    }
+  } catch {
+    // ignore errors and fallback to fixture
+  }
+
+  if (funnelData.length === 0) {
+    const { default: mock } = await import('../../fixtures/funnels.json');
+    funnelData = mock as FunnelDatum[];
+  }
+
+  return { props: { data: funnelData } };
+};
+
+export default FunnelsPage;


### PR DESCRIPTION
## Summary
- add FunnelChart component for visualizing step counts
- build admin/guest funnel page that pulls logUiEvent data with fixture fallback
- test rendering of funnel chart

## Testing
- `npm test` *(fails: uiSnapshot.test.tsx, telemetry.events.test.ts, useProfiler.test.tsx, cache.test.ts, supabaseRegistry.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895e173bb4c8323952f569d80623bb9