### PR TITLE
fix(rsc/ssg): stop passing functions to client, make agent-interface dynamic, and plug type holes

### DIFF
--- a/app/agent-interface/page.tsx
+++ b/app/agent-interface/page.tsx
@@ -1,10 +1,47 @@
 import UniversalAgentInterface from "@/components/universal/UniversalAgentInterface";
-import { SportsAdapter } from "@/components/universal/adapters/SportsAdapter";
+import { registry } from "@/lib/agents/registry";
 import { flags } from "@/lib/flags/experiments";
 
-export default function Page() {
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+function toClientSafeRegistry(reg: any) {
+  const stripFunctions = (obj: any): any => {
+    if (Array.isArray(obj)) return obj.map(stripFunctions);
+    if (obj && typeof obj === "object") {
+      const out: any = {};
+      for (const [k, v] of Object.entries(obj)) {
+        if (typeof v === "function") continue;
+        out[k] = stripFunctions(v);
+      }
+      return out;
+    }
+    return obj;
+  };
+  return stripFunctions(reg);
+}
+
+export default async function Page() {
   if (!flags.agentInterface) {
     return <div className="p-4 text-center">Agent interface not enabled.</div>;
   }
-  return <UniversalAgentInterface adapter={SportsAdapter} />;
+
+  const clientSafeAgents = toClientSafeRegistry(
+    Object.fromEntries(
+      registry.map((agent) => [
+        agent.name,
+        {
+          id: agent.name,
+          name: agent.name,
+          description: agent.description ?? "",
+          weight: agent.weight ?? 1,
+          tags: (agent as any).tags ?? [],
+        },
+      ])
+    )
+  );
+
+  return <UniversalAgentInterface agents={clientSafeAgents} />;
 }
+

--- a/app/ancient/page.tsx
+++ b/app/ancient/page.tsx
@@ -1,5 +1,9 @@
 import AncientTechCard from '../../components/ancient/AncientTechCard';
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 interface TechData {
   title: string;
   principle: string;

--- a/app/demo-rtl/page.tsx
+++ b/app/demo-rtl/page.tsx
@@ -1,5 +1,9 @@
 import '../../styles/rtl.css';
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 export default function RtlDemoPage() {
   return (
     <main className="rtl-demo" dir="rtl">

--- a/app/dev/preflight/page.tsx
+++ b/app/dev/preflight/page.tsx
@@ -1,3 +1,7 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 const DOCS_URL = 'https://github.com/EdgePicks/EdgePicks#environment-variables';
 
 interface EnvVar {

--- a/app/impact/page.tsx
+++ b/app/impact/page.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 import { useMemo, useState, useTransition } from "react";
 import { motion } from "framer-motion";
 import {

--- a/app/learn-stats/page.tsx
+++ b/app/learn-stats/page.tsx
@@ -3,6 +3,10 @@ import ConfidenceIntervalCard from '../../components/edu/ConfidenceIntervalCard'
 import BiasCard from '../../components/edu/BiasCard';
 import ErrorBarsCard from '../../components/edu/ErrorBarsCard';
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 export default function LearnStatsPage() {
   return (
     <main className="p-4 grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/app/maps/page.tsx
+++ b/app/maps/page.tsx
@@ -1,16 +1,20 @@
 'use client';
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 import { useState } from 'react';
-import dynamic from 'next/dynamic';
+import nextDynamic from 'next/dynamic';
 import 'leaflet/dist/leaflet.css';
 
 import clinicData from './data/clinic-density.json';
 import foodData from './data/food-deserts.json';
 import heatData from './data/heat-islands.json';
 
-const MapContainer = dynamic(() => import('react-leaflet').then(m => m.MapContainer), { ssr: false });
-const TileLayer = dynamic(() => import('react-leaflet').then(m => m.TileLayer), { ssr: false });
-const GeoJSON = dynamic(() => import('react-leaflet').then(m => m.GeoJSON), { ssr: false });
+const MapContainer = nextDynamic(() => import('react-leaflet').then(m => m.MapContainer), { ssr: false });
+const TileLayer = nextDynamic(() => import('react-leaflet').then(m => m.TileLayer), { ssr: false });
+const GeoJSON = nextDynamic(() => import('react-leaflet').then(m => m.GeoJSON), { ssr: false });
 
 function getColor(value: number, layer: 'clinic' | 'food' | 'heat') {
   switch (layer) {

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {

--- a/components/MatchupInsights.tsx
+++ b/components/MatchupInsights.tsx
@@ -6,7 +6,7 @@ import AgentExecutionTracker, {
   AgentStatus,
 } from './AgentExecutionTracker';
 import useFlowVisualizer from '../lib/dashboard/useFlowVisualizer';
-import type { AgentOutputs, PickSummary } from '../lib/types';
+import type { AgentOutputs, PickSummary, AgentResult } from '../lib/types';
 import type { AgentExecution } from '../lib/flow/runFlow';
 import agentsMeta from '../lib/agents/agents.json';
 
@@ -85,7 +85,7 @@ const MatchupInsights: React.FC<TrackerProps> = ({ events: propEvents, demo }) =
           }}
           onAgent={(exec: AgentExecution) => {
             if (exec.result) {
-              setAgents((prev) => ({ ...prev, [exec.name]: exec.result }));
+              setAgents((prev) => ({ ...prev, [exec.name]: exec.result as AgentResult }));
             }
           }}
           onComplete={(data: { pick: PickSummary }) => setPick(data.pick)}

--- a/components/universal/UniversalAgentInterface.tsx
+++ b/components/universal/UniversalAgentInterface.tsx
@@ -20,6 +20,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
+import { SportsAdapter } from "./adapters/SportsAdapter";
 import {
   ChevronRight,
   Play,
@@ -66,6 +67,14 @@ export interface DataAdapter {
   run(id: string, opts?: Record<string, any>): Promise<{ runId: string }>;
   archive?(runId: string): Promise<RunArchive>;
 }
+
+type ClientAgent = {
+  id: string;
+  name: string;
+  description?: string;
+  weight?: number;
+  tags?: string[];
+};
 
 // ---------- Demo Adapter (Sports) ----------
 const DemoSportsAdapter: DataAdapter = {
@@ -239,10 +248,10 @@ function Timeline({ events }: { events: AgentEvent[] }) {
 
 // ---------- Main ----------
 export default function UniversalAgentInterface({
-  adapter = DemoSportsAdapter,
+  agents: _agents,
   streamUrl,
 }: {
-  adapter?: DataAdapter;
+  agents: Record<string, ClientAgent>;
   streamUrl?: string;
 }) {
   const [items, setItems] = useState<Prediction[]>([]);
@@ -253,6 +262,7 @@ export default function UniversalAgentInterface({
   const [lowImpact, setLowImpact] = useState(false);
   const [locale, setLocale] = useState("en");
   const [speed, setSpeed] = useState(1);
+  const adapter = demoMode ? DemoSportsAdapter : SportsAdapter;
   const { events, isRunning } = useAgentStream({ enabled: !!selected, streamUrl, demo: demoMode });
   const ariaLiveRef = useRef<HTMLDivElement>(null);
 

--- a/llms.txt
+++ b/llms.txt
@@ -3350,3 +3350,23 @@ Files:
 - tsconfig.json (+2/-0)
 - types/react-leaflet-shims.d.ts (+2/-0)
 
+Timestamp: 2025-08-11T21:53:47.026Z
+Commit: 17b46792c85afa326f3c5d70f1604cc90c579f12
+Author: Codex
+Message: fix(rsc/ssg): stop passing functions to client, make agent-interface dynamic, and plug type holes
+Files:
+- app/agent-interface/page.tsx (+40/-3)
+- app/ancient/page.tsx (+4/-0)
+- app/demo-rtl/page.tsx (+4/-0)
+- app/dev/preflight/page.tsx (+4/-0)
+- app/impact/page.tsx (+4/-0)
+- app/learn-stats/page.tsx (+4/-0)
+- app/maps/page.tsx (+8/-4)
+- app/onboarding/page.tsx (+4/-0)
+- components/MatchupInsights.tsx (+2/-2)
+- components/universal/UniversalAgentInterface.tsx (+12/-2)
+- package-lock.json (+11/-0)
+- package.json (+2/-1)
+- scripts/assertClientSafeAgents.ts (+17/-0)
+- tsconfig.json (+11/-5)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@types/node": "^24.2.0",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.0",
+        "@types/react-window": "^1.8.8",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "ajv": "^8.17.1",
@@ -7813,6 +7814,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "bootstrap:env": "node scripts/bootstrap-env.mjs",
     "dev": "npm run bootstrap:env && next dev",
-    "prebuild": "ts-node --project tsconfig.node.json scripts/checkRouteConflicts.ts && ts-node --project tsconfig.node.json scripts/checkMergeMarkers.ts && npm run setup:dev",
+    "prebuild": "ts-node --project tsconfig.node.json scripts/checkRouteConflicts.ts && ts-node --project tsconfig.node.json scripts/checkMergeMarkers.ts && ts-node --project tsconfig.node.json scripts/assertClientSafeAgents.ts && npm run setup:dev",
     "build": "npm run validate-env && next build",
     "start": "npm run validate-env && next start",
     "test": "jest",
@@ -80,6 +80,7 @@
     "@types/node": "^24.2.0",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.0",
+    "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "ajv": "^8.17.1",

--- a/scripts/assertClientSafeAgents.ts
+++ b/scripts/assertClientSafeAgents.ts
@@ -1,0 +1,17 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+async function main() {
+  const pagePath = path.join(process.cwd(), "app", "agent-interface", "page.tsx");
+  const src = await fs.readFile(pagePath, "utf8");
+  if (src.includes("agents:") && src.match(/run\s*:\s*\(/)) {
+    console.error("[guard] Detected a likely function in agents props. Keep props data-only.");
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
-    "types": ["node", "./types/react-leaflet-shims"],
+      "types": ["node", "jest", "./types/react-leaflet-shims"],
     "plugins": [
       {
         "name": "next"
@@ -32,15 +32,21 @@
     ]
   },
   "include": [
+    "types/**/*.d.ts",
+    "app",
+    "components",
+    "lib",
+    "pages",
+    "scripts",
+    "tests",
+    "__tests__",
     "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
     ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",
     "scripts/uiSnapshot.ts",
-    "__tests__",
-    "tests"
+    "tests",
+    "__tests__"
   ]
 }


### PR DESCRIPTION
## Summary
- strip functions from agent registry and feed client-safe data to UniversalAgentInterface
- let UniversalAgentInterface import its own adapter and accept serializable props only
- force-dynamic rendering on agent-interface and other heavy pages, add guard script and type deps

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run build` *(fails: Type error in components/MatchupInsights.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689a6406e3248323be21074d8056ac96