### PR TITLE
Add deterministic helpers for stable snapshot tests

### DIFF
--- a/__tests__/__snapshots__/deterministic.utils.test.ts.snap
+++ b/__tests__/__snapshots__/deterministic.utils.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deterministic helpers produces stable values 1`] = `
+{
+  "now": "2024-01-01T00:00:00.000Z",
+  "random": 0.000007825903601782307,
+}
+`;

--- a/__tests__/deterministic.utils.test.ts
+++ b/__tests__/deterministic.utils.test.ts
@@ -1,0 +1,22 @@
+import { freezeTime, resetTime } from '../test/utils/freezeTime';
+import { freezeRandom, resetRandom } from '../test/utils/freezeRandom';
+
+describe('deterministic helpers', () => {
+  beforeAll(() => {
+    freezeTime();
+    freezeRandom(1);
+  });
+
+  afterAll(() => {
+    resetTime();
+    resetRandom();
+  });
+
+  it('produces stable values', () => {
+    const value = {
+      now: new Date().toISOString(),
+      random: Math.random(),
+    };
+    expect(value).toMatchSnapshot();
+  });
+});

--- a/llms.txt
+++ b/llms.txt
@@ -2840,3 +2840,19 @@ Files:
 
 
 
+Timestamp: 2025-08-08T13:34:03.757Z
+Commit: cd49ccb778e8d0e48e090099deef92b60c5e73f6
+Author: Codex
+Message: Add deterministic helpers and snapshot test
+Files:
+- test/utils/freezeRandom.ts (+1/-0)
+- test/utils/freezeTime.ts (+2/-1)
+
+Timestamp: 2025-08-08T13:34:20.549Z
+Commit: 7106831abb522add06839afa1404b3943b2a7321
+Author: Codex
+Message: Add sample test to verify deterministic helpers
+Files:
+- __tests__/__snapshots__/deterministic.utils.test.ts.snap (+8/-0)
+- __tests__/deterministic.utils.test.ts (+22/-0)
+

--- a/test/utils/freezeRandom.ts
+++ b/test/utils/freezeRandom.ts
@@ -7,6 +7,7 @@ export function freezeRandom(startSeed: number = 1) {
     seed = (seed * 16807) % 2147483647;
     return (seed - 1) / 2147483646;
   };
+  return resetRandom;
 }
 
 export function resetRandom() {

--- a/test/utils/freezeTime.ts
+++ b/test/utils/freezeTime.ts
@@ -1,5 +1,5 @@
 const ORIGINAL_DATE = Date;
-const FIXED_ISO = '2024-01-01T00:00:00.000Z';
+export const FIXED_ISO = '2024-01-01T00:00:00.000Z';
 
 export function freezeTime(iso: string = FIXED_ISO) {
   const fixed = new Date(iso);
@@ -18,6 +18,7 @@ export function freezeTime(iso: string = FIXED_ISO) {
   }
   // @ts-ignore
   global.Date = MockDate;
+  return resetTime;
 }
 
 export function resetTime() {


### PR DESCRIPTION
## Summary
- Enhance test utilities to freeze `Date` and `Math.random` with reset callbacks
- Add Jest test showcasing snapshot stability when time and randomness are frozen

## Testing
- `npm test -- -- __tests__/deterministic.utils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6895fb18184c8323b8a2c4d75b0d1dac