### PR TITLE
fix(build): resolve merge markers in llms.txt and harden precommit guard

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,10 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# noop to ensure node exists
+node -e "try{require('fs').readFileSync('.', {encoding:'utf8'});}catch{}"
+ts-node --project tsconfig.node.json scripts/checkMergeMarkers.ts
+
 npm run lint && npm run typecheck
 # Optional: run a tiny smoke build in CI only (not on local pre-commit)
 

--- a/__tests__/checkMergeMarkers.smoke.test.ts
+++ b/__tests__/checkMergeMarkers.smoke.test.ts
@@ -1,0 +1,32 @@
+/** @jest-environment node */
+import { spawnSync } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+
+describe('checkMergeMarkers script', () => {
+  const repoRoot = join(__dirname, '..');
+  const project = join(repoRoot, 'tsconfig.node.json');
+  const script = join(repoRoot, 'scripts/checkMergeMarkers.ts');
+  const run = (cwd: string) =>
+    spawnSync('node', ['-r', 'ts-node/register', script], {
+      cwd,
+      env: { ...process.env, TS_NODE_PROJECT: project },
+      encoding: 'utf8',
+    });
+
+  it('exits 0 when no markers', () => {
+    const dir = mkdtempSync(join(os.tmpdir(), 'mm-'));
+    const result = run(dir);
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(0);
+  });
+
+  it('exits 1 when markers are present', () => {
+    const dir = mkdtempSync(join(os.tmpdir(), 'mm-'));
+    writeFileSync(join(dir, 'bad.txt'), '<<<<<<< HEAD\n=======\n>>>>>>>');
+    const result = run(dir);
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(1);
+  });
+});

--- a/llms.txt
+++ b/llms.txt
@@ -3174,15 +3174,6 @@ Files:
 - scripts/bootstrapDevEnv.ts (+13/-0)
 - scripts/validateEnv.ts (+20/-16)
 
-Timestamp: 2025-08-09T03:28:34.777Z
-Commit: af5a5bef82e0da9c9894a6238b796f408cdbadc6
-Author: Codex
-Message: feat: stream agent lifecycle events
-Files:
-- __tests__/MatchupInputForm.sse.test.tsx (+92/-0)
-- __tests__/runAgents.sse.test.ts (+54/-0)
-- pages/api/run-agents.ts (+107/-1)
-=======
 Timestamp: 2025-08-09T03:23:37.105Z
 Commit: e1a7dced158bbb5cb22ac4cf78d02fb43992a21a
 Author: Codex
@@ -3200,6 +3191,15 @@ Files:
 - tsconfig.json (+7/-14)
 - tsconfig.node.json (+9/-0)
 
+Timestamp: 2025-08-09T03:28:34.777Z
+Commit: af5a5bef82e0da9c9894a6238b796f408cdbadc6
+Author: Codex
+Message: feat: stream agent lifecycle events
+Files:
+- __tests__/MatchupInputForm.sse.test.tsx (+92/-0)
+- __tests__/runAgents.sse.test.ts (+54/-0)
+- pages/api/run-agents.ts (+107/-1)
+
 Timestamp: 2025-08-09T03:38:12.017Z
 Commit: cb71685a340aa73f0284013d27f94fb04684d67b
 Author: Codex
@@ -3211,8 +3211,6 @@ Files:
 - pages/_app.tsx (+1/-2)
 - styles/base.css (+0/-48)
 - styles/globals.css (+0/-6)
-=======
-
 
 Timestamp: 2025-08-09T04:18:44.498Z
 Commit: f47b93a0ee2115c01833fdba5285f74fb0f82940


### PR DESCRIPTION
## Summary
- remove stray merge markers in llms.txt and restore chronological order
- run merge-marker check during pre-commit to catch future conflicts
- add smoke test to ensure checkMergeMarkers exits on conflict markers

## Testing
- `npx ts-node --project tsconfig.node.json scripts/checkMergeMarkers.ts`
- `npm run lint:fix` *(fails: Definition for rule '@typescript-eslint/ban-ts-comment' was not found)*
- `npm run typecheck` *(fails: Could not find a declaration file for module 'leaflet')*
- `npm test` *(fails: Argument for '--module' option must be: ...)*
- `npm run build` *(fails: You're importing a component that needs useEffect)*

------
https://chatgpt.com/codex/tasks/task_e_689a52e901d08323b4abca1e242f4317