### PR TITLE
feat: add client i18n hook with sample translations

### DIFF
--- a/lib/i18n/client.ts
+++ b/lib/i18n/client.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useContext, useEffect } from 'react';
+import { I18nContext } from './config';
+
+export function useI18n(ns?: string) {
+  const ctx = useContext(I18nContext);
+
+  useEffect(() => {
+    if (ns) {
+      ctx.loadNamespace(ns);
+    }
+  }, [ns, ctx]);
+
+  return ctx;
+}
+

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,4 +1,4 @@
 {
-  "hello": "Hello",
-  "welcome": "Welcome"
+  "hello": "Hello!",
+  "welcome": "Welcome!"
 }

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -1,4 +1,4 @@
 {
-  "hello": "Hola",
-  "welcome": "Bienvenido"
+  "hello": "¡Hola!",
+  "welcome": "¡Bienvenido!"
 }


### PR DESCRIPTION
## Summary
- add `useI18n` hook to load translations on the client
- provide example `hello` and `welcome` strings in English and Spanish dictionaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895fb1eeff8832394a7b4c47db373a5