### PR TITLE
Handle upcoming game fetch errors

### DIFF
--- a/__tests__/GameInsightsHero.test.tsx
+++ b/__tests__/GameInsightsHero.test.tsx
@@ -33,5 +33,15 @@ describe('GameInsightsHero', () => {
     fireEvent.click(screen.getByRole('button', { name: 'See agents in action' }));
     expect(onSeeAgents).toHaveBeenCalled();
   });
+
+  it('shows error state when fetch fails', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({ ok: false } as Response) as any;
+    render(<GameInsightsHero />);
+    expect(
+      await screen.findByText('Failed to load upcoming games.'),
+    ).toBeInTheDocument();
+    global.fetch = originalFetch;
+  });
 });
 

--- a/components/GameInsightsHero.tsx
+++ b/components/GameInsightsHero.tsx
@@ -17,14 +17,20 @@ export type GameInsightsHeroProps = {
   onSeeAgents?: () => void; // opens Matchup Insights with Advanced View
 };
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch upcoming games');
+  }
+  return res.json();
+};
 
 const GameInsightsHero: React.FC<GameInsightsHeroProps> = ({
   games: gamesProp,
   isLoading: loadingProp,
   onSeeAgents,
 }) => {
-  const { data, isLoading: swrLoading } = useSWR<GameInsightsHeroProps['games']>(
+  const { data, error, isLoading: swrLoading } = useSWR<GameInsightsHeroProps['games']>(
     gamesProp ? null : '/api/upcoming-games',
     fetcher,
     { revalidateOnFocus: false, dedupingInterval: 30000 },
@@ -45,6 +51,22 @@ const GameInsightsHero: React.FC<GameInsightsHeroProps> = ({
     return (
       <section aria-label="Upcoming games" className="p-4">
         <LoadingShimmer lines={6} lineClassName="h-16" />
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section aria-label="Upcoming games" className="p-4 text-center space-y-4">
+        <p>Failed to load upcoming games.</p>
+        {onSeeAgents && (
+          <button
+            onClick={onSeeAgents}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            See agents in action
+          </button>
+        )}
       </section>
     );
   }

--- a/llms.txt
+++ b/llms.txt
@@ -3841,3 +3841,11 @@ Files:
 - scripts/bootstrapDevEnv.ts (+9/-0)
 - stories/PredictionsPanel.stories.tsx (+1/-2)
 
+Timestamp: 2025-08-15T03:04:35.008Z
+Commit: de4a659c68b07cac2070c72b0968a503a3d3354a
+Author: Codex
+Message: Handle fetch errors in GameInsightsHero
+Files:
+- __tests__/GameInsightsHero.test.tsx (+10/-0)
+- components/GameInsightsHero.tsx (+24/-2)
+


### PR DESCRIPTION
## Summary
- Throw descriptive error when fetching upcoming games fails
- Show error fallback in `GameInsightsHero`
- Test error state for failed data retrieval

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea2fce998832391751c6d7a09b58e