### PR TITLE
Add RTL layout smoke demo

### DIFF
--- a/app/demo-rtl/page.tsx
+++ b/app/demo-rtl/page.tsx
@@ -1,0 +1,15 @@
+import '../../styles/rtl.css';
+
+export default function RtlDemoPage() {
+  return (
+    <main className="rtl-demo" dir="rtl">
+      <h1>RTL Layout Demo</h1>
+      <p>This page demonstrates a right-to-left layout with mirrored content.</p>
+      <div className="rtl-row">
+        <div className="box">First</div>
+        <div className="box">Second</div>
+        <div className="box">Third</div>
+      </div>
+    </main>
+  );
+}

--- a/llms.txt
+++ b/llms.txt
@@ -2840,3 +2840,11 @@ Files:
 
 
 
+Timestamp: 2025-08-08T13:57:19.194Z
+Commit: 8a5abad63c30c34ce415283c6d85ce922311614b
+Author: Codex
+Message: Add RTL layout demo page
+Files:
+- app/demo-rtl/page.tsx (+15/-0)
+- styles/rtl.css (+17/-0)
+

--- a/styles/rtl.css
+++ b/styles/rtl.css
@@ -1,0 +1,17 @@
+.rtl-demo {
+  direction: rtl;
+  text-align: right;
+}
+
+.rtl-row {
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.rtl-row .box {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  background: #f3f4f6;
+}


### PR DESCRIPTION
## Summary
- Add right-to-left demo page under `app/demo-rtl/`
- Provide accompanying `styles/rtl.css` for mirrored layout

## Testing
- `npm test` *(fails: Merge conflict marker encountered, some jest worker terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6895fb26798883239b730ae62ac4d7a5