### PR TITLE
feat: add PWA install prompt component

### DIFF
--- a/components/pwa/InstallPrompt.tsx
+++ b/components/pwa/InstallPrompt.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+export default function InstallPrompt() {
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferred(e as BeforeInstallPromptEvent);
+      setVisible(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler as EventListener);
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
+  }, []);
+
+  const triggerInstall = async () => {
+    if (!deferred) return;
+    deferred.prompt();
+    await deferred.userChoice;
+    setDeferred(null);
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={triggerInstall}
+      className="fixed bottom-4 right-4 px-4 py-2 rounded bg-emerald-600 text-white shadow-lg hover:bg-emerald-700"
+    >
+      Install App
+    </button>
+  );
+}
+

--- a/llms.txt
+++ b/llms.txt
@@ -2840,3 +2840,10 @@ Files:
 
 
 
+Timestamp: 2025-08-08T13:37:48.081Z
+Commit: 2ec8e47bbc059b444908fc155829ccbd7a4a6417
+Author: Codex
+Message: feat: add PWA install prompt component
+Files:
+- components/pwa/InstallPrompt.tsx (+41/-0)
+


### PR DESCRIPTION
## Summary
- add install prompt component to handle `beforeinstallprompt` and trigger PWA installation

## Testing
- `npm test` *(fails: merge conflict markers and snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6895fb98d00883239673c10d468ae042