### PR TITLE
feat: add impact dashboard

### DIFF
--- a/app/impact/metrics.json
+++ b/app/impact/metrics.json
@@ -1,0 +1,34 @@
+[
+  {
+    "category": "Education",
+    "date": "2025-01-01",
+    "usersHelped": 500,
+    "timeSaved": 1200,
+    "co2Saved": 30,
+    "accuracy": 0.95
+  },
+  {
+    "category": "Education",
+    "date": "2025-02-01",
+    "usersHelped": 650,
+    "timeSaved": 1400,
+    "co2Saved": 35,
+    "accuracy": 0.96
+  },
+  {
+    "category": "Environment",
+    "date": "2025-01-01",
+    "usersHelped": 400,
+    "timeSaved": 900,
+    "co2Saved": 60,
+    "accuracy": 0.89
+  },
+  {
+    "category": "Environment",
+    "date": "2025-02-01",
+    "usersHelped": 450,
+    "timeSaved": 950,
+    "co2Saved": 65,
+    "accuracy": 0.9
+  }
+]

--- a/app/impact/page.tsx
+++ b/app/impact/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { motion } from "framer-motion";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import data from "./metrics.json";
+import { Card } from "@/components/ui/card";
+
+interface MetricRecord {
+  category: string;
+  date: string;
+  usersHelped: number;
+  timeSaved: number;
+  co2Saved: number;
+  accuracy: number;
+}
+
+const metrics = data as MetricRecord[];
+const categories = Array.from(new Set(metrics.map((m) => m.category)));
+
+export default function ImpactDashboard() {
+  const [selected, setSelected] = useState<string>("All");
+  const [isPending, startTransition] = useTransition();
+
+  const filtered = useMemo(() => {
+    return selected === "All"
+      ? metrics
+      : metrics.filter((m) => m.category === selected);
+  }, [selected]);
+
+  const totals = useMemo(
+    () =>
+      filtered.reduce(
+        (acc, cur) => {
+          acc.usersHelped += cur.usersHelped;
+          acc.timeSaved += cur.timeSaved;
+          acc.co2Saved += cur.co2Saved;
+          acc.accuracy += cur.accuracy;
+          return acc;
+        },
+        { usersHelped: 0, timeSaved: 0, co2Saved: 0, accuracy: 0 }
+      ),
+    [filtered]
+  );
+
+  const avgAccuracy = filtered.length
+    ? totals.accuracy / filtered.length
+    : 0;
+
+  const accuracyData = filtered.map((m) => ({
+    date: m.date,
+    accuracy: m.accuracy,
+  }));
+
+  const handleSelect = (category: string) => {
+    startTransition(() => {
+      setSelected(category);
+    });
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex gap-2">
+        {["All", ...categories].map((c) => (
+          <motion.button
+            key={c}
+            onClick={() => handleSelect(c)}
+            whileTap={{ scale: 0.95 }}
+            animate={{
+              backgroundColor: selected === c ? "#2563eb" : "#1f2937",
+              color: selected === c ? "#fff" : "#9ca3af",
+            }}
+            className="px-3 py-1 rounded-md border border-gray-700"
+          >
+            {c}
+          </motion.button>
+        ))}
+      </div>
+      <motion.div
+        key={selected}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.3 }}
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"
+      >
+        <Card className="text-center">
+          <div className="text-sm text-gray-400">Users Helped</div>
+          <div className="text-2xl font-bold">{totals.usersHelped}</div>
+        </Card>
+        <Card className="text-center">
+          <div className="text-sm text-gray-400">Time Saved (hrs)</div>
+          <div className="text-2xl font-bold">{totals.timeSaved}</div>
+        </Card>
+        <Card className="text-center">
+          <div className="text-sm text-gray-400">CO₂ Saved (kg)</div>
+          <div className="text-2xl font-bold">{totals.co2Saved}</div>
+        </Card>
+        <Card className="text-center">
+          <div className="text-sm text-gray-400">Avg Accuracy</div>
+          <div className="text-2xl font-bold">
+            {(avgAccuracy * 100).toFixed(1)}%
+          </div>
+        </Card>
+      </motion.div>
+      <Card>
+        <div className="text-sm text-gray-400 mb-2">Accuracy Trail</div>
+        <div className="w-full h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={accuracyData}>
+              <XAxis dataKey="date" />
+              <YAxis domain={[0, 1]} tickFormatter={(v) => `${v * 100}%`} />
+              <Tooltip formatter={(v) => `${Number(v) * 100}%`} />
+              <Line
+                type="monotone"
+                dataKey="accuracy"
+                stroke="#82ca9d"
+                strokeWidth={2}
+                dot={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </Card>
+      {isPending && <div className="text-sm text-gray-400">Updating...</div>}
+    </div>
+  );
+}

--- a/llms.txt
+++ b/llms.txt
@@ -2562,3 +2562,11 @@ Files:
 
 
 
+Timestamp: 2025-08-08T12:40:05.349Z
+Commit: 437c25a99b954291ac01adcd43f16c74b4406b11
+Author: Codex
+Message: feat: add impact dashboard
+Files:
+- app/impact/metrics.json (+34/-0)
+- app/impact/page.tsx (+134/-0)
+


### PR DESCRIPTION
## Summary
- add community impact dashboard page with animated filters
- seed mock metrics for users helped, time saved, CO₂ saved, and accuracy

## Testing
- `npm test` *(fails: useProfiler.test.tsx, cache.test.ts, supabaseRegistry.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895ee8aefcc8323bf9f6a81332946ee