### PR TITLE
feat: add simulated agent flow with fallback

### DIFF
--- a/app/demo-0to1/page.tsx
+++ b/app/demo-0to1/page.tsx
@@ -1,4 +1,4 @@
-import dynamic from "next/dynamic";
+import nextDynamic from "next/dynamic";
 import { Metadata } from "next";
 import useSWR from "swr";
 import { jsonFetcher } from "@/lib/fetcher";
@@ -6,13 +6,13 @@ export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
-const AgentFlowVisualizer = dynamic(
+const AgentFlowVisualizer = nextDynamic(
   () => import("@/components/visuals/AgentFlowVisualizer"),
   { ssr: false }
 );
 
 export const metadata: Metadata = {
-  title: "0Ã¢ÂÂ1 Live Demo",
+  title: "0→1 Live Demo",
 };
 
 export default function Page() {
@@ -22,13 +22,13 @@ export default function Page() {
   return (
     <div className="container py-8 space-y-8">
       <section id="hero" className="space-y-2">
-        <h1 className="text-2xl font-semibold">ZeroÃ¢ÂÂtoÃ¢ÂÂOne Live Demo</h1>
+        <h1 className="text-2xl font-semibold">Zero‑to‑One Live Demo</h1>
         <p className="text-muted-foreground">This view streams agent activity when available, or simulates it automatically.</p>
         <a href="#live" className="inline-flex items-center rounded-md border px-3 py-1.5 text-sm hover:bg-accent">Jump to Live ↴</a>
       </section>
 
       <section>
-        <h2 className="text-lg font-medium mb-2">TodayÃ¢ÂÂs Matchups</h2>
+        <h2 className="text-lg font-medium mb-2">Today’s Matchups</h2>
         {loadingGames ? (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {Array.from({ length: 4 }).map((_, i) => (
@@ -60,7 +60,7 @@ export default function Page() {
               <div className="flex items-center justify-between">
                 <div>
                   <div className="text-sm">Top pick</div>
-                  <div className="text-base font-semibold">{preds.topPick.matchup ?? "Ã¢ÂÂ"}</div>
+                  <div className="text-base font-semibold">{preds.topPick.matchup ?? "—"}</div>
                 </div>
                 <div className="text-sm">Confidence: <span className="font-semibold">{Math.round((preds.topPick.confidence ?? 0.6) * 100)}%</span></div>
               </div>
@@ -78,4 +78,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/llms.txt
+++ b/llms.txt
@@ -3805,3 +3805,10 @@ Files:
 - tsconfig.jest.json (+1/-1)
 - types/reactflow.d.ts (+5/-6)
 
+Timestamp: 2025-08-12T04:05:05.456Z
+Commit: 9cae2cbd5cdf7a5200569ec043ad2ee3659a8efa
+Author: Codex
+Message: fix: ensure demo uses nextDynamic and clean typography
+Files:
+- app/demo-0to1/page.tsx (+6/-7)
+


### PR DESCRIPTION
## Summary
- expose NEXT_PUBLIC_AGENT_FLOW_MODE to toggle live vs simulated flows
- add json fetcher and expand demo to fetch games & predictions via SWR
- stream agent flow over SSE when available, otherwise pulse simulated edges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689abbe752c48323931c92ef990b35c5