### PR TITLE
feat: add preflight env check page

### DIFF
--- a/app/dev/preflight/page.tsx
+++ b/app/dev/preflight/page.tsx
@@ -1,0 +1,83 @@
+const DOCS_URL = 'https://github.com/EdgePicks/EdgePicks#environment-variables';
+
+interface EnvVar {
+  key: string;
+  why: string;
+  docs: string;
+}
+
+interface Feature {
+  name: string;
+  vars: EnvVar[];
+}
+
+const FEATURES: Feature[] = [
+  {
+    name: 'Authentication',
+    vars: [
+      { key: 'NEXTAUTH_URL', why: 'NextAuth callback URL for OAuth providers.', docs: DOCS_URL },
+      { key: 'NEXTAUTH_SECRET', why: 'Encrypts NextAuth session tokens.', docs: DOCS_URL },
+      { key: 'GOOGLE_CLIENT_ID', why: 'Google OAuth client ID.', docs: DOCS_URL },
+      { key: 'GOOGLE_CLIENT_SECRET', why: 'Google OAuth client secret.', docs: DOCS_URL },
+    ],
+  },
+  {
+    name: 'Supabase',
+    vars: [
+      { key: 'SUPABASE_URL', why: 'Supabase project URL.', docs: DOCS_URL },
+      { key: 'SUPABASE_KEY', why: 'Supabase service role key.', docs: DOCS_URL },
+    ],
+  },
+  {
+    name: 'Sports Data',
+    vars: [
+      { key: 'SPORTS_API_KEY', why: 'Allows fetching sports stats and schedules.', docs: DOCS_URL },
+      { key: 'ODDS_API_KEY', why: 'Retrieves betting lines from the odds API.', docs: DOCS_URL },
+    ],
+  },
+  {
+    name: 'Runtime Limits',
+    vars: [
+      { key: 'LIVE_MODE', why: 'Toggles live vs mock mode.', docs: DOCS_URL },
+      { key: 'PREDICTION_CACHE_TTL_SEC', why: 'Caches predictions for N seconds.', docs: DOCS_URL },
+      { key: 'MAX_FLOW_CONCURRENCY', why: 'Limits concurrent agent flows.', docs: DOCS_URL },
+    ],
+  },
+];
+
+export default function PreflightPage() {
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-semibold">Secrets &amp; Env Preflight</h1>
+      <p className="text-sm text-gray-600">Read-only check of required environment variables.</p>
+      {FEATURES.map((feature) => (
+        <div key={feature.name} className="space-y-2">
+          <h2 className="text-xl font-semibold">{feature.name}</h2>
+          <ul className="space-y-1">
+            {feature.vars.map((v) => {
+              const missing = !process.env[v.key];
+              return (
+                <li key={v.key} className="flex items-center gap-2">
+                  <span className="font-mono">{v.key}</span>
+                  {missing ? (
+                    <a
+                      href={v.docs}
+                      className="bg-red-200 text-red-800 text-xs px-2 py-0.5 rounded"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Missing
+                    </a>
+                  ) : (
+                    <span className="bg-green-200 text-green-800 text-xs px-2 py-0.5 rounded">Present</span>
+                  )}
+                  <span className="text-sm text-gray-600">{v.why}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,18 @@
+import '../styles/globals.css';
+import '../styles/typography.css';
+import '../styles/intelligence.css';
+
+export const metadata = {
+  title: 'EdgePicks',
+  description: 'EdgePicks App',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/llms.txt
+++ b/llms.txt
@@ -2562,3 +2562,11 @@ Files:
 
 
 
+Timestamp: 2025-08-08T12:41:34.334Z
+Commit: 76c84b11fc802016cd1911be26fed71f2759a45e
+Author: Codex
+Message: feat: add preflight env check page
+Files:
+- app/dev/preflight/page.tsx (+83/-0)
+- app/layout.tsx (+18/-0)
+


### PR DESCRIPTION
## Summary
- add app router layout
- show env variable requirements and missing badges for devs

## Testing
- `npm test` *(fails: useProfiler.test.tsx, cache.test.ts, supabaseRegistry.test.ts)*
- `npm run typecheck` *(fails: components/Onboarding.tsx, lib/server/cache.ts, lib/telemetry/events.ts, tests/visual/percy.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895ee9267908323b87c2b23f458d4a1