### PR TITLE
feat: add ancient tech gallery

### DIFF
--- a/app/ancient/page.tsx
+++ b/app/ancient/page.tsx
@@ -1,0 +1,128 @@
+import AncientTechCard from '../../components/ancient/AncientTechCard';
+
+interface TechData {
+  title: string;
+  principle: string;
+  modernAnalog: string;
+  applyLink: string;
+  simulation: {
+    label: string;
+    min: number;
+    max: number;
+    step: number;
+    unit: string;
+    outputLabel: string;
+    formula: (value: number) => number;
+  };
+}
+
+const techs: TechData[] = [
+  {
+    title: 'Qanats',
+    principle:
+      'Underground channels transport water using gravity while preventing evaporation.',
+    modernAnalog: 'Subsurface irrigation systems.',
+    applyLink: 'https://example.com/apply/qanats',
+    simulation: {
+      label: 'Channel slope (°)',
+      min: 1,
+      max: 5,
+      step: 0.5,
+      unit: 'L/min',
+      outputLabel: 'Water flow',
+      formula: (v) => v * 50,
+    },
+  },
+  {
+    title: 'Windcatchers (Badgirs)',
+    principle: 'Tall towers capture breezes and funnel them indoors for cooling.',
+    modernAnalog: 'Passive cooling towers and modern HVAC vents.',
+    applyLink: 'https://example.com/apply/windcatchers',
+    simulation: {
+      label: 'Wind speed (m/s)',
+      min: 0,
+      max: 20,
+      step: 1,
+      unit: '°C drop',
+      outputLabel: 'Cooling effect',
+      formula: (v) => v * 0.5,
+    },
+  },
+  {
+    title: 'Terracing',
+    principle:
+      'Step-like fields slow water runoff and prevent soil erosion on slopes.',
+    modernAnalog: 'Contour farming and green roofs.',
+    applyLink: 'https://example.com/apply/terracing',
+    simulation: {
+      label: 'Slope angle (°)',
+      min: 0,
+      max: 45,
+      step: 5,
+      unit: '% retention',
+      outputLabel: 'Soil retained',
+      formula: (v) => 100 - v,
+    },
+  },
+  {
+    title: 'Roman Concrete',
+    principle:
+      'Volcanic ash and seawater create durable concrete that self-heals over time.',
+    modernAnalog: 'Self-healing concrete mixes.',
+    applyLink: 'https://example.com/apply/roman-concrete',
+    simulation: {
+      label: 'Ash ratio (%)',
+      min: 0,
+      max: 50,
+      step: 5,
+      unit: 'durability index',
+      outputLabel: 'Longevity',
+      formula: (v) => v * 2,
+    },
+  },
+  {
+    title: 'Ash-Alkali Soap',
+    principle:
+      'Wood ash combined with fats yields alkaline soap for cleaning.',
+    modernAnalog: 'Biodegradable lye-based soaps.',
+    applyLink: 'https://example.com/apply/ash-soap',
+    simulation: {
+      label: 'Lye concentration (%)',
+      min: 0,
+      max: 100,
+      step: 10,
+      unit: 'cleaning power',
+      outputLabel: 'Effectiveness',
+      formula: (v) => v,
+    },
+  },
+  {
+    title: 'Zeer Pots',
+    principle:
+      'Nested clay pots with wet sand use evaporative cooling to preserve food.',
+    modernAnalog: 'Off-grid refrigeration and evaporative coolers.',
+    applyLink: 'https://example.com/apply/zeer-pots',
+    simulation: {
+      label: 'Ambient humidity (%)',
+      min: 0,
+      max: 100,
+      step: 10,
+      unit: '°C drop',
+      outputLabel: 'Cooling effect',
+      formula: (v) => (100 - v) * 0.2,
+    },
+  },
+];
+
+export default function AncientGalleryPage() {
+  return (
+    <div className="p-4 space-y-4 sm:space-y-6">
+      <h1 className="text-2xl font-bold">Lost Innovations</h1>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {techs.map((tech) => (
+          <AncientTechCard key={tech.title} {...tech} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ancient/AncientTechCard.tsx
+++ b/components/ancient/AncientTechCard.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { agentCard } from '../../styles/cardStyles';
+
+interface SimulationConfig {
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  unit: string;
+  outputLabel: string;
+  formula: (value: number) => number;
+}
+
+interface AncientTechCardProps {
+  title: string;
+  principle: string;
+  modernAnalog: string;
+  simulation: SimulationConfig;
+  applyLink: string;
+}
+
+const AncientTechCard: React.FC<AncientTechCardProps> = ({
+  title,
+  principle,
+  modernAnalog,
+  simulation,
+  applyLink,
+}) => {
+  const [value, setValue] = useState(simulation.min);
+  const result = simulation.formula(value);
+
+  return (
+    <div className={agentCard}>
+      <h2 className="text-xl font-semibold mb-2">{title}</h2>
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-1">
+        <span className="font-medium">Principle:</span> {principle}
+      </p>
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
+        <span className="font-medium">Modern analog:</span> {modernAnalog}
+      </p>
+      <div className="mb-4">
+        <label className="block text-sm font-medium mb-1">
+          {simulation.label}: {value}
+        </label>
+        <input
+          type="range"
+          min={simulation.min}
+          max={simulation.max}
+          step={simulation.step}
+          value={value}
+          onChange={(e) => setValue(Number(e.target.value))}
+          className="w-full"
+        />
+        <div className="text-sm mt-2">
+          {simulation.outputLabel}: {result.toFixed(1)} {simulation.unit}
+        </div>
+      </div>
+      <Link
+        href={applyLink}
+        className="text-blue-600 hover:underline text-sm"
+      >
+        Apply in product thinking
+      </Link>
+    </div>
+  );
+};
+
+export default AncientTechCard;

--- a/llms.txt
+++ b/llms.txt
@@ -2562,3 +2562,11 @@ Files:
 
 
 
+Timestamp: 2025-08-08T12:41:30.690Z
+Commit: 52307f9f5385f679183131d0e7f6607cf66d07b2
+Author: Codex
+Message: feat: add ancient tech gallery
+Files:
+- app/ancient/page.tsx (+128/-0)
+- components/ancient/AncientTechCard.tsx (+71/-0)
+


### PR DESCRIPTION
## Summary
- add AncientTechCard component with principle, analog, slider simulation, and apply link
- create lost innovations gallery page listing qanats, windcatchers, terracing, roman concrete, ash-alkali soap, and zeer pots

## Testing
- `npm test` *(fails: useProfiler.test.tsx, cache.test.ts, supabaseRegistry.test.ts, uiSnapshot.test.tsx, telemetry.events.test.ts, Onboarding.goal.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6895eeb1a7988323b6ea9f1ed88de8e3