### PR TITLE
feat: add accessible modal

### DIFF
--- a/__tests__/modal.a11y.test.tsx
+++ b/__tests__/modal.a11y.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Modal } from '../components/ui/Modal';
+import { Open } from '../stories/Modal.stories';
+
+expect.extend(toHaveNoViolations);
+
+describe('Modal accessibility', () => {
+  it('has no violations', async () => {
+    const { container } = render(<Modal {...Open.args} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import FocusTrap from '../a11y/FocusTrap';
+import { cn } from '../../lib/utils';
+
+export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  className,
+  ...props
+}) => {
+  const overlayRef = React.useRef<HTMLDivElement>(null);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const titleId = React.useId();
+  const previouslyFocused = React.useRef<Element | null>(null);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    previouslyFocused.current = document.activeElement;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    contentRef.current?.focus();
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      if (previouslyFocused.current instanceof HTMLElement) {
+        previouslyFocused.current.focus();
+      }
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) {
+      onClose();
+    }
+  };
+
+  const stopPropagation = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onMouseDown={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <FocusTrap>
+        <div
+          ref={contentRef}
+          tabIndex={-1}
+          className={cn('bg-white text-gray-900 p-6 rounded shadow-md focus:outline-none', className)}
+          onMouseDown={stopPropagation}
+          {...props}
+        >
+          <h2 id={titleId} className="text-lg font-semibold mb-4">
+            {title}
+          </h2>
+          {children}
+        </div>
+      </FocusTrap>
+    </div>
+  );
+};

--- a/llms.txt
+++ b/llms.txt
@@ -2840,3 +2840,12 @@ Files:
 
 
 
+Timestamp: 2025-08-08T14:12:40.878Z
+Commit: f41ffc8567523da6e794460e5f1e0708f92b1929
+Author: Codex
+Message: feat: add accessible modal
+Files:
+- __tests__/modal.a11y.test.tsx (+14/-0)
+- components/ui/Modal.tsx (+79/-0)
+- stories/Modal.stories.tsx (+21/-0)
+

--- a/stories/Modal.stories.tsx
+++ b/stories/Modal.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Modal, ModalProps } from '../components/ui/Modal';
+import { Button } from '../components/ui/button';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Modal',
+  component: Modal,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    title: 'Example Modal',
+    onClose: () => {},
+    children: <Button>Close</Button>,
+  },
+};


### PR DESCRIPTION
## Summary
- add accessible Modal component with ARIA labels and focus trap
- provide Modal story for Storybook
- validate Modal accessibility via jest-axe

## Testing
- `npm test` *(fails: cache.test.ts, supabaseRegistry.test.ts, telemetry.events.test.ts, i18n.test.tsx, cacheDriver.test.ts, llmsLog.test.ts, PredictionMarquee.test.tsx, a11y.test.tsx, LandingDeepLink.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa90b2008323ae318915f21a6d22