### PR TITLE
feat: add confidence explainer tooltip

### DIFF
--- a/components/edu/ConfidenceExplainer.tsx
+++ b/components/edu/ConfidenceExplainer.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+import Tooltip from '../Tooltip';
+
+const ConfidenceExplainer: React.FC = () => {
+  return (
+    <div className="text-sm space-y-3">
+      <p>
+        <Tooltip
+          content={
+            <div>
+              <strong>Confidence Interval:</strong>
+              <div>95% CI [45%, 55%] means the true value likely falls in that range.</div>
+            </div>
+          }
+        >
+          <span className="underline cursor-help">CI</span>
+        </Tooltip>{' '}provides the likely range for an estimate.
+      </p>
+      <p>
+        <Tooltip
+          content={
+            <div>
+              <strong>Number Needed to Treat:</strong>
+              <div>NNT 20 means treating 20 people helps one extra person.</div>
+            </div>
+          }
+        >
+          <span className="underline cursor-help">NNT</span>
+        </Tooltip>{' '}shows the impact of an intervention.
+      </p>
+      <p>
+        <Tooltip
+          content={
+            <div>
+              <strong>Calibration:</strong>
+              <div>If 60% predictions occur 6 out of 10 times, they are well calibrated.</div>
+            </div>
+          }
+        >
+          <span className="underline cursor-help">Calibration</span>
+        </Tooltip>{' '}checks how probabilities match outcomes.
+      </p>
+    </div>
+  );
+};
+
+export default ConfidenceExplainer;

--- a/llms.txt
+++ b/llms.txt
@@ -2840,3 +2840,10 @@ Files:
 
 
 
+Timestamp: 2025-08-08T13:28:58.377Z
+Commit: db59429060b7161fda47ab4cbf1418ecc85985b8
+Author: Codex
+Message: feat: add confidence explainer tooltip
+Files:
+- components/edu/ConfidenceExplainer.tsx (+49/-0)
+


### PR DESCRIPTION
## Summary
- add `ConfidenceExplainer` component with inline tooltips for CI, NNT, and calibration
- provide simple static examples explaining each concept

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895fab8f1bc8323a23e528c17999e08