### PR TITLE
Add pricing teaser modal

### DIFF
--- a/__tests__/marketing/PricingTeaser.test.tsx
+++ b/__tests__/marketing/PricingTeaser.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PricingTeaser from '../../components/marketing/PricingTeaser';
+
+describe('PricingTeaser', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <PricingTeaser isOpen={false} onUpgrade={jest.fn()} onKeepDemo={jest.fn()} />
+    );
+    expect(screen.queryByTestId('pricing-teaser')).toBeNull();
+  });
+
+  it('shows teaser and handles interactions', () => {
+    const onUpgrade = jest.fn();
+    const onKeep = jest.fn();
+    render(
+      <PricingTeaser isOpen onUpgrade={onUpgrade} onKeepDemo={onKeep} />
+    );
+    expect(
+      screen.getByRole('heading', { name: /unlock full access/i })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /upgrade now/i }));
+    expect(onUpgrade).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /keep using demo/i }));
+    expect(onKeep).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('pricing-teaser'));
+    expect(onKeep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/components/marketing/PricingTeaser.tsx
+++ b/components/marketing/PricingTeaser.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button } from '../ui/button';
+
+interface PricingTeaserProps {
+  isOpen: boolean;
+  onUpgrade: () => void;
+  onKeepDemo: () => void;
+}
+
+const PricingTeaser: React.FC<PricingTeaserProps> = ({
+  isOpen,
+  onUpgrade,
+  onKeepDemo,
+}) => {
+  if (!isOpen) return null;
+
+  const stopPropagation = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={onKeepDemo}
+      data-testid="pricing-teaser"
+    >
+      <div
+        className="bg-white p-6 rounded shadow-md w-full max-w-sm text-center space-y-4"
+        onClick={stopPropagation}
+      >
+        <h2 className="text-xl font-semibold">Unlock full access</h2>
+        <p className="text-sm text-slate-700">
+          Upgrade to get unlimited picks and deeper insights.
+        </p>
+        <Button className="w-full" variant="primaryCTA" onClick={onUpgrade}>
+          Upgrade now
+        </Button>
+        <button
+          onClick={onKeepDemo}
+          className="w-full px-4 py-2 rounded border border-slate-300 text-slate-700 hover:bg-slate-50"
+        >
+          Keep using demo
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PricingTeaser;

--- a/llms.txt
+++ b/llms.txt
@@ -2562,3 +2562,11 @@ Files:
 
 
 
+Timestamp: 2025-08-08T12:47:52.181Z
+Commit: c91433642353fe2e0ab56c734157da950ce71ca9
+Author: Codex
+Message: Add pricing teaser modal
+Files:
+- __tests__/marketing/PricingTeaser.test.tsx (+32/-0)
+- components/marketing/PricingTeaser.tsx (+49/-0)
+


### PR DESCRIPTION
## Summary
- introduce PricingTeaser modal for upgrade prompt with demo path
- cover open/close paths and interactions with unit tests

## Testing
- `npm test` *(fails: useProfiler, cache, supabaseRegistry, telemetry.events, Onboarding.goal, uiSnapshot)*

------
https://chatgpt.com/codex/tasks/task_e_6895e1b32c4c83238459197c417b55a5