### PR TITLE
feat: add open knowledge lens components

### DIFF
--- a/components/lens/LensAnnotation.tsx
+++ b/components/lens/LensAnnotation.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useLens } from './LensContext';
+
+interface Props {
+  datasetId: string;
+  children: React.ReactNode;
+}
+
+const LensAnnotation: React.FC<Props> = ({ datasetId, children }) => {
+  const { active, open, datasets } = useLens();
+  const index = datasets.findIndex((d) => d.id === datasetId);
+  if (index === -1) return <>{children}</>;
+  return (
+    <span className="relative">
+      {children}
+      {active && (
+        <sup
+          className="ml-1 cursor-pointer text-blue-600"
+          onClick={() => open(datasetId)}
+        >
+          {index + 1}
+        </sup>
+      )}
+    </span>
+  );
+};
+
+export default LensAnnotation;

--- a/components/lens/LensContext.tsx
+++ b/components/lens/LensContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import datasets from '../../data/open-datasets.json';
+
+interface Dataset {
+  id: string;
+  title: string;
+  url: string;
+  description: string;
+}
+
+interface LensContextValue {
+  active: boolean;
+  toggle: () => void;
+  open: (datasetId: string) => void;
+  close: () => void;
+  selected: Dataset | null;
+  datasets: Dataset[];
+}
+
+const LensContext = createContext<LensContextValue | undefined>(undefined);
+
+export const LensProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [active, setActive] = useState(false);
+  const [selected, setSelected] = useState<Dataset | null>(null);
+
+  const toggle = () => setActive((prev) => !prev);
+  const open = (datasetId: string) => {
+    const ds = datasets.find((d) => d.id === datasetId) || null;
+    setSelected(ds);
+  };
+  const close = () => setSelected(null);
+
+  return (
+    <LensContext.Provider value={{ active, toggle, open, close, selected, datasets }}>
+      {children}
+    </LensContext.Provider>
+  );
+};
+
+export const useLens = () => {
+  const ctx = useContext(LensContext);
+  if (!ctx) {
+    throw new Error('useLens must be used within LensProvider');
+  }
+  return ctx;
+};
+
+export default LensContext;

--- a/components/lens/LensSideSheet.tsx
+++ b/components/lens/LensSideSheet.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useLens } from './LensContext';
+import { Button } from '../ui/button';
+
+const LensSideSheet: React.FC = () => {
+  const { selected, close } = useLens();
+  if (!selected) return null;
+  return (
+    <div className="fixed inset-0 z-40 flex">
+      <div className="flex-1" onClick={close} />
+      <div className="w-80 max-w-full bg-white text-gray-900 shadow-lg p-4 overflow-y-auto">
+        <div className="flex justify-between items-start mb-4">
+          <h2 className="text-lg font-semibold">{selected.title}</h2>
+          <Button onClick={close}>Close</Button>
+        </div>
+        <p className="mb-2">{selected.description}</p>
+        <a
+          href={selected.url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 underline break-all"
+        >
+          {selected.url}
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default LensSideSheet;

--- a/components/lens/LensToggle.tsx
+++ b/components/lens/LensToggle.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Button } from '../ui/button';
+import { useLens } from './LensContext';
+
+const LensToggle: React.FC = () => {
+  const { active, toggle } = useLens();
+  return (
+    <Button onClick={toggle} className="ml-2">
+      {active ? 'Hide Lens' : 'Show Lens'}
+    </Button>
+  );
+};
+
+export default LensToggle;

--- a/components/lens/index.ts
+++ b/components/lens/index.ts
@@ -1,0 +1,4 @@
+export { LensProvider, useLens } from './LensContext';
+export { default as LensToggle } from './LensToggle';
+export { default as LensAnnotation } from './LensAnnotation';
+export { default as LensSideSheet } from './LensSideSheet';

--- a/data/open-datasets.json
+++ b/data/open-datasets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "who-covid19-cases",
+    "title": "WHO COVID-19 Global Cases",
+    "url": "https://covid19.who.int/WHO-COVID-19-global-table-data.csv",
+    "description": "Daily global counts of COVID-19 cases reported to WHO."
+  },
+  {
+    "id": "cdc-fluview",
+    "title": "CDC FluView Interactive",
+    "url": "https://gis.cdc.gov/grasp/fluview/fluportaldashboard.html",
+    "description": "Influenza surveillance data for the United States."
+  },
+  {
+    "id": "unicef-water",
+    "title": "UNICEF Water and Sanitation Data",
+    "url": "https://data.unicef.org/resources/dataset/wash-data/",
+    "description": "Global water and sanitation statistics compiled by UNICEF."
+  }
+]

--- a/llms.txt
+++ b/llms.txt
@@ -2562,3 +2562,15 @@ Files:
 
 
 
+Timestamp: 2025-08-08T12:39:51.017Z
+Commit: efa7ee966a62f5986291ec1407685acda237c25a
+Author: Codex
+Message: feat: add open knowledge lens components
+Files:
+- components/lens/LensAnnotation.tsx (+28/-0)
+- components/lens/LensContext.tsx (+48/-0)
+- components/lens/LensSideSheet.tsx (+30/-0)
+- components/lens/LensToggle.tsx (+14/-0)
+- components/lens/index.ts (+4/-0)
+- data/open-datasets.json (+20/-0)
+


### PR DESCRIPTION
## Summary
- add lens context and UI components for overlaying open dataset citations
- include toggle, annotation overlay, and side sheet panel
- add static index of public-health datasets

## Testing
- `npm test` *(fails: merge conflict marker encountered in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6895eeaa096483238e38e2bb0fece5b9