### PR TITLE
refactor: load theme script externally

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -80,6 +80,10 @@ const nextConfig = {
         source: '/(.*)',
         headers: [
           {
+            key: 'Content-Security-Policy',
+            value: "script-src 'self';",
+          },
+          {
             key: 'X-DNS-Prefetch-Control',
             value: 'on',
           },

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,25 +1,11 @@
 import { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 
 export default function Document() {
   return (
     <Html>
       <Head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                try {
-                  var storageKey = 'theme';
-                  var stored = localStorage.getItem(storageKey);
-                  var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                  if (stored === 'dark' || (!stored && prefersDark)) {
-                    document.documentElement.classList.add('dark');
-                  }
-                } catch (e) {}
-              })();
-            `,
-          }}
-        />
+        <Script src="/theme-init.js" strategy="beforeInteractive" />
       </Head>
       <body>
         <Main />

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,10 @@
+(function() {
+  try {
+    var storageKey = 'theme';
+    var stored = localStorage.getItem(storageKey);
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (stored === 'dark' || (!stored && prefersDark)) {
+      document.documentElement.classList.add('dark');
+    }
+  } catch (e) {}
+})();


### PR DESCRIPTION
## Summary
- move inline theme initialization script to `public/theme-init.js`
- load theme script early via `next/script`
- add Content-Security-Policy header permitting local scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ea2fe42f48323a6b6e094fa8620fa