### PR TITLE
chore: split test typechecking

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -3869,3 +3869,19 @@ Files:
 - tsconfig.json (+22/-5)
 
 
+Timestamp: 2025-08-15T03:33:19.808Z
+Commit: c9c74bd8b1309028ae0d283e645ce06c5b1c7836
+Author: Codex
+Message: chore: split test typechecking
+Files:
+- package.json (+1/-0)
+- tsconfig.json (+3/-3)
+
+Timestamp: 2025-08-15T03:33:26.083Z
+Commit: 1af1f2526324d412ba1c2badf478cbc8d3ba06e3
+Author: Codex
+Message: chore: split test typechecking
+Files:
+- llms.txt (+8/-0)
+- tsconfig.test.json (+4/-0)
+

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepare": "husky",
     "lint": "next lint",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.test.json --noEmit",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "doctor": "npm run lint && npm run typecheck",
     "check": "npm run doctor",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,12 +50,12 @@
     "pages",
     "scripts",
     "hooks",
-    "__tests__",
-    "tests",
     "jest.setup.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "__tests__/**/*",
+    "tests/**/*"
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["__tests__/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- exclude tests from main TS project
- add standalone tsconfig for tests
- expose typecheck:tests npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ea722bdf08323b9830ee5a5bb1387