### PR TITLE
fix(rsc): mark UniversalAgentInterface as client and isolate any server-only logic

### DIFF
--- a/__tests__/rsc-boundary/UniversalAgentInterface.rsc.test.ts
+++ b/__tests__/rsc-boundary/UniversalAgentInterface.rsc.test.ts
@@ -1,0 +1,7 @@
+import UniversalAgentInterface from "@/components/universal/UniversalAgentInterface";
+
+describe("UniversalAgentInterface RSC boundary", () => {
+  it("exports a function", () => {
+    expect(typeof UniversalAgentInterface).toBe("function");
+  });
+});

--- a/components/AgentNodeGraph.tsx
+++ b/components/AgentNodeGraph.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import useSWR from 'swr';

--- a/components/universal/UniversalAgentInterface.tsx
+++ b/components/universal/UniversalAgentInterface.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // components/universal/UniversalAgentInterface.tsx
 // Universal Agent Interface — Sports-first, Industry-ready
 // - Upcoming games first (confidence + disagreement)

--- a/llms.txt
+++ b/llms.txt
@@ -3293,3 +3293,12 @@ Files:
 - lib/flags/experiments.ts (+3/-3)
 - lib/flags/flags.ts (+2/-2)
 
+Timestamp: 2025-08-11T20:53:12.572Z
+Commit: c8e9880c6f6ea8e5d98910e52f096aff88e440c3
+Author: Codex
+Message: fix(rsc): mark UniversalAgentInterface as client and isolate any server-only logic
+Files:
+- __tests__/rsc-boundary/UniversalAgentInterface.rsc.test.ts (+7/-0)
+- components/AgentNodeGraph.tsx (+2/-0)
+- components/universal/UniversalAgentInterface.tsx (+2/-0)
+


### PR DESCRIPTION
## Summary
- mark `UniversalAgentInterface` as a client component
- ensure `AgentNodeGraph` is also client ready
- add test to guard RSC boundary for `UniversalAgentInterface`

## Testing
- `npm test` *(fails: error TS6046: Argument for '--module' option must be: 'none', 'commonjs', ...)*
- `npm run build` *(fails: Module not found: Can't resolve '@/components/ui/badge')*

------
https://chatgpt.com/codex/tasks/task_e_689a56f2cad48323a9d741a761b6ee35