### PR TITLE
Add interactive stats explainers

### DIFF
--- a/app/learn-stats/page.tsx
+++ b/app/learn-stats/page.tsx
@@ -1,0 +1,15 @@
+import ZScoreCard from '../../components/edu/ZScoreCard';
+import ConfidenceIntervalCard from '../../components/edu/ConfidenceIntervalCard';
+import BiasCard from '../../components/edu/BiasCard';
+import ErrorBarsCard from '../../components/edu/ErrorBarsCard';
+
+export default function LearnStatsPage() {
+  return (
+    <main className="p-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+      <ZScoreCard />
+      <ConfidenceIntervalCard />
+      <BiasCard />
+      <ErrorBarsCard />
+    </main>
+  );
+}

--- a/components/edu/BiasCard.tsx
+++ b/components/edu/BiasCard.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+
+const BiasCard: React.FC = () => {
+  const [bias, setBias] = useState(0);
+  const trueValue = 50;
+  const data = [
+    { name: 'True', value: trueValue },
+    { name: 'Estimate', value: trueValue + bias },
+  ];
+
+  return (
+    <div className="p-4 border rounded">
+      <h3 className="font-bold mb-2">Bias</h3>
+      <input
+        type="range"
+        min={-20}
+        max={20}
+        step={1}
+        value={bias}
+        onChange={(e) => setBias(parseInt(e.target.value))}
+        className="w-full"
+      />
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="value">
+              <Cell fill="#82ca9d" />
+              <Cell fill="#8884d8" />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-2 text-sm">Bias: {bias}</p>
+    </div>
+  );
+};
+
+export default BiasCard;

--- a/components/edu/ConfidenceIntervalCard.tsx
+++ b/components/edu/ConfidenceIntervalCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  ReferenceArea,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+const ConfidenceIntervalCard: React.FC = () => {
+  const [n, setN] = useState(30);
+  const std = 1;
+  const z = 1.96; // 95% confidence
+
+  const data = useMemo(() => {
+    const arr: { x: number; y: number }[] = [];
+    for (let x = -4; x <= 4; x += 0.1) {
+      const y = (1 / Math.sqrt(2 * Math.PI)) * Math.exp(-(x * x) / 2);
+      arr.push({ x: parseFloat(x.toFixed(1)), y });
+    }
+    return arr;
+  }, []);
+
+  const margin = z * std / Math.sqrt(n);
+
+  return (
+    <div className="p-4 border rounded">
+      <h3 className="font-bold mb-2">Confidence Interval</h3>
+      <input
+        type="range"
+        min={10}
+        max={400}
+        step={10}
+        value={n}
+        onChange={(e) => setN(parseInt(e.target.value))}
+        className="w-full"
+      />
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+            <XAxis type="number" dataKey="x" domain={[-4, 4]} />
+            <YAxis hide domain={[0, 0.5]} />
+            <Tooltip />
+            <Line type="monotone" dataKey="y" stroke="#82ca9d" dot={false} />
+            <ReferenceArea x1={-margin} x2={margin} fill="#82ca9d" fillOpacity={0.3} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-2 text-sm">n = {n}, margin ±{margin.toFixed(2)}</p>
+    </div>
+  );
+};
+
+export default ConfidenceIntervalCard;

--- a/components/edu/ErrorBarsCard.tsx
+++ b/components/edu/ErrorBarsCard.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ErrorBar,
+  ResponsiveContainer,
+} from 'recharts';
+
+const ErrorBarsCard: React.FC = () => {
+  const [err, setErr] = useState(5);
+  const data = [
+    { x: 1, y: 5, err },
+    { x: 2, y: 10, err },
+    { x: 3, y: 7, err },
+  ];
+
+  return (
+    <div className="p-4 border rounded">
+      <h3 className="font-bold mb-2">Error Bars</h3>
+      <input
+        type="range"
+        min={1}
+        max={10}
+        step={1}
+        value={err}
+        onChange={(e) => setErr(parseInt(e.target.value))}
+        className="w-full"
+      />
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+            <CartesianGrid />
+            <XAxis type="number" dataKey="x" />
+            <YAxis type="number" dataKey="y" />
+            <Tooltip />
+            <Scatter data={data} fill="#8884d8">
+              <ErrorBar dataKey="err" width={4} strokeWidth={2} />
+            </Scatter>
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-2 text-sm">Error ±{err}</p>
+    </div>
+  );
+};
+
+export default ErrorBarsCard;

--- a/components/edu/ZScoreCard.tsx
+++ b/components/edu/ZScoreCard.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  ReferenceLine,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+const ZScoreCard: React.FC = () => {
+  const [z, setZ] = useState(0);
+
+  const data = useMemo(() => {
+    const arr: { x: number; y: number }[] = [];
+    for (let x = -4; x <= 4; x += 0.1) {
+      const y = (1 / Math.sqrt(2 * Math.PI)) * Math.exp(-(x * x) / 2);
+      arr.push({ x: parseFloat(x.toFixed(1)), y });
+    }
+    return arr;
+  }, []);
+
+  return (
+    <div className="p-4 border rounded">
+      <h3 className="font-bold mb-2">Z-Score</h3>
+      <input
+        type="range"
+        min={-3}
+        max={3}
+        step={0.1}
+        value={z}
+        onChange={(e) => setZ(parseFloat(e.target.value))}
+        className="w-full"
+      />
+      <div className="h-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+            <XAxis type="number" dataKey="x" domain={[-4, 4]} />
+            <YAxis hide domain={[0, 0.5]} />
+            <Tooltip />
+            <Line type="monotone" dataKey="y" stroke="#8884d8" dot={false} />
+            <ReferenceLine x={z} stroke="red" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-2 text-sm">Current z-score: {z.toFixed(1)}</p>
+    </div>
+  );
+};
+
+export default ZScoreCard;

--- a/llms.txt
+++ b/llms.txt
@@ -2562,3 +2562,14 @@ Files:
 
 
 
+Timestamp: 2025-08-08T12:39:46.223Z
+Commit: 26050e2c7f521db654f95edeb58ca5df507f2d6a
+Author: Codex
+Message: Add interactive stats explainers
+Files:
+- app/learn-stats/page.tsx (+15/-0)
+- components/edu/BiasCard.tsx (+52/-0)
+- components/edu/ConfidenceIntervalCard.tsx (+58/-0)
+- components/edu/ErrorBarsCard.tsx (+53/-0)
+- components/edu/ZScoreCard.tsx (+54/-0)
+


### PR DESCRIPTION
## Summary
- add learn-stats page with demos for z-scores, confidence intervals, bias, and error bars
- implement reusable education components with sliders and live Recharts
- demos run purely client-side with no network requests

## Testing
- `npm test` *(fails: useProfiler.test.tsx, cache.test.ts, supabaseRegistry.test.ts, telemetry.events.test.ts, Onboarding.goal.test.tsx, uiSnapshot.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6895ee640dfc8323b73779ebd5d7a686