### PR TITLE
feat: add typography scale and baseline utilities

### DIFF
--- a/stories/TypographyBaseline.stories.tsx
+++ b/stories/TypographyBaseline.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+const meta: Meta = {
+  title: 'Typography/Baseline',
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Demo: Story = {
+  render: () => (
+    <div className="baseline-grid p-4">
+      <h1 className="type-h1 baseline-6">Heading One</h1>
+      <h2 className="type-h2 baseline-4">Heading Two</h2>
+      <p className="type-body baseline-2">
+        The quick brown fox jumps over the lazy dog.
+      </p>
+      <p className="type-body baseline-2">
+        Pack my box with five dozen liquor jugs.
+      </p>
+    </div>
+  ),
+};

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -1,5 +1,11 @@
 @tailwind components;
 
+:root {
+  --type-base: 1rem;
+  --type-scale: 1.25;
+  --baseline: 0.25rem;
+}
+
 @layer components {
   .confidenceText {
     @apply font-semibold;
@@ -11,6 +17,49 @@
   }
   .beta-h2 {
     @apply text-xl sm:text-2xl font-semibold;
+  }
+
+  /* Typographic scale */
+  .type-h1 {
+    font-size: calc(var(--type-base) * var(--type-scale) * var(--type-scale));
+    line-height: calc(var(--baseline) * 12);
+  }
+
+  .type-h2 {
+    font-size: calc(var(--type-base) * var(--type-scale));
+    line-height: calc(var(--baseline) * 8);
+  }
+
+  .type-body {
+    font-size: var(--type-base);
+    line-height: calc(var(--baseline) * 6);
+  }
+}
+
+@layer utilities {
+  .baseline-grid {
+    background-image: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.1) 1px,
+      transparent 1px
+    );
+    background-size: 100% calc(var(--baseline));
+  }
+
+  .baseline-1 {
+    margin-bottom: calc(var(--baseline) * 1);
+  }
+  .baseline-2 {
+    margin-bottom: calc(var(--baseline) * 2);
+  }
+  .baseline-3 {
+    margin-bottom: calc(var(--baseline) * 3);
+  }
+  .baseline-4 {
+    margin-bottom: calc(var(--baseline) * 4);
+  }
+  .baseline-6 {
+    margin-bottom: calc(var(--baseline) * 6);
   }
 }
 


### PR DESCRIPTION
## Summary
- add CSS variables and utilities for typographic scale and baseline grid
- include Storybook demo to visualize headings and body text aligned on baseline

## Testing
- `npm test` *(fails: cache.test.ts, supabaseRegistry.test.ts, telemetry.events.test.ts, i18n.test.tsx, cacheDriver.test.ts, llmsLog.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa7e90ac8323aa0daab4f3e26721