### PR TITLE
feat: demo cleanup and typing

### DIFF
--- a/__tests__/AgentFlowVisualizer.render.test.tsx
+++ b/__tests__/AgentFlowVisualizer.render.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import AgentFlowVisualizer from '../components/visuals/AgentFlowVisualizer';
+import React from 'react';
+
+type FlowEdge = { id: string; source: string; target: string };
+
+describe('AgentFlowVisualizer render', () => {
+  it('renders heading and appends edge under simulation', () => {
+    jest.useFakeTimers();
+    const original = global.EventSource;
+    delete (global as any).EventSource;
+
+    let edges: FlowEdge[] = [];
+    const setEdges: React.Dispatch<React.SetStateAction<FlowEdge[]>> = (update) => {
+      edges = typeof update === 'function' ? update(edges) : update;
+    };
+
+    render(<AgentFlowVisualizer setEdges={setEdges} />);
+    expect(screen.getByRole('heading', { name: /agent flow/i })).toBeInTheDocument();
+
+    jest.advanceTimersByTime(1000);
+    expect(edges.length).toBeGreaterThan(0);
+
+    global.EventSource = original;
+  });
+});

--- a/__tests__/AgentFlowVisualizer.test.tsx
+++ b/__tests__/AgentFlowVisualizer.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
 import AgentFlowVisualizer from '../components/visuals/AgentFlowVisualizer';
 
 describe('AgentFlowVisualizer', () => {
   it('renders heading', () => {
-    render(<AgentFlowVisualizer />);
+    const setEdges = jest.fn();
+    render(<AgentFlowVisualizer setEdges={setEdges} />);
     expect(screen.getByRole('heading', { name: /agent flow/i })).toBeInTheDocument();
   });
 });

--- a/__tests__/supabaseRegistry.test.ts
+++ b/__tests__/supabaseRegistry.test.ts
@@ -32,7 +32,9 @@ describe('getSupabaseAgentRegistry', () => {
     const first = await getSupabaseAgentRegistry();
     const second = await getSupabaseAgentRegistry();
 
-    expect(first).toEqual(sample);
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    expect(first.data.get('a1')).toEqual(sample[0]);
     expect(second).toBe(first);
     expect(fromMock).toHaveBeenCalledTimes(1);
     expect(cacheMock).toHaveBeenCalledTimes(1);

--- a/app/(shell)/page.tsx
+++ b/app/(shell)/page.tsx
@@ -1,9 +1,9 @@
 import nextDynamic from "next/dynamic";
 import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
-
 // Client components (animation/data hooks)
 const AgentNetwork = nextDynamic(() => import("@/components/visuals/AgentNetwork"), { ssr: false });
 const LiveAgentPanel = nextDynamic(() => import("@/components/home/LiveAgentPanel"), { ssr: false });
@@ -26,12 +26,18 @@ export default function HomePage() {
               See how our expert agents analyze live data to give you smarter picks.
             </p>
             <div className="mt-6 flex gap-3">
-              <a href="#matchups" className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-primary-foreground hover:opacity-90">
+              <a
+                href="#matchups"
+                className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-primary-foreground hover:opacity-90"
+              >
                 See Today’s Predictions
               </a>
-              <a href="#how-it-works" className="inline-flex items-center rounded-md border px-4 py-2 hover:bg-accent">
-                How It Works
-              </a>
+              <Link
+                href="/demo-0to1"
+                className={buttonVariants({ variant: 'ghost' })}
+              >
+                Live Demo
+              </Link>
             </div>
           </div>
           <div className="min-h-[260px] lg:min-h-[360px]">

--- a/app/demo-0to1/page.tsx
+++ b/app/demo-0to1/page.tsx
@@ -1,4 +1,6 @@
+"use client";
 import dynamicImport from "next/dynamic";
+import { useState } from "react";
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
@@ -6,7 +8,10 @@ const AgentNetwork = dynamicImport(() => import("@/components/visuals/AgentNetwo
 const QuickMatchups = dynamicImport(() => import("@/components/predictions/QuickMatchups"), { ssr: false });
 const AgentFlowVisualizer = dynamicImport(() => import("@/components/visuals/AgentFlowVisualizer"), { ssr: false });
 
+type FlowEdge = { id: string; source: string; target: string };
+
 export default function DemoZeroToOnePage() {
+  const [edges, setEdges] = useState<FlowEdge[]>([]);
   return (
     <div className="space-y-6 p-4">
       <section>
@@ -15,7 +20,7 @@ export default function DemoZeroToOnePage() {
       <div className="min-h-[280px]">
         <AgentNetwork />
       </div>
-      <AgentFlowVisualizer />
+      <AgentFlowVisualizer setEdges={setEdges} />
     </div>
   );
 }

--- a/components/layout/SiteHeader.tsx
+++ b/components/layout/SiteHeader.tsx
@@ -6,7 +6,7 @@ const tabs = [
   { href: "/", label: "Home" },
   { href: "/predictions", label: "Predictions" },
   { href: "/leaderboard", label: "Leaderboard" },
-  { href: "/demo/mlb", label: "MLB Demo" },
+  { href: "/demo-0to1", label: "Demo", mobileHidden: true },
 ];
 
 export default function SiteHeader() {
@@ -18,11 +18,16 @@ export default function SiteHeader() {
         <nav className="flex gap-4 text-sm">
           {tabs.map(t => {
             const active = pathname === t.href;
+            const base = active
+              ? "text-primary underline underline-offset-4"
+              : "text-muted-foreground hover:text-foreground";
+            const hidden = t.mobileHidden ? "hidden sm:inline" : "";
             return (
               <Link
                 key={t.href}
                 href={t.href}
-                className={active ? "text-primary underline underline-offset-4" : "text-muted-foreground hover:text-foreground"}
+                aria-current={active ? 'page' : undefined}
+                className={`${base} ${hidden}`}
               >
                 {t.label}
               </Link>

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,7 @@
 import 'dotenv/config';
 import { jest } from '@jest/globals';
+import * as swrInternal from 'swr/_internal';
+const swrCache: Map<any, any> = (swrInternal as any).cache;
 import { freezeTime, resetTime } from './lib/test/freezeTime';
 import { server } from './test/msw/server';
 
@@ -13,6 +15,7 @@ afterEach(() => {
   jest.restoreAllMocks();
   resetTime();
   server.resetHandlers();
+  swrCache.clear();
 });
 afterAll(() => server.close());
 

--- a/lib/agents/guardianAgent.ts
+++ b/lib/agents/guardianAgent.ts
@@ -1,7 +1,33 @@
-// @ts-nocheck
-import { AgentOutputs, AgentResult, Matchup } from '../types';
+import { z } from 'zod';
 import { logAgentReflection } from './utils';
-import { AgentReflection } from '../../types/AgentReflection';
+import type { AgentReflection } from '../../types/AgentReflection';
+import type { Matchup } from '../types';
+
+// --- Schemas ---
+const MatchupSchema = z.object({
+  homeTeam: z.string(),
+}).passthrough();
+
+const AgentOutputSchema = z.object({
+  team: z.string(),
+  reason: z.string().optional(),
+});
+
+const AgentOutputsSchema = z.record(AgentOutputSchema);
+
+export const GuardianAgentResultSchema = z.object({
+  team: z.string(),
+  score: z.number(),
+  reason: z.string(),
+  warnings: z.array(z.string()).optional(),
+});
+
+export type GuardianMatchup = z.infer<typeof MatchupSchema>;
+export type GuardianAgentOutputs = Partial<z.infer<typeof AgentOutputsSchema>>;
+export type GuardianAgentResult = z.infer<typeof GuardianAgentResultSchema>;
+
+const entries = <T extends Record<string, unknown>>(obj: T) =>
+  Object.entries(obj) as [keyof T, T[keyof T]][];
 
 /**
  * Reviews previous agent outputs for inconsistencies or missing data
@@ -10,23 +36,26 @@ import { AgentReflection } from '../../types/AgentReflection';
  */
 export const guardianAgent = async (
   matchup: Matchup,
-  agents: Partial<AgentOutputs> = {}
-): Promise<AgentResult> => {
+  agents: GuardianAgentOutputs = {},
+): Promise<GuardianAgentResult> => {
   const warnings: string[] = [];
-  const results = Object.entries(agents);
+  const results = entries(agents);
 
   if (results.length === 0) {
     warnings.push('No agent outputs available for review.');
   } else {
     // Check for missing reasoning
     for (const [name, result] of results) {
-      if (!result.reason || result.reason.trim().length < 5) {
-        warnings.push(`Agent ${name} provided incomplete reasoning.`);
+      const parsed = AgentOutputSchema.safeParse(result);
+      if (!parsed.success || !parsed.data.reason || parsed.data.reason.trim().length < 5) {
+        warnings.push(`Agent ${String(name)} provided incomplete reasoning.`);
       }
     }
 
     // Check if agents disagree on predicted winner
-    const teams = new Set(results.map(([_, r]) => r.team));
+    const teams = new Set(
+      results.map(([_, r]) => AgentOutputSchema.parse(r).team),
+    );
     if (teams.size > 1) {
       warnings.push('Agents disagree on the predicted winner.');
     }
@@ -40,12 +69,13 @@ export const guardianAgent = async (
   };
   await logAgentReflection('guardianAgent', reflection);
 
-  return {
-    team: matchup.homeTeam,
+  const m = MatchupSchema.parse(matchup);
+  return GuardianAgentResultSchema.parse({
+    team: m.homeTeam,
     score: 0,
     reason,
     warnings: warnings.length > 0 ? warnings : undefined,
-  };
+  });
 };
 
 export default guardianAgent;

--- a/lib/server/cache.ts
+++ b/lib/server/cache.ts
@@ -79,6 +79,16 @@ export function buildCacheKey(league: string, gameId: string, agents: string[]) 
   return `${league}:${gameId}:${agents.sort().join(',')}`;
 }
 
+export function cache<T extends (...args: any[]) => Promise<any>>(fn: T): T {
+  let memo: Promise<ReturnType<T>> | null = null;
+  return (async (...args: Parameters<T>) => {
+    if (!memo) {
+      memo = fn(...args);
+    }
+    return memo as Promise<ReturnType<T>>;
+  }) as T;
+}
+
 export async function getCachedPrediction(key: string) {
   const now = Date.now();
   const entry = memoryCache.get(key);

--- a/llms.txt
+++ b/llms.txt
@@ -3765,3 +3765,28 @@ Files:
 - scripts/uiSnapshot.tsx (+3/-1)
 - types/reactflow.d.ts (+13/-0)
 
+Timestamp: 2025-08-12T03:23:10.113Z
+Commit: 18eaf5536136e131d2d7fc59857f445f18d06a73
+Author: Codex
+Message: feat: demo cleanup and typing
+Files:
+- __tests__/AgentFlowVisualizer.render.test.tsx (+26/-0)
+- __tests__/AgentFlowVisualizer.test.tsx (+3/-1)
+- __tests__/supabaseRegistry.test.ts (+3/-1)
+- app/(shell)/page.tsx (+11/-5)
+- app/demo-0to1/page.tsx (+6/-1)
+- components/layout/SiteHeader.tsx (+7/-2)
+- components/visuals/AgentFlowVisualizer.tsx (+31/-9)
+- jest.setup.ts (+3/-0)
+- lib/agents/guardianAgent.ts (+42/-12)
+- lib/agents/supabaseRegistry.ts (+26/-13)
+- lib/server/cache.ts (+10/-0)
+- tests/visual/percy.spec.ts (+0/-1)
+
+Timestamp: 2025-08-12T03:24:18.427Z
+Commit: 5203d94ddb2770c5272a948714692e64cf9e4b2b
+Author: Codex
+Message: test: adjust visualizer render test
+Files:
+- __tests__/AgentFlowVisualizer.render.test.tsx (+2/-2)
+

--- a/tests/visual/percy.spec.ts
+++ b/tests/visual/percy.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { test } from '@playwright/test';
 import percySnapshot from '@percy/playwright';
 


### PR DESCRIPTION
## Summary
- add zod schemas and typed helpers for guardian agent
- type supabase registry with Result wrapper and cache
- expose SSE status and edge updates in AgentFlowVisualizer; wire demo link

## Testing
- `npm run guard:aliases`
- `npm run guard:swr`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aaf9571fc8323a3673def8e1007ae