### PR TITLE
docs: add agent method cards

### DIFF
--- a/components/docs/MethodCard.tsx
+++ b/components/docs/MethodCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface MethodCardProps {
+  title: string;
+  description: string;
+  children?: React.ReactNode;
+}
+
+export default function MethodCard({ title, description, children }: MethodCardProps) {
+  return (
+    <div className="border rounded p-4 mb-4 bg-white shadow-sm">
+      <h2 className="text-lg font-semibold mb-1">{title}</h2>
+      <p className="text-sm text-gray-700 mb-2">{description}</p>
+      {children}
+    </div>
+  );
+}
+

--- a/content/agents/guardianAgent.mdx
+++ b/content/agents/guardianAgent.mdx
@@ -1,0 +1,8 @@
+export const meta = {
+  name: 'guardianAgent',
+  title: 'Guardian Agent',
+  description: 'Raises warnings on risky or inconsistent picks.',
+};
+
+Guardian Agent reviews outputs for red flags and encourages more cautious decisions.
+

--- a/content/agents/injuryScout.mdx
+++ b/content/agents/injuryScout.mdx
@@ -1,0 +1,8 @@
+export const meta = {
+  name: 'injuryScout',
+  title: 'Injury Scout',
+  description: 'Scans injury reports and roster depth for team advantages.',
+};
+
+Injury Scout analyzes player availability and depth charts to highlight injury-driven edges.
+

--- a/content/agents/lineWatcher.mdx
+++ b/content/agents/lineWatcher.mdx
@@ -1,0 +1,8 @@
+export const meta = {
+  name: 'lineWatcher',
+  title: 'Line Watcher',
+  description: 'Monitors betting line movement to flag sharp market behavior.',
+};
+
+Line Watcher keeps tabs on odds shifts to spot signals from sharp bettors and market moves.
+

--- a/content/agents/statCruncher.mdx
+++ b/content/agents/statCruncher.mdx
@@ -1,0 +1,8 @@
+export const meta = {
+  name: 'statCruncher',
+  title: 'Stat Cruncher',
+  description: 'Compares efficiency metrics and advanced stats.',
+};
+
+Stat Cruncher digs into historical performance data to surface statistical mismatches.
+

--- a/content/agents/trendsAgent.mdx
+++ b/content/agents/trendsAgent.mdx
@@ -1,0 +1,8 @@
+export const meta = {
+  name: 'trendsAgent',
+  title: 'Trends Agent',
+  description: 'Evaluates historical trends and momentum shifts.',
+};
+
+Trends Agent reviews prior matchups and momentum to provide contextual trend insights.
+

--- a/docs/agents/index.mdx
+++ b/docs/agents/index.mdx
@@ -1,0 +1,28 @@
+import MethodCard from '../../components/docs/MethodCard';
+import * as InjuryScout from '../../content/agents/injuryScout.mdx';
+import * as LineWatcher from '../../content/agents/lineWatcher.mdx';
+import * as StatCruncher from '../../content/agents/statCruncher.mdx';
+import * as TrendsAgent from '../../content/agents/trendsAgent.mdx';
+import * as GuardianAgent from '../../content/agents/guardianAgent.mdx';
+
+const methods = [
+  InjuryScout,
+  LineWatcher,
+  StatCruncher,
+  TrendsAgent,
+  GuardianAgent,
+];
+
+export default function AgentsDocs() {
+  return (
+    <>
+      <h1>Agent Methods</h1>
+      {methods.map(({ default: Content, meta }) => (
+        <MethodCard key={meta.name} title={meta.title} description={meta.description}>
+          <Content />
+        </MethodCard>
+      ))}
+    </>
+  );
+}
+

--- a/llms.txt
+++ b/llms.txt
@@ -2840,3 +2840,16 @@ Files:
 
 
 
+Timestamp: 2025-08-08T13:34:35.685Z
+Commit: 96f02f0d790a5689e0c05020c99cfe95f2a62f3e
+Author: Codex
+Message: docs: add agent method cards
+Files:
+- components/docs/MethodCard.tsx (+18/-0)
+- content/agents/guardianAgent.mdx (+8/-0)
+- content/agents/injuryScout.mdx (+8/-0)
+- content/agents/lineWatcher.mdx (+8/-0)
+- content/agents/statCruncher.mdx (+8/-0)
+- content/agents/trendsAgent.mdx (+8/-0)
+- docs/agents/index.mdx (+28/-0)
+


### PR DESCRIPTION
## Summary
- create MethodCard component for docs
- add MDX summaries for agents and generate cards on /docs/agents

## Testing
- `npm test` *(fails: cache.test.ts, supabaseRegistry.test.ts, telemetry.events.test.ts, i18n.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6895fb895a948323ac0e139b172619ac