### PR TITLE
chore: remove legacy root page

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -3922,3 +3922,10 @@ Files:
 - pages/api/trends.ts (+11/-1)
 - types/agents.ts (+1/-4)
 
+Timestamp: 2025-08-15T04:02:20.876Z
+Commit: 781d572ca731a02e6c121912c21b72fcb0398689
+Author: Codex
+Message: chore: remove legacy root page
+Files:
+- pages/index.tsx (+0/-9)
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,0 @@
-import UpcomingGamesHero from '@/components/UpcomingGamesHero';
-
-export default function HomePage() {
-  return (
-    <main className="container mx-auto p-6">
-      <UpcomingGamesHero />
-    </main>
-  );
-}


### PR DESCRIPTION
## Summary
- remove legacy root page to avoid app and pages router conflict

## Testing
- `npm test`
- `npm run validate-env && npm run typecheck && npm run lint && npx next build` *(fails: AccuracySnapshot.tsx needs `use client`; Module not found: Can't resolve 'os')*

------
https://chatgpt.com/codex/tasks/task_e_689eaffc870883238b86e70508ba627f