### PR TITLE
chore: stabilize Jest with TS and restore UI shell

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/__mocks__/svgMock.ts
+++ b/__mocks__/svgMock.ts
@@ -1,0 +1,2 @@
+export default "SvgMock";
+export const ReactComponent = "svg";

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,7 @@
 
 /* Inline former typography.css rules */
 :root {
+  color-scheme: dark;
   --type-base: 1rem;
   --type-scale: 1.25;
   --baseline: 0.25rem;
@@ -113,3 +114,6 @@
     margin-bottom: calc(var(--baseline) * 6);
   }
 }
+
+/* Leaflet */
+@import "leaflet/dist/leaflet.css";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,21 @@
-import './globals.css';
-import type { ReactNode } from 'react';
+import "./globals.css";
+import { Providers } from "./providers";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 
-export const revalidate = 0;
-export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
-
-export const metadata = {
-  title: 'EdgePicks',
-  description: 'EdgePicks App',
+export const metadata: Metadata = {
+  title: "EdgePicks",
+  description: "Sports predictions and agent interface"
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter", display: "swap" });
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen">{children}</body>
+    <html lang="en" className={inter.variable}>
+      <body className="min-h-screen bg-background text-foreground antialiased">
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+export default function Page() {
+  redirect("/agent-interface");
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider } from "next-themes";
+import { Toaster } from "@/components/ui/sonner-toaster";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+      {children}
+      <Toaster />
+    </ThemeProvider>
+  );
+}

--- a/components/a11y/Landmarks.tsx
+++ b/components/a11y/Landmarks.tsx
@@ -1,12 +1,6 @@
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
-
-type Props = React.HTMLAttributes<HTMLDivElement> & {
-  as?: keyof JSX.IntrinsicElements; // optional polymorphic
-};
-
+type Props = React.HTMLAttributes<HTMLElement> & { as?: keyof JSX.IntrinsicElements };
 export default function Landmarks({ as: As = "main", ...rest }: Props) {
   const Comp: any = As;
-  return <Comp className={cn(rest.className)} {...rest} />;
+  return <Comp {...rest} />;
 }

--- a/components/ui/sonner-toaster.tsx
+++ b/components/ui/sonner-toaster.tsx
@@ -1,0 +1,3 @@
+"use client";
+import { Toaster } from "sonner";
+export { Toaster };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,4 @@
 import nextJest from "next/jest.js";
-
 const createJestConfig = nextJest({ dir: "./" });
 
 const config: any = {
@@ -8,24 +7,24 @@ const config: any = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
     "\\.(css|less|sass|scss)$": "identity-obj-proxy",
+    "\\.(svg)$": "<rootDir>/__mocks__/svgMock.ts",
   },
   transform: {
     "^.+\\.(ts|tsx)$": [
       "ts-jest",
       { tsconfig: "<rootDir>/tsconfig.jest.json", isolatedModules: true }
-    ],
+    ]
   },
   transformIgnorePatterns: [
-    // Allow transforming ESM packages that Jest chokes on
-    "/node_modules/(?!(@?react-leaflet|leaflet|d3-|d3|tslib|nanoid|uuid|@radix-ui|lucide-react|framer-motion)/)",
+    "/node_modules/(?!(@?react-leaflet|leaflet|d3|d3-|lodash-es|uuid|nanoid|tslib|@radix-ui|lucide-react|framer-motion)/)"
   ],
   testPathIgnorePatterns: ["/node_modules/", "/.next/", "/dist/"],
   collectCoverageFrom: [
-    "components/**/*.{ts,tsx}",
     "app/**/*.{ts,tsx}",
+    "components/**/*.{ts,tsx}",
     "lib/**/*.{ts,tsx}",
-    "!**/*.d.ts",
-  ],
+    "!**/*.d.ts"
+  ]
 };
 
 export default createJestConfig(config);

--- a/llms.txt
+++ b/llms.txt
@@ -3411,3 +3411,22 @@ Files:
 - tsconfig.json (+14/-28)
 - types/{react-leaflet-shims.d.ts => shims.d.ts} (+4/-0)
 
+Timestamp: 2025-08-11T23:02:12.493Z
+Commit: 20920a89437c81a6f0236674b2a9dbc8276fead2
+Author: Codex
+Message: test+types+ui: fix Jest ESM/TS, add shims, wire Providers/theme/toast/fonts, and redirect home to app
+Files:
+- __mocks__/fileMock.js (+1/-0)
+- __mocks__/svgMock.ts (+2/-0)
+- app/globals.css (+4/-0)
+- app/layout.tsx (+14/-12)
+- app/page.tsx (+9/-0)
+- app/providers.tsx (+14/-0)
+- components/a11y/Landmarks.tsx (+2/-8)
+- components/ui/sonner-toaster.tsx (+3/-0)
+- jest.config.ts (+6/-7)
+- package-lock.json (+30/-0)
+- package.json (+4/-1)
+- tsconfig.jest.json (+1/-1)
+- tsconfig.json (+2/-1)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-leaflet": "^4.2.1",
         "react-window": "^1.8.11",
         "recharts": "^2.15.4",
+        "sonner": "^1.5.0",
         "swr": "^2.3.4",
         "tailwind-merge": "^3.3.1",
         "zod": "^3.25.76"
@@ -46,6 +47,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
         "@types/leaflet": "^1.9.20",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^24.2.0",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.0",
@@ -62,6 +64,7 @@
         "jest": "^29.7.0",
         "jest-axe": "^10.0.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-transform-stub": "^2.0.0",
         "msw": "^1.3.5",
         "postcss": "^8.4.31",
         "storybook": "^7.6.17",
@@ -7700,6 +7703,16 @@
       "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
@@ -17248,6 +17261,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/jest-transform-stub": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz",
+      "integrity": "sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -22153,6 +22173,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-leaflet": "^4.2.1",
     "react-window": "^1.8.11",
     "recharts": "^2.15.4",
+    "sonner": "^1.5.0",
     "swr": "^2.3.4",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.25.76"
@@ -82,6 +83,7 @@
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.0",
     "@types/react-window": "^1.8.8",
+    "@types/lodash-es": "^4.17.12",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "ajv": "^8.17.1",
@@ -101,6 +103,7 @@
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
-    "zod-to-json-schema": "^3.24.6"
+    "zod-to-json-schema": "^3.24.6",
+    "jest-transform-stub": "^2.0.0"
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -9,5 +9,5 @@
     "noEmit": true,
     "types": ["jest", "node"]
   },
-  "include": ["**/*.ts", "**/*.tsx", "jest.setup.ts", "__tests__/**/*", "tests/**/*"]
+  "include": ["**/*.ts", "**/*.tsx", "jest.setup.ts", "__tests__/**/*", "__mocks__/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": true
+    "strict": true,
+    "types": ["node"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- configure Jest for ESM + TypeScript with css/svg mocks
- add theme provider and toaster, load globals and fonts, redirect home to agent interface
- include Node types and shims, add sonner and Jest-related dev deps

## Testing
- `npm test` *(fails: upcoming-games API contract schema errors)*
- `CI_UNBLOCK=true npm run build` *(fails: TypeError originalFetch is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689a74ad31e883238b79c903cddcbad8