### PR TITLE
feat: add design tokens

### DIFF
--- a/lib/theme/tokens.ts
+++ b/lib/theme/tokens.ts
@@ -1,0 +1,30 @@
+export const colors = {
+  bg: 'var(--color-bg)',
+  fg: 'var(--color-fg)',
+  primary: 'var(--color-primary)',
+  muted: 'var(--color-muted)',
+} as const;
+
+export const space = {
+  xs: 'var(--space-xs)',
+  sm: 'var(--space-sm)',
+  md: 'var(--space-md)',
+  lg: 'var(--space-lg)',
+  xl: 'var(--space-xl)',
+} as const;
+
+export const typography = {
+  fontBody: 'var(--font-body)',
+  fontHeading: 'var(--font-heading)',
+  sizeSm: 'var(--font-size-sm)',
+  sizeBase: 'var(--font-size-base)',
+  sizeLg: 'var(--font-size-lg)',
+} as const;
+
+export const tokens = {
+  colors,
+  space,
+  typography,
+} as const;
+
+export type Tokens = typeof tokens;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,21 @@
+:root {
+  /* Colors */
+  --color-bg: #ffffff;
+  --color-fg: #111827;
+  --color-primary: #3b82f6;
+  --color-muted: #9ca3af;
+
+  /* Spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 2rem;
+  --space-xl: 4rem;
+
+  /* Typography */
+  --font-body: 'Inter', sans-serif;
+  --font-heading: 'Inter', sans-serif;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.25rem;
+}


### PR DESCRIPTION
## Summary
- define CSS custom properties for color, spacing and typography
- expose matching TypeScript token map for components

## Testing
- `npm test` *(fails: merge conflict markers in telemetry.events and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa7317d48323af307f3fecea57ab