### PR TITLE
feat: normalize odds and tighten types

### DIFF
--- a/components/AgentCard.tsx
+++ b/components/AgentCard.tsx
@@ -63,11 +63,12 @@ const AgentCard: React.FC<Props> = ({
     );
   }
 
-  const scorePct = Math.round(result.score * 100);
+  const score = result?.score ?? 0;
+  const scorePct = Math.round(score * 100);
   const glowColor =
-    result.score > 0.66
+    score > 0.66
       ? 'rgba(34,197,94,0.6)'
-      : result.score > 0.33
+      : score > 0.33
       ? 'rgba(250,204,21,0.6)'
       : 'rgba(239,68,68,0.6)';
   const Icon = (agentIcons[name] || Info) as LucideIcon;
@@ -80,7 +81,7 @@ const AgentCard: React.FC<Props> = ({
     >
       <div className="flex items-start justify-between">
         <ReasoningDisclosure
-          reason={result.reason}
+          reason={result.reason ?? ''}
           className="flex items-center gap-2 font-medium cursor-pointer"
           tabIndex={0}
           onMouseEnter={() =>

--- a/components/AgentComparePanel.tsx
+++ b/components/AgentComparePanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import AgentCard from './AgentCard';
 import { AgentOutputs, AgentName } from '@/lib/types';
+import { getAgent, AgentKey } from '@/lib/types/compat';
 
 interface Props {
   agents: AgentOutputs;
@@ -9,8 +10,13 @@ interface Props {
 const AgentComparePanel: React.FC<Props> = ({ agents }) => {
   return (
     <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
-      {(Object.keys(agents) as AgentName[]).map((name) => (
-        <AgentCard key={name} name={name} result={agents[name]} showTeam />
+      {(Object.keys(agents) as AgentKey[]).map((name) => (
+        <AgentCard
+          key={name}
+          name={name as AgentName}
+          result={getAgent(agents, name)}
+          showTeam
+        />
       ))}
     </div>
   );

--- a/components/AgentDebugPanel.tsx
+++ b/components/AgentDebugPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ScoreBar from './ScoreBar';
 import AgentTooltip from './AgentTooltip';
 import { AgentOutputs } from '@/lib/types';
+import { getAgent, AgentKey } from '@/lib/types/compat';
 import { registry as agentRegistry } from '@/lib/agents/registry';
 import { formatAgentName } from '@/lib/utils';
 
@@ -20,7 +21,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
     <div>
       <div className="space-y-4 sm:hidden">
         {agentRegistry.map(({ name, weight, type }) => {
-          const result = agents[name];
+          const result = getAgent(agents, name as AgentKey);
           const display = formatAgentName(name);
           if (!result) {
             return (
@@ -30,8 +31,9 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               </div>
             );
           }
-          const scorePct = result.score * 100;
-          const weighted = result.score * weight;
+          const score = result?.score ?? 0;
+          const scorePct = score * 100;
+          const weighted = score * weight;
           const weightedPct = weighted * 100;
           const badge = typeBadge[type] || type;
 
@@ -49,7 +51,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               <div className="mt-2">
                 <ScoreBar percent={scorePct} className="w-full" />
                 <div className="mt-1 font-mono text-sm">
-                  {result.score.toFixed(2)} ({Math.round(scorePct)}%)
+                  {score.toFixed(2)} ({Math.round(scorePct)}%)
                 </div>
               </div>
               <div className="mt-2">
@@ -67,7 +69,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
               </div>
               {result.warnings && result.warnings.length > 0 && (
                 <ul className="mt-2 text-xs text-yellow-700 list-disc pl-4">
-                  {result.warnings.map((w, i) => (
+                  {result.warnings.map((w: string, i: number) => (
                     <li key={i}>{w}</li>
                   ))}
                 </ul>
@@ -89,7 +91,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
           </thead>
           <tbody>
             {agentRegistry.map(({ name, weight, type }) => {
-              const result = agents[name];
+              const result = getAgent(agents, name as AgentKey);
               const display = formatAgentName(name);
               if (!result) {
                 return (
@@ -101,8 +103,9 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
                   </tr>
                 );
               }
-              const scorePct = result.score * 100;
-              const weighted = result.score * weight;
+              const score = result?.score ?? 0;
+              const scorePct = score * 100;
+              const weighted = score * weight;
               const weightedPct = weighted * 100;
               const badge = typeBadge[type] || type;
 
@@ -116,7 +119,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
                     <div className="flex items-center gap-2">
                       <ScoreBar percent={scorePct} />
                       <span className="w-20 text-right font-mono">
-                        {result.score.toFixed(2)} ({Math.round(scorePct)}%)
+                        {score.toFixed(2)} ({Math.round(scorePct)}%)
                       </span>
                     </div>
                   </td>
@@ -132,7 +135,7 @@ const AgentDebugPanel: React.FC<Props> = ({ agents }) => {
                     <div className="truncate" title={result.reason}>{result.reason}</div>
                     {result.warnings && result.warnings.length > 0 && (
                       <ul className="mt-1 list-disc pl-4 text-yellow-700">
-                        {result.warnings.map((w, i) => (
+                        {result.warnings.map((w: string, i: number) => (
                           <li key={i}>{w}</li>
                         ))}
                       </ul>

--- a/components/AgentRationalePanel.tsx
+++ b/components/AgentRationalePanel.tsx
@@ -29,7 +29,9 @@ const AgentRationalePanel: React.FC<Props> = ({ executions, winner }) => {
   const agents = executions.filter(
     (e) => e.result && e.name !== 'guardianAgent'
   ) as Required<AgentExecution>[];
-  const maxScore = Math.max(...agents.map((a) => a.result.score));
+  const maxScore = Math.max(
+    ...agents.map((a) => a.result.score ?? 0)
+  );
   const [expanded, setExpanded] = useState<Record<AgentName, boolean>>({});
 
   const toggle = (name: AgentName) =>
@@ -38,10 +40,11 @@ const AgentRationalePanel: React.FC<Props> = ({ executions, winner }) => {
   return (
     <div className="flex flex-col gap-2">
       {agents.map(({ name, result }) => {
-        const disagree = result.team !== winner;
-        const delta = Math.round((maxScore - result.score) * 100);
+        const score = result?.score ?? 0;
+        const disagree = result?.team !== winner;
+        const delta = Math.round((maxScore - score) * 100);
         const Icon = (agentIcons[name] || Info) as LucideIcon;
-        const reason = result.reason;
+        const reason = result?.reason ?? '';
         const isLong = reason.length > 200;
         const showFull = expanded[name];
         const displayText = showFull ? reason : reason.slice(0, 200);
@@ -58,9 +61,9 @@ const AgentRationalePanel: React.FC<Props> = ({ executions, winner }) => {
               <span className="flex items-center gap-2">
                 <Icon className="w-4 h-4" /> {formatAgentName(name)}
               </span>
-              <span className="px-2 py-0.5 bg-slate-700 rounded-full text-xs">
-                {Math.round(result.score * 100)}%
-              </span>
+                <span className="px-2 py-0.5 bg-slate-700 rounded-full text-xs">
+                  {Math.round(score * 100)}%
+                </span>
             </div>
             <p className="text-xs text-gray-300 mt-1">
               {displayText}

--- a/components/AgentSummary.tsx
+++ b/components/AgentSummary.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import AgentCard from './AgentCard';
 import { AgentOutputs } from '@/lib/types';
 import { registry as agentRegistry } from '@/lib/agents/registry';
+import { getAgent, AgentKey } from '@/lib/types/compat';
 
 interface Props {
   agents: Partial<AgentOutputs>;
@@ -11,7 +12,7 @@ const AgentSummary: React.FC<Props> = ({ agents }) => {
   return (
     <ul className="mt-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {agentRegistry.map(({ name, weight }) => {
-        const result = agents[name];
+        const result = getAgent(agents, name as AgentKey);
         return (
           <li key={name} className="list-none">
             <AgentCard name={name} result={result} weight={weight} showWeight />

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -6,6 +6,7 @@ import AgentSummary from './AgentSummary';
 import AgentComparePanel from './AgentComparePanel';
 import ScoreBar from './ScoreBar';
 import { AgentOutputs } from '@/lib/types';
+import { getAgent, AgentKey } from '@/lib/types/compat';
 import { getContribution, formatAgentName } from '@/lib/utils';
 import { registry as agentRegistry } from '@/lib/agents/registry';
 import { getAccuracyHistory } from '@/lib/accuracy';
@@ -30,7 +31,7 @@ const ConfidenceBreakdown: React.FC<BreakdownProps> = ({ agents, total }) => {
       </div>
       <ul className="space-y-2 text-sm">
         {agentRegistry.map(({ name, weight }) => {
-          const score = agents[name].score;
+          const score = getAgent(agents, name as AgentKey)?.score ?? 0;
           const contribution = getContribution(score, weight);
           const contributionPct = total > 0 ? (contribution / total) * 100 : 0;
           const display = formatAgentName(name);

--- a/components/PredictionsPanel.tsx
+++ b/components/PredictionsPanel.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import AgentNodeGraph from './AgentNodeGraph';
-import type { AgentOutputs, AgentLifecycle, PickSummary, AgentName } from '@/lib/types';
+import type {
+  AgentOutputs,
+  AgentLifecycle,
+  PickSummary,
+  AgentName,
+  Reason,
+} from '@/lib/types';
 import type { FlowNode, FlowEdge } from '@/lib/dashboard/useFlowVisualizer';
 import { z } from 'zod';
 
@@ -19,6 +25,7 @@ type PickWithReasoning = PickSummary & {
   reasoning?: unknown;
   betType?: string;
   impliedEdge?: number;
+  reasons?: Reason[];
 };
 
 const ConfidenceBar: React.FC<{ percent: number; label: string }> = ({
@@ -159,10 +166,10 @@ const PredictionsPanel: React.FC<Props> = ({
                 </div>
               )}
             </div>
-          ) : pick.topReasons && pick.topReasons.length > 0 ? (
+          ) : pick.reasons && pick.reasons.length > 0 ? (
             <ul className="mt-2 list-disc list-inside text-sm text-gray-300">
-              {pick.topReasons.map((r, i) => (
-                <li key={i}>{r}</li>
+              {pick.reasons.map((r: Reason, i: number) => (
+                <li key={i}>{r.explanation}</li>
               ))}
             </ul>
           ) : (
@@ -190,9 +197,6 @@ const PredictionsPanel: React.FC<Props> = ({
                 <div className="text-xs text-gray-400 flex flex-wrap gap-2">
                   {typeof result.weight !== 'undefined' && (
                     <span>Weight: {result.weight}</span>
-                  )}
-                  {typeof result.scoreTotal !== 'undefined' && (
-                    <span>Score: {result.scoreTotal.toFixed(2)}</span>
                   )}
                 </div>
                 {typeof result.confidenceEstimate !== 'undefined' && (

--- a/components/agents/AgentTrustScore.tsx
+++ b/components/agents/AgentTrustScore.tsx
@@ -3,7 +3,7 @@ import { AgentOutputs } from '@/lib/types';
 
 export const computeVariance = (agents: Partial<AgentOutputs>): number => {
   const scores = Object.values(agents)
-    .map((r) => r?.score)
+    .map((r) => r?.score ?? 0)
     .filter((s): s is number => typeof s === 'number');
   if (scores.length === 0) return 0;
   const mean = scores.reduce((sum, s) => sum + s, 0) / scores.length;

--- a/components/agents/DisagreementBadge.tsx
+++ b/components/agents/DisagreementBadge.tsx
@@ -7,8 +7,8 @@ export const computeDisagreement = (
   agents: Partial<AgentOutputs>
 ): number => {
   const picks = Object.values(agents)
-    .map((r) => r?.team)
-    .filter((t): t is string => typeof t === 'string');
+    .map((r) => r?.team ?? '')
+    .filter((t): t is string => t !== '');
   if (picks.length === 0) return 0;
   const counts = picks.reduce<Record<string, number>>((acc, team) => {
     acc[team] = (acc[team] || 0) + 1;

--- a/components/predictions/QuickMatchups.tsx
+++ b/components/predictions/QuickMatchups.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useUpcomingGames } from '@/hooks/useUpcomingGames';
 import { safeLocalDate } from '@/lib/normalize';
+import { toNormalizedOdds } from '@/lib/odds/normalize';
+import { toNum } from '@/lib/num';
 
 export default function QuickMatchups() {
   const { data, error, isLoading } = useUpcomingGames();
@@ -12,23 +14,26 @@ export default function QuickMatchups() {
   return (
     <div className="overflow-x-auto">
       <div className="flex gap-3 min-w-full">
-        {data.map(g => (
-          <article key={g.id} className="min-w-[260px] rounded-xl border p-4 hover:bg-accent/40 transition">
-            <div className="text-sm text-muted-foreground">{safeLocalDate(g.kickoff)}</div>
-            <div className="mt-1 font-medium">
-              {g.awayTeam || 'TBD'} @ {g.homeTeam || 'TBD'}
-            </div>
-            {g.odds && (g.odds.home != null || g.odds.away != null) && (
-              <div className="mt-2 text-sm">
-                {g.odds.home != null ? `Home: ${g.odds.home}` : 'Home: —'} • {g.odds.away != null ? `Away: ${g.odds.away}` : 'Away: —'}
-                {g.odds.draw != null ? ` • Draw: ${g.odds.draw}` : ''}
+        {data.map(g => {
+          const odds = toNormalizedOdds(g.odds);
+          return (
+            <article key={g.id} className="min-w-[260px] rounded-xl border p-4 hover:bg-accent/40 transition">
+              <div className="text-sm text-muted-foreground">{safeLocalDate(g.time)}</div>
+              <div className="mt-1 font-medium">
+                {g.awayTeam || 'TBD'} @ {g.homeTeam || 'TBD'}
               </div>
-            )}
-            <a href={`/predictions?gameId=${encodeURIComponent(g.id)}`} className="mt-3 inline-flex text-sm text-primary hover:underline">
-              View insights →
-            </a>
-          </article>
-        ))}
+              {(odds.homeSpread !== undefined || odds.awaySpread !== undefined || odds.total !== undefined) && (
+                <div className="mt-2 text-sm">
+                  Home: {odds.homeSpread !== undefined ? toNum(odds.homeSpread) : '—'} • Away: {odds.awaySpread !== undefined ? toNum(odds.awaySpread) : '—'}
+                  {odds.total !== undefined ? ` • Total: ${toNum(odds.total)}` : ''}
+                </div>
+              )}
+              <a href={`/predictions?gameId=${encodeURIComponent(g.id)}`} className="mt-3 inline-flex text-sm text-primary hover:underline">
+                View insights →
+              </a>
+            </article>
+          );
+        })}
       </div>
     </div>
   );

--- a/hooks/useUpcomingGames.ts
+++ b/hooks/useUpcomingGames.ts
@@ -2,10 +2,10 @@
 import useSWR from 'swr';
 import { apiGet } from '@/lib/api';
 import { normalizeUpcomingGames } from '@/lib/normalize';
-import type { UpcomingGame } from '@/types/game';
+import type { Matchup } from '@/lib/types';
 
 export function useUpcomingGames(league?: string) {
-  const { data, error, isLoading } = useSWR<UpcomingGame[]>(
+  const { data, error, isLoading } = useSWR<Matchup[]>(
     '/api/upcoming-games',
     async () => {
       const raw = await apiGet<any>('/api/upcoming-games');

--- a/lib/accuracy.ts
+++ b/lib/accuracy.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabaseClient';
 import { registry as agentRegistry } from './agents/registry';
 import type { AgentName, AgentOutputs } from './types';
+import { getAgent, AgentKey } from './types/compat';
 
 interface MatchupRow {
   agents: AgentOutputs;
@@ -56,7 +57,7 @@ export async function recomputeAccuracy() {
 
     // Agent stats
     agentRegistry.forEach(({ name }) => {
-      const pick = row.agents?.[name]?.team;
+      const pick = getAgent(row.agents || {}, name as AgentKey)?.team;
       if (!pick) return;
       if (pick === actual) {
         agentTallies[name as AgentName].wins += 1;

--- a/lib/agents/injuryScout.ts
+++ b/lib/agents/injuryScout.ts
@@ -1,4 +1,4 @@
-import { AgentResult, Matchup } from '@/types';
+import { AgentResult, Matchup } from '../types';
 
 import { pseudoMetric, logAgentReflection } from './utils';
 import { AgentReflection } from '../../types/AgentReflection';
@@ -34,7 +34,7 @@ export const injuryScout = async (matchup: Matchup): Promise<AgentResult> => {
   await logAgentReflection('injuryScout', reflection);
 
   return {
-    name: 'InjuryScout', // Added required property
+    name: 'injuryScout',
     team: favored,
     score,
     reason,

--- a/lib/agents/lifecycleAgent.ts
+++ b/lib/agents/lifecycleAgent.ts
@@ -12,10 +12,10 @@ export function lifecycleAgent(
   if (!matchup) return;
   try {
     const agents: AgentOutputs = {} as AgentOutputs;
+    const duration = 'durationMs' in event ? event.durationMs ?? 0 : 0;
     const pick: PickSummary = {
       winner: event.name,
-      confidence: event.durationMs ?? 0,
-      topReasons: [`status: ${event.status}`],
+      confidence: duration,
     };
     logMatchup(matchup, agents, pick, null, 'lifecycle');
   } catch (err) {

--- a/lib/agents/loadAgents.ts
+++ b/lib/agents/loadAgents.ts
@@ -1,6 +1,9 @@
-import type { Agent } from './registry';
+import type { AgentMeta } from './registry';
 import { registry } from './registry';
-import type { AgentFunc } from '../types';
+import type { AgentResult, Matchup } from '../types';
+
+type AgentFunc = (matchup: Matchup) => Promise<AgentResult>;
+type Agent = AgentMeta & { run: AgentFunc };
 
 export async function loadAgents(): Promise<Agent[]> {
   const [{ injuryScout }, { lineWatcher }, { statCruncher }, { trendsAgent }, { guardianAgent }] = await Promise.all([
@@ -16,7 +19,7 @@ export async function loadAgents(): Promise<Agent[]> {
     lineWatcher,
     statCruncher,
     trendsAgent,
-    guardianAgent,
+    guardianAgent: guardianAgent as unknown as AgentFunc,
   };
 
   return registry.map((meta) => ({

--- a/lib/agents/statCruncher.ts
+++ b/lib/agents/statCruncher.ts
@@ -31,6 +31,7 @@ export const statCruncher = async (matchup: Matchup): Promise<AgentResult> => {
   await logAgentReflection('statCruncher', reflection);
 
   return {
+    name: 'statCruncher',
     team: favored,
     score,
     reason,

--- a/lib/agents/trendsAgent.ts
+++ b/lib/agents/trendsAgent.ts
@@ -70,6 +70,7 @@ export const trendsAgent = async (_: Matchup): Promise<TrendsResult> => {
   await logAgentReflection('trendsAgent', reflection);
 
   return {
+    name: 'trendsAgent',
     team: 'N/A',
     score: 0,
     reason: 'Trends analysis',

--- a/lib/dashboard/useFlowVisualizer.ts
+++ b/lib/dashboard/useFlowVisualizer.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import type { AgentLifecycle, AgentName } from '../types';
+import { toNum } from '../num';
 
 export type NodeStatus = 'pending' | 'running' | 'completed' | 'errored';
 
@@ -56,9 +57,9 @@ export default function useFlowVisualizer() {
 
         if (event.status === 'started') {
           updated.status = 'running';
-          updated.startedAt = event.startedAt;
-          if (flowStartRef.current === null || event.startedAt < flowStartRef.current) {
-            flowStartRef.current = event.startedAt;
+          updated.startedAt = toNum(event.startedAt);
+          if (flowStartRef.current === null || toNum(event.startedAt) < flowStartRef.current) {
+            flowStartRef.current = toNum(event.startedAt);
           }
           if (lastNodeRef.current) {
             const from = lastNodeRef.current;
@@ -74,12 +75,12 @@ export default function useFlowVisualizer() {
           lastNodeRef.current = event.name;
         } else if (event.status === 'completed') {
           updated.status = 'completed';
-          updated.endedAt = event.endedAt;
-          updated.durationMs = event.durationMs;
+          updated.endedAt = toNum(event.endedAt);
+          updated.durationMs = toNum(event.durationMs);
         } else if (event.status === 'errored') {
           updated.status = 'errored';
-          updated.endedAt = event.endedAt;
-          updated.durationMs = event.durationMs;
+          updated.endedAt = toNum(event.endedAt);
+          updated.durationMs = toNum(event.durationMs);
         }
 
         return { ...prev, [event.name]: updated };
@@ -94,7 +95,7 @@ export default function useFlowVisualizer() {
           ...prev,
           [event.name]: {
             status: event.status,
-            durationMs: event.durationMs,
+            durationMs: toNum(event.durationMs),
           },
         };
       });
@@ -103,7 +104,7 @@ export default function useFlowVisualizer() {
   );
 
   const nodeList = Object.values(nodes).sort(
-    (a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0)
+    (a, b) => toNum(a.startedAt) - toNum(b.startedAt)
   );
 
   return {

--- a/lib/data/schedule.mlb.ts
+++ b/lib/data/schedule.mlb.ts
@@ -19,6 +19,7 @@ const MlbScheduleSchema = z.array(MlbGameSchema);
 export function normalizeMlbSchedule(data: unknown): Matchup[] {
   const games = MlbScheduleSchema.parse(data);
   return games.map((g) => ({
+    id: `mlb-${g.id}`,
     homeTeam: g.home,
     awayTeam: g.away,
     time: g.commence_time,

--- a/lib/mock/agentOutput.ts
+++ b/lib/mock/agentOutput.ts
@@ -1,43 +1,55 @@
-import { MatchupWithPick } from '../types';
+import { MatchupWithPick, Reason } from '../types';
+
+const mkReason = (text: string): Reason => ({
+  agent: 'mock',
+  explanation: text,
+  weight: 1,
+});
 
 export const mockMatchups: MatchupWithPick[] = [
   {
+    id: 'mock-1',
+    gameId: 'mock-1',
     homeTeam: 'Patriots',
     awayTeam: 'Jets',
     time: '',
     league: '',
-    pick: 'Patriots',
+    winner: 'Patriots',
     confidence: 0.72,
     reasons: [
       'Jets missing starting QB',
       'Patriots defense ranks top 5 vs run',
       'Line moved 2 points toward NE',
-    ],
+    ].map(mkReason),
   },
   {
+    id: 'mock-2',
+    gameId: 'mock-2',
     homeTeam: 'Cowboys',
     awayTeam: 'Eagles',
     time: '',
     league: '',
-    pick: 'Eagles',
+    winner: 'Eagles',
     confidence: 0.61,
     reasons: [
       'Eagles healthier on offensive line',
       'Public heavy on Cowboys, line stagnant',
       'Stat models favor PHI by 1.5',
-    ],
+    ].map(mkReason),
   },
   {
+    id: 'mock-3',
+    gameId: 'mock-3',
     homeTeam: 'Packers',
     awayTeam: 'Bears',
     time: '',
     league: '',
-    pick: 'Packers',
+    winner: 'Packers',
     confidence: 0.67,
     reasons: [
       'Bears star RB questionable with ankle',
       'Green Bay -3 to -4.5 line movement',
       'QB efficiency edge to Packers',
-    ],
+    ].map(mkReason),
   },
 ];

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -1,4 +1,4 @@
-import type { UpcomingGame } from "@/types/game";
+import type { Matchup } from "@/lib/types";
 
 function toIso(dateStr?: string | null, timeStr?: string | null, epochSec?: number | null): string | null {
   // Prefer epoch seconds if present
@@ -23,11 +23,11 @@ function toIso(dateStr?: string | null, timeStr?: string | null, epochSec?: numb
   return null;
 }
 
-export function normalizeUpcomingGames(raw: any): UpcomingGame[] {
+export function normalizeUpcomingGames(raw: any): Matchup[] {
   const list: any[] = Array.isArray(raw?.data) ? raw.data : Array.isArray(raw) ? raw : [];
   
   return list
-    .map((game): UpcomingGame | null => {
+    .map((game): Matchup | null => {
       try {
         const kickoff = toIso(
           game.dateEvent || game.event_date || game.date,
@@ -40,22 +40,21 @@ export function normalizeUpcomingGames(raw: any): UpcomingGame[] {
           league: game.league || game.competition || game.sport || 'Unknown',
           homeTeam: game.homeTeam || game.home_team || game.strHomeTeam || game.home || game.teamHome || '',
           awayTeam: game.awayTeam || game.away_team || game.strAwayTeam || game.away || game.teamAway || '',
-          status: 'upcoming',
           kickoff: kickoff || undefined,
           gameId: game.id || game.gameId || game.idEvent || game.idGame || game.event_id || `game-${Date.now()}`,
-          time: kickoff || undefined,
+          time: kickoff || '',
           odds: {
             homeSpread: typeof game.homeSpread === 'number' ? game.homeSpread : undefined,
             awaySpread: typeof game.awaySpread === 'number' ? game.awaySpread : undefined,
             total: typeof game.total === 'number' ? game.total : undefined,
-          }
+          },
         };
       } catch (e) {
         console.error('Failed to normalize game:', e);
         return null;
       }
     })
-    .filter((game): game is UpcomingGame => game !== null);
+    .filter((game): game is Matchup => game !== null);
 }
 
 export function safeLocalDate(iso: string | null | undefined): string {

--- a/lib/num.ts
+++ b/lib/num.ts
@@ -1,0 +1,2 @@
+export const toNum = (v: string | number | undefined | null) =>
+  typeof v === "string" ? Number(v) : v ?? 0;

--- a/lib/odds/normalize.ts
+++ b/lib/odds/normalize.ts
@@ -1,0 +1,8 @@
+export type NormalizedOdds = { homeSpread?: number; awaySpread?: number; total?: number };
+export function toNormalizedOdds(v: any): NormalizedOdds {
+  return {
+    homeSpread: v?.spread?.home ?? v?.homeSpread,
+    awaySpread: v?.spread?.away ?? v?.awaySpread,
+    total: v?.total ?? v?.overUnder,
+  };
+}

--- a/lib/types/compat.ts
+++ b/lib/types/compat.ts
@@ -1,0 +1,5 @@
+import type { AgentOutputs } from "../types";
+export type AgentKey = keyof AgentOutputs;
+export function getAgent<T extends AgentKey>(o: Partial<AgentOutputs>, k: T) {
+  return o[k];
+}

--- a/lib/utils/fallbackMatchups.ts
+++ b/lib/utils/fallbackMatchups.ts
@@ -3,6 +3,8 @@ import { Matchup } from '../types';
 export function getFallbackMatchups(): (Matchup & { useFallback: true })[] {
   return [
     {
+      id: 'nfl-DAL-NYG-2025-09-07',
+      gameId: 'DAL-NYG-2025-09-07',
       homeTeam: 'Dallas Cowboys',
       awayTeam: 'New York Giants',
       time: '2025-09-07T20:20:00Z',

--- a/llms.txt
+++ b/llms.txt
@@ -3885,3 +3885,40 @@ Files:
 - llms.txt (+8/-0)
 - tsconfig.test.json (+4/-0)
 
+Timestamp: 2025-08-15T03:53:21.576Z
+Commit: 125eedb177e02adf1ff424ac4e35f3981f838253
+Author: Codex
+Message: feat: normalize odds and tighten types
+Files:
+- components/AgentCard.tsx (+5/-4)
+- components/AgentComparePanel.tsx (+8/-2)
+- components/AgentDebugPanel.tsx (+13/-10)
+- components/AgentRationalePanel.tsx (+10/-7)
+- components/AgentSummary.tsx (+2/-1)
+- components/MatchupCard.tsx (+2/-1)
+- components/PredictionsPanel.tsx (+11/-7)
+- components/agents/AgentTrustScore.tsx (+1/-1)
+- components/agents/DisagreementBadge.tsx (+2/-2)
+- components/predictions/MatchupInsights.tsx (+28/-18)
+- components/predictions/QuickMatchups.tsx (+21/-16)
+- hooks/useUpcomingGames.ts (+2/-2)
+- lib/accuracy.ts (+2/-1)
+- lib/agents/injuryScout.ts (+2/-2)
+- lib/agents/lifecycleAgent.ts (+2/-2)
+- lib/agents/lineWatcher.ts (+25/-21)
+- lib/agents/loadAgents.ts (+6/-3)
+- lib/agents/pickBot.ts (+12/-5)
+- lib/agents/statCruncher.ts (+1/-0)
+- lib/agents/trendsAgent.ts (+1/-0)
+- lib/dashboard/useFlowVisualizer.ts (+10/-9)
+- lib/data/schedule.mlb.ts (+1/-0)
+- lib/flow/runFlow.ts (+41/-23)
+- lib/mock/agentOutput.ts (+19/-7)
+- lib/normalize.ts (+6/-7)
+- lib/num.ts (+2/-0)
+- lib/odds/normalize.ts (+8/-0)
+- lib/types/compat.ts (+5/-0)
+- lib/utils/fallbackMatchups.ts (+2/-0)
+- pages/api/trends.ts (+11/-1)
+- types/agents.ts (+1/-4)
+

--- a/pages/api/trends.ts
+++ b/pages/api/trends.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { loadFlow } from '@/lib/flow/loadFlow';
 import { runFlow } from '@/lib/flow/runFlow';
+import type { Matchup } from '@/lib/types';
 
 export const config = {
   api: {
@@ -19,9 +20,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const flowName = typeof flowNameParam === 'string' ? flowNameParam : 'trends';
   const flow = await loadFlow(flowName);
 
+  const matchup: Matchup = {
+    id: 'trends-placeholder',
+    gameId: 'trends-placeholder',
+    homeTeam: '',
+    awayTeam: '',
+    time: new Date().toISOString(),
+    league: '',
+  };
+
   await runFlow(
     flow,
-    { homeTeam: '', awayTeam: '', time: '', league: '' },
+    matchup,
     ({ name, result, error }) => {
       if (!error && result) {
         res.write(`data: ${JSON.stringify({ type: 'agent', name, result })}\n\n`);

--- a/types/agents.ts
+++ b/types/agents.ts
@@ -27,9 +27,6 @@ export type AgentLifecycle =
   | { type: 'complete'; agent: AgentName; status: 'completed'; durationMs: number; endedAt: string } // Added properties
   | { type: 'error'; agent: AgentName; status: 'errored'; message: string; durationMs?: number; endedAt?: string }; // Added properties
 
-export interface AgentOutputs {
-  results: AgentResult[]; // Explicitly defined
-  lifecycle: AgentLifecycle[]; // Explicitly defined
-}
+export type AgentOutputs = Record<AgentName, AgentResult>;
 
 export type AgentFunc = (args: unknown) => Promise<AgentResult>;


### PR DESCRIPTION
## Summary
- normalize incoming odds model and add helper utilities
- harden agent data access and guard optional fields
- ensure mock data and schedule entries include stable IDs

## Testing
- `npm run validate-env`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Conflicting app and page file found)*

------
https://chatgpt.com/codex/tasks/task_e_689eaba6b6e88323826448ff2b254c51