### PR TITLE
feat: simulate agent flow when live stream unavailable

### DIFF
--- a/__tests__/AgentFlowVisualizer.fallback.test.tsx
+++ b/__tests__/AgentFlowVisualizer.fallback.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Ensures the visualizer appends at least one edge while in simulation mode.
+ */
+import React from "react";
+import { jest } from "@jest/globals";
+import { render, screen, waitFor } from "@testing-library/react";
+import AgentFlowVisualizer from "@/components/visuals/AgentFlowVisualizer";
+
+describe("AgentFlowVisualizer (simulation fallback)", () => {
+  beforeAll(() => {
+    // Force simulation by removing EventSource
+    // @ts-ignore
+    delete (global as any).EventSource;
+    jest.useFakeTimers();
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("appends an edge under simulation", async () => {
+    render(<AgentFlowVisualizer />);
+    // Fast-forward enough ticks to create at least one edge
+    jest.advanceTimersByTime(1200);
+    await waitFor(() => {
+      const list = screen.getByTestId("flow-edges");
+      // In the lightweight UL fallback we render IDs; ensure at least one item exists
+      // (we don't assert on exact ID because it's time-based)
+      expect(list.querySelectorAll("li").length).toBeGreaterThan(0);
+    });
+  });
+});
+

--- a/__tests__/AgentFlowVisualizer.test.tsx
+++ b/__tests__/AgentFlowVisualizer.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { jest } from '@jest/globals';
 import AgentFlowVisualizer from '../components/visuals/AgentFlowVisualizer';
 
 describe('AgentFlowVisualizer', () => {
-  it('renders heading', () => {
-    const setEdges = jest.fn();
-    render(<AgentFlowVisualizer setEdges={setEdges} />);
-    expect(screen.getByRole('heading', { name: /agent flow/i })).toBeInTheDocument();
+  it('renders status text', () => {
+    render(<AgentFlowVisualizer />);
+    expect(screen.getByText(/Agent Flow/)).toBeInTheDocument();
   });
 });
+

--- a/app/demo-0to1/page.tsx
+++ b/app/demo-0to1/page.tsx
@@ -1,26 +1,81 @@
-"use client";
-import dynamicImport from "next/dynamic";
-import { useState } from "react";
+import dynamic from "next/dynamic";
+import { Metadata } from "next";
+import useSWR from "swr";
+import { jsonFetcher } from "@/lib/fetcher";
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
-const AgentNetwork = dynamicImport(() => import("@/components/visuals/AgentNetwork"), { ssr: false });
-const QuickMatchups = dynamicImport(() => import("@/components/predictions/QuickMatchups"), { ssr: false });
-const AgentFlowVisualizer = dynamicImport(() => import("@/components/visuals/AgentFlowVisualizer"), { ssr: false });
 
-type FlowEdge = { id: string; source: string; target: string };
+const AgentFlowVisualizer = dynamic(
+  () => import("@/components/visuals/AgentFlowVisualizer"),
+  { ssr: false }
+);
 
-export default function DemoZeroToOnePage() {
-  const [edges, setEdges] = useState<FlowEdge[]>([]);
+export const metadata: Metadata = {
+  title: "0Ã¢ÂÂ1 Live Demo",
+};
+
+export default function Page() {
+  const { data: games, isLoading: loadingGames } = useSWR("/api/upcoming-games", jsonFetcher);
+  const { data: preds, isLoading: loadingPreds } = useSWR("/api/run-predictions", jsonFetcher);
+
   return (
-    <div className="space-y-6 p-4">
-      <section>
-        <QuickMatchups />
+    <div className="container py-8 space-y-8">
+      <section id="hero" className="space-y-2">
+        <h1 className="text-2xl font-semibold">ZeroÃ¢ÂÂtoÃ¢ÂÂOne Live Demo</h1>
+        <p className="text-muted-foreground">This view streams agent activity when available, or simulates it automatically.</p>
+        <a href="#live" className="inline-flex items-center rounded-md border px-3 py-1.5 text-sm hover:bg-accent">Jump to Live ↴</a>
       </section>
-      <div className="min-h-[280px]">
-        <AgentNetwork />
-      </div>
-      <AgentFlowVisualizer setEdges={setEdges} />
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">TodayÃ¢ÂÂs Matchups</h2>
+        {loadingGames ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-16 rounded-md border animate-pulse bg-muted" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {games?.slice?.(0, 6)?.map((g: any) => (
+              <div key={g.id ?? `${g.home}-${g.away}`} className="rounded-md border p-3 flex items-center justify-between">
+                <div className="text-sm">
+                  <div className="font-medium">{g.home} vs {g.away}</div>
+                  <div className="text-muted-foreground">{g.startTime ?? "TBD"}</div>
+                </div>
+                <div className="text-xs text-muted-foreground">league: {g.league ?? "n/a"}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">Top Pick Snapshot</h2>
+        {loadingPreds ? (
+          <div className="h-20 rounded-md border animate-pulse bg-muted" />
+        ) : (
+          <div className="rounded-md border p-3">
+            {preds?.topPick ? (
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm">Top pick</div>
+                  <div className="text-base font-semibold">{preds.topPick.matchup ?? "Ã¢ÂÂ"}</div>
+                </div>
+                <div className="text-sm">Confidence: <span className="font-semibold">{Math.round((preds.topPick.confidence ?? 0.6) * 100)}%</span></div>
+              </div>
+            ) : (
+              <div className="text-sm text-muted-foreground">No live pick available.</div>
+            )}
+          </div>
+        )}
+      </section>
+
+      <section id="live">
+        <h2 className="text-lg font-medium mb-2">Agent Flow</h2>
+        <AgentFlowVisualizer />
+      </section>
     </div>
   );
 }
+

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,6 +14,7 @@ const config: import('jest').Config = {
   testMatch: [
     '<rootDir>/__tests__/smoke.exists.test.tsx',
     '<rootDir>/__tests__/AgentFlowVisualizer.test.tsx',
+    '<rootDir>/__tests__/AgentFlowVisualizer.fallback.test.tsx',
   ],
   // TEMP quarantine while we fix contracts/e2e/a11y:
   testPathIgnorePatterns: ['<rootDir>/tests/', '<rootDir>/scripts/update-llms-log.test.js', '<rootDir>/lib/logUiEvent.test.js'],

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -39,3 +39,11 @@ export const ENV = parsed.success ? parsed.data : ({} as z.infer<typeof envSchem
 if (process.env.FEATURE_AGENT_INTERFACE === 'true' && !process.env.SPORTS_API_KEY) {
   console.warn('SPORTS_API_KEY missing; running agent interface in demo mode.');
 }
+
+export type FlowMode = 'live' | 'sim';
+/**
+ * Client-safe env access. Use NEXT_PUBLIC_* for anything read in the browser.
+ */
+export const NEXT_PUBLIC_AGENT_FLOW_MODE: FlowMode =
+  (process.env.NEXT_PUBLIC_AGENT_FLOW_MODE as FlowMode) || 'sim';
+

--- a/lib/fetcher.ts
+++ b/lib/fetcher.ts
@@ -1,0 +1,6 @@
+export async function jsonFetcher<T = any>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init);
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json() as Promise<T>;
+}
+

--- a/llms.txt
+++ b/llms.txt
@@ -3790,3 +3790,18 @@ Message: test: adjust visualizer render test
 Files:
 - __tests__/AgentFlowVisualizer.render.test.tsx (+2/-2)
 
+Timestamp: 2025-08-12T03:52:54.528Z
+Commit: 606ae5a027407145f83475abdbdfe0620145024f
+Author: Codex
+Message: feat: add simulated agent flow with fallback
+Files:
+- __tests__/AgentFlowVisualizer.fallback.test.tsx (+32/-0)
+- __tests__/AgentFlowVisualizer.test.tsx (+4/-5)
+- app/demo-0to1/page.tsx (+70/-15)
+- components/visuals/AgentFlowVisualizer.tsx (+117/-107)
+- jest.config.ts (+1/-0)
+- lib/env.ts (+8/-0)
+- lib/fetcher.ts (+6/-0)
+- tsconfig.jest.json (+1/-1)
+- types/reactflow.d.ts (+5/-6)
+

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -4,5 +4,5 @@
     "jsx": "react-jsx",
     "types": ["jest", "node"]
   },
-  "include": ["jest.setup.ts", "__tests__/**/*.ts", "__tests__/**/*.tsx"]
+  "include": ["types/**/*.d.ts", "jest.setup.ts", "__tests__/**/*.ts", "__tests__/**/*.tsx"]
 }

--- a/types/reactflow.d.ts
+++ b/types/reactflow.d.ts
@@ -1,13 +1,12 @@
-declare module 'reactflow' {
-  export interface Node<T = any> {
-    id: string;
-    position?: { x: number; y: number };
-    data?: T;
-  }
+declare module "reactflow" {
   export interface Edge<T = any> {
     id: string;
     source: string;
     target: string;
+    data?: T;
+  }
+  export interface Node<T = any> {
+    id: string;
     data?: T;
   }
 }


### PR DESCRIPTION
## Summary
- add client env flag and json fetcher utility
- stream or simulate agent activity in `AgentFlowVisualizer`
- expand demo page with live data snapshots and link SWR fetcher
- cover simulation fallback with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ab6011aa48323821183b084c7e380