### PR TITLE
feat(home): expand bettor-first landing experience

### DIFF
--- a/app/(shell)/page.tsx
+++ b/app/(shell)/page.tsx
@@ -3,27 +3,32 @@ import Link from "next/link";
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
-// Client-only visuals and data panels
+
+// Client components (animation/data hooks)
 const AgentNetwork = nextDynamic(() => import("@/components/visuals/AgentNetwork"), { ssr: false });
-const QuickMatchups = nextDynamic(() => import("@/components/predictions/QuickMatchups"), { ssr: false });
+const LiveAgentPanel = nextDynamic(() => import("@/components/home/LiveAgentPanel"), { ssr: false });
+const HomeQuickPicks = nextDynamic(() => import("@/components/home/HomeQuickPicks"), { ssr: false });
+const ConfidenceSnapshot = nextDynamic(() => import("@/components/home/ConfidenceSnapshot"), { ssr: false });
+const HowItWorks = nextDynamic(() => import("@/components/home/HowItWorks"), { ssr: false });
+const StickyNavBar = nextDynamic(() => import("@/components/home/StickyNavBar"), { ssr: false });
 
 export default function HomePage() {
   return (
-    <div className="space-y-10">
-      {/* HERO: Live Agent Network + CTA */}
-      <section className="relative overflow-hidden rounded-2xl border bg-gradient-to-b from-background to-background/60">
+    <div className="space-y-12">
+      {/* 1) HERO */}
+      <section className="relative overflow-hidden rounded-2xl border bg-gradient-to-b from-background to-background/60" id="hero">
         <div className="grid gap-6 lg:grid-cols-2">
           <div className="p-6 sm:p-10 flex flex-col justify-center">
             <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight">
               AI‑Powered Sports Insights, <span className="text-primary">Explained</span>.
             </h1>
             <p className="mt-3 text-muted-foreground">
-              Our specialist agents analyze live odds, injuries, weather, and trends—then show you the why behind every pick.
+              See how our expert agents analyze live data to give you smarter picks.
             </p>
             <div className="mt-6 flex gap-3">
-              <Link href="/predictions" className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-primary-foreground hover:opacity-90">
+              <a href="#matchups" className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-primary-foreground hover:opacity-90">
                 See Today’s Predictions
-              </Link>
+              </a>
               <a href="#how-it-works" className="inline-flex items-center rounded-md border px-4 py-2 hover:bg-accent">
                 How It Works
               </a>
@@ -35,33 +40,27 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* QUICK MATCHUPS: bettor fast path */}
-      <section aria-labelledby="quick-matchups">
+      {/* 2) LIVE AGENT NETWORK PANEL */}
+      <LiveAgentPanel />
+
+      {/* 3) QUICK PICKS */}
+      <section id="matchups" aria-labelledby="quick-matchups">
         <div className="mb-3 flex items-center justify-between">
           <h2 id="quick-matchups" className="text-xl font-semibold">Today’s Matchups</h2>
-          <Link href="/leaderboard" className="text-sm text-muted-foreground hover:underline">Accuracy & Leaderboard →</Link>
+          <Link href="/predictions" className="text-sm text-muted-foreground hover:underline">Open Predictions →</Link>
         </div>
-        <QuickMatchups />
+        <HomeQuickPicks />
       </section>
 
-      {/* EXPLAINER */}
-      <section id="how-it-works" className="rounded-2xl border p-6 sm:p-8">
-        <h2 className="text-xl font-semibold">How EdgePicks Works</h2>
-        <ol className="mt-4 grid gap-4 sm:grid-cols-3">
-          <li className="rounded-lg border p-4">
-            <div className="font-medium">1) We Pull Live Data</div>
-            <p className="text-sm text-muted-foreground mt-1">Schedules, odds, injuries, weather, and trends.</p>
-          </li>
-          <li className="rounded-lg border p-4">
-            <div className="font-medium">2) Agents Debate</div>
-            <p className="text-sm text-muted-foreground mt-1">Independent agents form their own picks and confidence.</p>
-          </li>
-          <li className="rounded-lg border p-4">
-            <div className="font-medium">3) You Get Reasons</div>
-            <p className="text-sm text-muted-foreground mt-1">Transparent rationales behind every recommendation.</p>
-          </li>
-        </ol>
-      </section>
+      {/* 4) CONFIDENCE TRENDS & ACCURACY */}
+      <ConfidenceSnapshot />
+
+      {/* 5) HOW IT WORKS */}
+      <HowItWorks />
+
+      {/* 6) STICKY NAV (optional; harmless on desktop) */}
+      <StickyNavBar />
     </div>
   );
 }
+

--- a/components/home/ConfidenceSnapshot.tsx
+++ b/components/home/ConfidenceSnapshot.tsx
@@ -1,0 +1,71 @@
+"use client";
+import useSWR from "swr";
+import { apiGet } from "@/lib/api";
+import { useMemo } from "react";
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+
+type AccuracyPoint = { date: string; accuracy: number; avgConfidence?: number };
+type Leaderboard = { agent: string; winPct: number }[];
+
+export default function ConfidenceSnapshot() {
+  const { data: history } = useSWR<AccuracyPoint[]>(
+    "/api/accuracy-history",
+    (k) => apiGet<AccuracyPoint[]>(k),
+    { revalidateOnFocus: false }
+  );
+  const { data: weekAcc } = useSWR<{ accuracy: number }>(
+    "/api/accuracy",
+    (k) => apiGet<{ accuracy: number }>(k),
+    { revalidateOnFocus: false }
+  );
+  const { data: lb } = useSWR<Leaderboard>(
+    "/api/leaderboard",
+    (k) => apiGet<Leaderboard>(k),
+    { revalidateOnFocus: false }
+  );
+
+  const top3 = (lb ?? []).slice(0, 3);
+  const avgAcc = useMemo(() => weekAcc?.accuracy ?? null, [weekAcc]);
+
+  return (
+    <section aria-labelledby="conf-acc" className="grid gap-6 lg:grid-cols-3 rounded-2xl border p-4">
+      <div className="lg:col-span-2">
+        <h2 id="conf-acc" className="text-xl font-semibold mb-3">
+          Confidence Trends
+        </h2>
+        <div className="w-full h-56">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={history ?? []}>
+              <XAxis dataKey="date" />
+              <YAxis domain={[0, 1]} tickFormatter={(v) => `${Math.round(v * 100)}%`} />
+              <Tooltip formatter={(v) => `${Math.round(Number(v) * 100)}%`} />
+              <Line type="monotone" dataKey="accuracy" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+      <div className="space-y-4">
+        <div className="rounded-xl border p-4">
+          <div className="text-sm text-muted-foreground">Last Week’s Accuracy</div>
+          <div className="text-2xl font-bold">
+            {avgAcc != null ? `${Math.round(avgAcc * 100)}%` : "—"}
+          </div>
+        </div>
+        <div className="rounded-xl border p-4">
+          <div className="text-sm text-muted-foreground mb-2">Top Agents (This Week)</div>
+          <ul className="text-sm space-y-1">
+            {(top3.length ? top3 : [{ agent: "—", winPct: 0 }]).map((a, i) => (
+              <li key={`${a.agent}-${i}`} className="flex justify-between">
+                <span>{a.agent}</span>
+                <span className="text-muted-foreground">
+                  {a.winPct ? `${Math.round(a.winPct * 100)}%` : "—"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/home/HomeQuickPicks.tsx
+++ b/components/home/HomeQuickPicks.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useState } from "react";
+import dynamic from "next/dynamic";
+
+const QuickMatchups = dynamic(() => import("@/components/predictions/QuickMatchups"), { ssr: false });
+
+const leagues = ["NFL", "MLB", "NBA"]; // lightweight toggle (future: filter upstream)
+
+export default function HomeQuickPicks() {
+  const [league, setLeague] = useState<string>("NFL");
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        {leagues.map((l) => (
+          <button
+            key={l}
+            onClick={() => setLeague(l)}
+            className={`px-3 py-1 rounded-md border text-sm ${l === league ? "bg-primary text-primary-foreground" : "hover:bg-accent"}`}
+            aria-pressed={l === league}
+          >
+            {l}
+          </button>
+        ))}
+      </div>
+      {/* For now QuickMatchups shows all; league filter can be wired when API supports it */}
+      <QuickMatchups />
+    </div>
+  );
+}
+

--- a/components/home/HowItWorks.tsx
+++ b/components/home/HowItWorks.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { motion } from "framer-motion";
+
+export default function HowItWorks() {
+  return (
+    <section id="how-it-works" className="rounded-2xl border p-6 sm:p-8">
+      <h2 className="text-xl font-semibold">How EdgePicks Works</h2>
+      <ol className="mt-4 grid gap-4 sm:grid-cols-3">
+        <li className="rounded-lg border p-4">
+          <div className="font-medium">1) We Pull Live Data</div>
+          <p className="text-sm text-muted-foreground mt-1">Odds, stats, injuries, weather.</p>
+        </li>
+        <li className="rounded-lg border p-4">
+          <div className="font-medium">2) Agents Debate</div>
+          <p className="text-sm text-muted-foreground mt-1">Independent agents form picks + confidence.</p>
+        </li>
+        <li className="rounded-lg border p-4">
+          <div className="font-medium">3) You Get Reasons</div>
+          <p className="text-sm text-muted-foreground mt-1">Clear rationales behind every pick.</p>
+        </li>
+      </ol>
+
+      {/* Mini funnel diagram */}
+      <div className="mt-6 relative h-32">
+        <motion.div
+          className="absolute left-4 top-6 h-3 w-3 rounded-full bg-primary"
+          animate={{ scale: [1, 1.1, 1] }}
+          transition={{ repeat: Infinity, duration: 2 }}
+        />
+        <motion.div
+          className="absolute left-4 top-16 h-3 w-3 rounded-full bg-primary/70"
+          animate={{ scale: [1, 1.1, 1] }}
+          transition={{ repeat: Infinity, duration: 2, delay: 0.2 }}
+        />
+        <motion.div
+          className="absolute left-4 top-24 h-3 w-3 rounded-full bg-primary/60"
+          animate={{ scale: [1, 1.1, 1] }}
+          transition={{ repeat: Infinity, duration: 2, delay: 0.4 }}
+        />
+        <motion.div className="absolute left-12 top-14 h-2 w-28 rounded-md bg-muted" />
+        <motion.div
+          className="absolute left-44 top-14 h-6 w-6 rounded-full bg-primary"
+          animate={{ scale: [1, 1.05, 1] }}
+          transition={{ repeat: Infinity, duration: 3 }}
+        />
+        <div className="absolute left-52 top-14 text-sm text-muted-foreground">Consensus</div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/home/LiveAgentPanel.tsx
+++ b/components/home/LiveAgentPanel.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { motion } from "framer-motion";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+
+const AgentNetwork = dynamic(() => import("@/components/visuals/AgentNetwork"), { ssr: false });
+
+export default function LiveAgentPanel() {
+  return (
+    <section aria-labelledby="live-agents" className="relative rounded-2xl border">
+      <div className="flex items-center justify-between px-4 pt-4">
+        <h2 id="live-agents" className="text-xl font-semibold">Live Agent Network</h2>
+        <Link href="/leaderboard" className="text-sm text-muted-foreground hover:underline">
+          Accuracy & Leaderboard →
+        </Link>
+      </div>
+      <div className="grid gap-4 p-4 lg:grid-cols-3">
+        <div className="lg:col-span-2 min-h-[280px]">
+          <AgentNetwork />
+        </div>
+        <div className="rounded-xl border p-4">
+          <div className="text-sm text-muted-foreground">Status</div>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="mt-1 font-medium"
+          >
+            Agents analyzing current matchups…
+          </motion.div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Hover nodes to see which data each specialist is inspecting.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/home/StickyNavBar.tsx
+++ b/components/home/StickyNavBar.tsx
@@ -1,0 +1,45 @@
+"use client";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+export default function StickyNavBar() {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    const onScroll = () => setShow(window.scrollY > 320);
+    onScroll();
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+  if (!show) return null;
+  return (
+    <nav aria-label="Quick Nav" className="fixed inset-x-0 bottom-3 z-40">
+      <div className="mx-auto max-w-5xl">
+        <div className="mx-3 rounded-2xl border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 shadow">
+          <ul className="flex items-center justify-around p-2 text-sm">
+            <li>
+              <a href="#matchups" className="hover:underline">
+                Matchups
+              </a>
+            </li>
+            <li>
+              <a href="#live-agents" className="hover:underline">
+                Agents
+              </a>
+            </li>
+            <li>
+              <Link href="/leaderboard" className="hover:underline">
+                Leaderboard
+              </Link>
+            </li>
+            <li>
+              <Link href="/predictions" className="hover:underline">
+                My Picks
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  );
+}
+

--- a/llms.txt
+++ b/llms.txt
@@ -3700,3 +3700,15 @@ Files:
 - components/visuals/AgentNetwork.tsx (+81/-0)
 - lib/api.ts (+13/-1)
 
+Timestamp: 2025-08-12T01:58:34.673Z
+Commit: 4ad8983bca69e86c94cec0a6c43bb05f534eee57
+Author: Codex
+Message: feat(home): add bettor-first landing components
+Files:
+- app/(shell)/page.tsx (+29/-30)
+- components/home/ConfidenceSnapshot.tsx (+71/-0)
+- components/home/HomeQuickPicks.tsx (+30/-0)
+- components/home/HowItWorks.tsx (+51/-0)
+- components/home/LiveAgentPanel.tsx (+38/-0)
+- components/home/StickyNavBar.tsx (+45/-0)
+


### PR DESCRIPTION
## Summary
- rebuild homepage with hero, live agent panel, quick picks, confidence snapshot, explainer and sticky nav
- add home-specific components for quick league toggle and accuracy visuals

## Testing
- `npm test -- --passWithNoTests`
- `npm run build` *(fails: Type error: Type '"ghost"' is not assignable to type '"default" | "primary" | "primaryCTA" | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_689a9e5fe47c8323bcc85e9e74beee02