### PR TITLE
feat(home): normalize upcoming-games data and refine QuickMatchups

### DIFF
--- a/components/predictions/QuickMatchups.tsx
+++ b/components/predictions/QuickMatchups.tsx
@@ -1,9 +1,9 @@
 'use client';
-import { useApi } from '@/hooks/useApiData';
-import type { UpcomingGame } from '@/lib/types';
+import { useUpcomingGames } from '@/hooks/useUpcomingGames';
+import { safeLocalDate } from '@/lib/normalize';
 
 export default function QuickMatchups() {
-  const { data, error, isLoading } = useApi<UpcomingGame[]>('/api/upcoming-games');
+  const { data, error, isLoading } = useUpcomingGames();
 
   if (isLoading) return <div className="text-sm text-muted-foreground">Loading games…</div>;
   if (error) return <div className="text-sm text-red-500">Failed to load games.</div>;
@@ -14,11 +14,14 @@ export default function QuickMatchups() {
       <div className="flex gap-3 min-w-full">
         {data.map(g => (
           <article key={g.id} className="min-w-[260px] rounded-xl border p-4 hover:bg-accent/40 transition">
-            <div className="text-sm text-muted-foreground">{new Date(g.kickoff).toLocaleString()}</div>
-            <div className="mt-1 font-medium">{g.awayTeam} @ {g.homeTeam}</div>
-            {g.odds && (
+            <div className="text-sm text-muted-foreground">{safeLocalDate(g.kickoff)}</div>
+            <div className="mt-1 font-medium">
+              {g.awayTeam || 'TBD'} @ {g.homeTeam || 'TBD'}
+            </div>
+            {g.odds && (g.odds.home != null || g.odds.away != null) && (
               <div className="mt-2 text-sm">
-                Home: {g.odds.home} • Away: {g.odds.away}{g.odds.draw != null ? ` • Draw: ${g.odds.draw}` : ''}
+                {g.odds.home != null ? `Home: ${g.odds.home}` : 'Home: —'} • {g.odds.away != null ? `Away: ${g.odds.away}` : 'Away: —'}
+                {g.odds.draw != null ? ` • Draw: ${g.odds.draw}` : ''}
               </div>
             )}
             <a href={`/predictions?gameId=${encodeURIComponent(g.id)}`} className="mt-3 inline-flex text-sm text-primary hover:underline">

--- a/hooks/useUpcomingGames.ts
+++ b/hooks/useUpcomingGames.ts
@@ -1,0 +1,15 @@
+'use client';
+import useSWR from 'swr';
+import { apiGet } from '@/lib/api';
+import { normalizeUpcomingGames } from '@/lib/normalize';
+import type { UpcomingGame } from '@/lib/types';
+
+export function useUpcomingGames() {
+  return useSWR<UpcomingGame[]>('/api/upcoming-games', async (key) => {
+    const raw = await apiGet<any>(key);
+    return normalizeUpcomingGames(raw);
+  }, {
+    revalidateOnFocus: true,
+    errorRetryCount: 2,
+  });
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -23,3 +23,10 @@ export const getUpcomingGames = () => apiGet<UpcomingGame[]>('/api/upcoming-game
 export const getAgentEvents = () => apiGet<AgentEvent[]>('/api/agent-events');
 export const getPrediction = (gameId: string) =>
   apiGet<Prediction>(`/api/run-predictions?gameId=${encodeURIComponent(gameId)}`);
+
+// Normalized convenience (kept separate to avoid circular deps in hooks)
+export async function getNormalizedUpcomingGames(): Promise<import("./types").UpcomingGame[]> {
+  const raw = await apiGet<any>("/api/upcoming-games");
+  const { normalizeUpcomingGames } = await import("./normalize");
+  return normalizeUpcomingGames(raw);
+}

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -1,0 +1,94 @@
+import type { UpcomingGame } from "@/lib/types";
+
+function toIso(dateStr?: string | null, timeStr?: string | null, epochSec?: number | null): string | null {
+  // Prefer epoch seconds if present
+  if (typeof epochSec === "number" && !Number.isNaN(epochSec)) {
+    try {
+      return new Date(epochSec * 1000).toISOString();
+    } catch {
+      /* ignore */
+    }
+  }
+  // Try combined date+time (assume UTC if 'Z' or include offset; otherwise treat as local and coerce)
+  if (dateStr && timeStr) {
+    const joined = `${dateStr} ${timeStr}`.trim();
+    const d = new Date(joined);
+    if (!Number.isNaN(d.getTime())) return d.toISOString();
+  }
+  // Try date only
+  if (dateStr) {
+    const d = new Date(dateStr);
+    if (!Number.isNaN(d.getTime())) return d.toISOString();
+  }
+  return null;
+}
+
+export function normalizeUpcomingGames(raw: any): UpcomingGame[] {
+  const list: any[] = Array.isArray(raw?.data) ? raw.data : Array.isArray(raw) ? raw : [];
+  return list.map((g, i): UpcomingGame => {
+    // Accept a variety of shapes
+    const id =
+      g.id ??
+      g.gameId ??
+      g.idEvent ??
+      g.idGame ??
+      g.event_id ??
+      String(g._id ?? i);
+
+    const home =
+      g.homeTeam ??
+      g.home_team ??
+      g.strHomeTeam ??
+      g.home ??
+      g.teamHome ??
+      "";
+
+    const away =
+      g.awayTeam ??
+      g.away_team ??
+      g.strAwayTeam ??
+      g.away ??
+      g.teamAway ??
+      "";
+
+    // kickoff candidates: ISO, epoch seconds, TheSportsDB date+time
+    const kickoffIso =
+      g.kickoff ??
+      g.commence_time ??
+      g.startTime ??
+      g.start_time ??
+      toIso(g.dateEvent || g.event_date || g.date, g.strTime || g.event_time || g.time, g.epoch || g.timestamp) ??
+      null;
+
+    // odds candidates
+    const odds =
+      g.odds ??
+      (g.prices
+        ? { home: g.prices.home, away: g.prices.away, draw: g.prices.draw ?? undefined }
+        : g.moneyline
+        ? { home: g.moneyline.home, away: g.moneyline.away, draw: g.moneyline.draw ?? undefined }
+        : null);
+
+    const logos =
+      g.logos ??
+      (g.homeLogo || g.awayLogo ? { home: g.homeLogo, away: g.awayLogo } : undefined);
+
+    return {
+      id: String(id),
+      league: g.league || g.sport || "NFL",
+      homeTeam: String(home),
+      awayTeam: String(away),
+      kickoff: kickoffIso || "",
+      odds: odds ?? null,
+      logos: logos ?? {},
+    };
+  });
+}
+
+export function safeLocalDate(iso: string | null | undefined): string {
+  if (!iso) return "TBD";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "TBD";
+  return d.toLocaleString();
+}
+

--- a/llms.txt
+++ b/llms.txt
@@ -3700,3 +3700,13 @@ Files:
 - components/visuals/AgentNetwork.tsx (+81/-0)
 - lib/api.ts (+13/-1)
 
+Timestamp: 2025-08-12T01:51:50.722Z
+Commit: b733df72e1f14532d23d9751e1285d775d14f947
+Author: Codex
+Message: feat(home): normalize /api/upcoming-games to canonical type; fix QuickMatchups date/team rendering
+Files:
+- components/predictions/QuickMatchups.tsx (+10/-7)
+- hooks/useUpcomingGames.ts (+15/-0)
+- lib/api.ts (+7/-0)
+- lib/normalize.ts (+94/-0)
+


### PR DESCRIPTION
## Summary
- normalize TheSportsDB/moneyline game payloads into canonical `UpcomingGame` entries
- add `useUpcomingGames` hook and `safeLocalDate` helper
- update QuickMatchups to consume normalized games and handle TBD fields

## Testing
- `npm run build` *(fails: Type '"ghost"' is not assignable to type '"default" | "primary" | "primaryCTA" | undefined')*
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a9c43909883238892c3f13f936282