### PR TITLE
feat: map agent events to graph edges

### DIFF
--- a/__tests__/mapAgentEventsToGraph.test.ts
+++ b/__tests__/mapAgentEventsToGraph.test.ts
@@ -1,0 +1,39 @@
+import { toGraph } from '@/components/universal/mapAgentEventsToGraph';
+import type { AgentEvent } from '@/components/universal/UniversalAgentInterface';
+
+describe('mapAgentEventsToGraph', () => {
+  it('creates edges based on sequential agent execution', () => {
+    const events: AgentEvent[] = [
+      { id: '1', agent: 'A', status: 'running', t: 0 },
+      { id: '2', agent: 'A', status: 'completed', t: 1 },
+      { id: '3', agent: 'B', status: 'running', t: 2 },
+      { id: '4', agent: 'B', status: 'completed', t: 3 },
+      { id: '5', agent: 'C', status: 'running', t: 4 },
+      { id: '6', agent: 'C', status: 'completed', t: 5 },
+    ];
+
+    const { edges } = toGraph(events);
+    expect(edges).toEqual([
+      { id: 'A-B', source: 'A', target: 'B' },
+      { id: 'B-C', source: 'B', target: 'C' },
+    ]);
+  });
+
+  it('creates edges from explicit dependencies when present', () => {
+    const events: AgentEvent[] = [
+      { id: '1', agent: 'A', status: 'running', t: 0 },
+      { id: '2', agent: 'A', status: 'completed', t: 1 },
+      { id: '3', agent: 'B', status: 'running', t: 2, meta: { dependsOn: 'A' } },
+      { id: '4', agent: 'B', status: 'completed', t: 3 },
+      { id: '5', agent: 'C', status: 'running', t: 4, meta: { dependsOn: ['A', 'B'] } },
+      { id: '6', agent: 'C', status: 'completed', t: 5 },
+    ];
+
+    const { edges } = toGraph(events);
+    expect(edges).toEqual([
+      { id: 'A-B', source: 'A', target: 'B' },
+      { id: 'A-C', source: 'A', target: 'C' },
+      { id: 'B-C', source: 'B', target: 'C' },
+    ]);
+  });
+});

--- a/components/universal/mapAgentEventsToGraph.ts
+++ b/components/universal/mapAgentEventsToGraph.ts
@@ -1,16 +1,57 @@
 import type { AgentEvent } from "./UniversalAgentInterface";
 import type { FlowNode, FlowEdge } from "@/lib/dashboard/useFlowVisualizer";
 
+/**
+ * Translate agent lifecycle events to graph nodes/edges.
+ *
+ * Edges are determined either from explicit dependencies declared on the event
+ * metadata (`meta.dependsOn`) or, if absent, by the order in which agents begin
+ * execution. This mirrors the runtime behavior where agents are executed in the
+ * configured flow order unless specific dependencies override it.
+ */
 export function toGraph(events: AgentEvent[]): { nodes: FlowNode[]; edges: FlowEdge[] } {
   const nodeMap = new Map<string, FlowNode>();
-  events.forEach((e) => {
-    const existing = nodeMap.get(e.agent) || { id: e.agent as any, label: e.agent as any, status: "pending" as const };
+  const edges: FlowEdge[] = [];
+  const edgeSet = new Set<string>();
+  let lastRunning: string | null = null;
+
+  const sorted = [...events].sort((a, b) => a.t - b.t);
+
+  sorted.forEach((e) => {
+    const existing =
+      nodeMap.get(e.agent) || ({ id: e.agent as any, label: e.agent as any, status: "pending" as const } satisfies FlowNode);
+
     if (e.status === "running") existing.status = "running";
     if (e.status === "completed") existing.status = "completed";
     if (e.status === "error") existing.status = "errored";
+
     nodeMap.set(e.agent, existing);
+
+    if (e.status === "running") {
+      const dependsRaw = (e.meta as any)?.dependsOn ?? (e.meta as any)?.dependency ?? (e.meta as any)?.deps;
+      const depends: string[] | undefined =
+        Array.isArray(dependsRaw) ? dependsRaw : dependsRaw ? [dependsRaw] : undefined;
+
+      if (depends && depends.length > 0) {
+        depends.forEach((dep) => {
+          const id = `${dep}-${e.agent}`;
+          if (!edgeSet.has(id)) {
+            edges.push({ id, source: dep as any, target: e.agent as any });
+            edgeSet.add(id);
+          }
+        });
+      } else if (lastRunning && lastRunning !== e.agent) {
+        const id = `${lastRunning}-${e.agent}`;
+        if (!edgeSet.has(id)) {
+          edges.push({ id, source: lastRunning as any, target: e.agent as any });
+          edgeSet.add(id);
+        }
+      }
+
+      lastRunning = e.agent;
+    }
   });
+
   const nodes = Array.from(nodeMap.values());
-  const edges: FlowEdge[] = []; // TODO: derive from your flow registry if available
   return { nodes, edges };
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,7 @@ const config: import('jest').Config = {
     '<rootDir>/__tests__/AgentFlowVisualizer.test.tsx',
     '<rootDir>/__tests__/AgentFlowVisualizer.fallback.test.tsx',
     '<rootDir>/__tests__/devLogin.prod.test.ts',
+    '<rootDir>/__tests__/mapAgentEventsToGraph.test.ts',
   ],
   // TEMP quarantine while we fix contracts/e2e/a11y:
   testPathIgnorePatterns: ['<rootDir>/tests/', '<rootDir>/scripts/update-llms-log.test.js', '<rootDir>/lib/logUiEvent.test.js'],

--- a/llms.txt
+++ b/llms.txt
@@ -3841,3 +3841,12 @@ Files:
 - scripts/bootstrapDevEnv.ts (+9/-0)
 - stories/PredictionsPanel.stories.tsx (+1/-2)
 
+Timestamp: 2025-08-15T03:05:32.653Z
+Commit: 48fb323504f6ab04e900fc275aca0ae1fae021fd
+Author: Codex
+Message: feat: map agent events to graph edges
+Files:
+- __tests__/mapAgentEventsToGraph.test.ts (+39/-0)
+- components/universal/mapAgentEventsToGraph.ts (+44/-3)
+- jest.config.ts (+1/-0)
+


### PR DESCRIPTION
## Summary
- build edges between agent nodes using explicit dependencies or start order
- test graph mapping logic to ensure edges reflect execution sequence
- include new test in jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ea2f7bb48832390121f992405e928