### PR TITLE
feat(forms): add form primitives

### DIFF
--- a/components/forms/Error.tsx
+++ b/components/forms/Error.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+import { useFieldContext } from './Field';
+
+export interface ErrorProps extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+export const Error = React.forwardRef<HTMLParagraphElement, ErrorProps>(
+  ({ className, ...props }, ref) => {
+    const { error, errorId } = useFieldContext();
+    if (!error) return null;
+    return (
+      <p
+        ref={ref}
+        id={errorId}
+        className={cn('text-sm text-red-600', className)}
+        {...props}
+      >
+        {error}
+      </p>
+    );
+  }
+);
+Error.displayName = 'Error';

--- a/components/forms/Field.tsx
+++ b/components/forms/Field.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+interface FieldContextValue {
+  id: string;
+  errorId: string;
+  error?: string;
+}
+
+const FieldContext = React.createContext<FieldContextValue | undefined>(undefined);
+
+export const useFieldContext = (): FieldContextValue => {
+  const context = React.useContext(FieldContext);
+  if (!context) {
+    throw new Error('Field components must be used within a <Field>');
+  }
+  return context;
+};
+
+export interface FieldProps extends React.HTMLAttributes<HTMLDivElement> {
+  id?: string;
+  error?: string;
+}
+
+export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
+  ({ children, id, error, className, ...props }, ref) => {
+    const fieldId = id ?? React.useId();
+    const errorId = `${fieldId}-error`;
+
+    return (
+      <FieldContext.Provider value={{ id: fieldId, errorId, error }}>
+        <div ref={ref} className={cn('flex flex-col gap-1', className)} {...props}>
+          {children}
+        </div>
+      </FieldContext.Provider>
+    );
+  }
+);
+Field.displayName = 'Field';

--- a/components/forms/Label.tsx
+++ b/components/forms/Label.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+import { useFieldContext } from './Field';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => {
+    const { id } = useFieldContext();
+    return (
+      <label
+        ref={ref}
+        htmlFor={id}
+        className={cn('text-sm font-medium text-gray-700', className)}
+        {...props}
+      />
+    );
+  }
+);
+Label.displayName = 'Label';

--- a/llms.txt
+++ b/llms.txt
@@ -2840,3 +2840,13 @@ Files:
 
 
 
+Timestamp: 2025-08-08T13:34:29.354Z
+Commit: 081ffed4772b7723f741cad952aa62dcdbadfe4a
+Author: Codex
+Message: feat(forms): add form primitives
+Files:
+- components/forms/Error.tsx (+23/-0)
+- components/forms/Field.tsx (+39/-0)
+- components/forms/Label.tsx (+20/-0)
+- stories/forms/Field.stories.tsx (+64/-0)
+

--- a/stories/forms/Field.stories.tsx
+++ b/stories/forms/Field.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+import { Field, useFieldContext } from '../../components/forms/Field';
+import { Label } from '../../components/forms/Label';
+import { Error } from '../../components/forms/Error';
+import { cn } from '../../lib/utils';
+
+const meta: Meta<typeof Field> = {
+  title: 'Forms/Field',
+  component: Field,
+};
+
+export default meta;
+
+const TextInput = (
+  props: React.InputHTMLAttributes<HTMLInputElement>
+): JSX.Element => {
+  const { id, error, errorId } = useFieldContext();
+  return (
+    <input
+      id={id}
+      aria-invalid={!!error}
+      aria-describedby={error ? errorId : undefined}
+      className={cn(
+        'border rounded px-2 py-1',
+        error ? 'border-red-500' : 'border-green-500'
+      )}
+      {...props}
+    />
+  );
+};
+
+type Story = StoryObj<typeof Field>;
+
+export const ErrorState: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('');
+    const error = value.length < 3 ? 'Must be at least 3 characters' : undefined;
+
+    return (
+      <Field error={error}>
+        <Label>Name</Label>
+        <TextInput value={value} onChange={(e) => setValue(e.target.value)} />
+        <Error />
+      </Field>
+    );
+  },
+};
+
+export const SuccessState: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('Edge');
+    const error = value.length < 3 ? 'Must be at least 3 characters' : undefined;
+
+    return (
+      <Field error={error}>
+        <Label>Name</Label>
+        <TextInput value={value} onChange={(e) => setValue(e.target.value)} />
+        <Error />
+        {!error && <p className="text-sm text-green-600">Looks good!</p>}
+      </Field>
+    );
+  },
+};


### PR DESCRIPTION
## Summary
- add Field context for managing form IDs and error states
- create Label and Error helpers consuming Field context
- demo success and error handling in storybook

## Testing
- `npm test` *(fails: cache.test.ts, supabaseRegistry.test.ts, telemetry.events.test.ts, cacheDriver.test.ts, llmsLog.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895fb346b7083238a772092a1fee3ad