### PR TITLE
feat: add keyboard shortcut overlay

### DIFF
--- a/components/a11y/Keymap.tsx
+++ b/components/a11y/Keymap.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface ShortcutEntry {
+  keys: string;
+  description: string;
+}
+
+export default function Keymap() {
+  const [open, setOpen] = useState(false);
+  const [shortcuts, setShortcuts] = useState<ShortcutEntry[]>([]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const isQuestionMark = e.key === '?' || (e.key === '/' && e.shiftKey);
+      if (isQuestionMark) {
+        e.preventDefault();
+        setOpen((o) => !o);
+      } else if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const nodes = Array.from(document.querySelectorAll<HTMLElement>('[aria-keyshortcuts]'));
+    const entries = nodes
+      .map((el) => {
+        const keys = el.getAttribute('aria-keyshortcuts') || '';
+        const description =
+          el.getAttribute('aria-label') ||
+          el.getAttribute('title') ||
+          el.textContent?.trim() ||
+          '';
+        return { keys, description };
+      })
+      .filter((e) => e.keys);
+    setShortcuts(entries);
+  }, [open]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 bg-black/50 p-4 text-gray-900">
+      <div className="mx-auto max-w-md rounded bg-white p-4 shadow-lg">
+        <h2 className="mb-2 text-lg font-bold">Keyboard Shortcuts</h2>
+        {shortcuts.length ? (
+          <ul className="space-y-1">
+            {shortcuts.map((s, idx) => (
+              <li key={idx} className="flex items-center justify-between">
+                <kbd className="rounded bg-gray-200 px-2 py-1 font-mono">{s.keys}</kbd>
+                <span className="ml-2">{s.description}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No shortcuts available.</p>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}
+

--- a/llms.txt
+++ b/llms.txt
@@ -2840,3 +2840,10 @@ Files:
 
 
 
+Timestamp: 2025-08-08T13:59:49.441Z
+Commit: 8c50a4a2d6fe3480ce32016589618d986ea1ff1b
+Author: Codex
+Message: feat: add keyboard shortcut overlay
+Files:
+- components/a11y/Keymap.tsx (+67/-0)
+


### PR DESCRIPTION
## Summary
- add Keymap overlay component to display page shortcuts on `?`

## Testing
- `npm test` *(fails: merge conflict markers and OOM errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa98af5c832383f60c38ac030261