### PR TITLE
fix: mark AccuracySnapshot client & streamline env usage

### DIFF
--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
-import { createServiceClient } from '@/lib/supabaseClient';
+import { supabaseServer } from '@/lib/supabaseClient';
 import { ENV } from '@/lib/env';
 
 // Enable streaming responses
 export const dynamic = 'force-dynamic';
-export const runtime = 'edge';
 export const fetchCache = 'force-no-store';
 
 function streamResponse(readable: ReadableStream): Response {
@@ -32,7 +31,7 @@ export async function GET(request: Request) {
     return new NextResponse('Run ID is required', { status: 400 });
   }
 
-  const supabase = createServiceClient();
+  const supabase = supabaseServer();
 
   // Create a stream for SSE
   const stream = new TransformStream();
@@ -91,7 +90,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const supabase = createServiceClient();
+    const supabase = supabaseServer();
 
     // Log to Supabase
     const { error } = await supabase

--- a/components/AccuracySnapshot.tsx
+++ b/components/AccuracySnapshot.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from 'react';
 import { apiGet } from '@/lib/api';
 

--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -1,28 +1,27 @@
-import 'dotenv/config';
-
-function required(name, condition = true) {
-  const val = process.env[name];
-  if (!condition) return val ?? '';
-  if (!val) throw new Error(`[env] Missing required env: ${name}`);
-  return val;
-}
-
 const provider = process.env.SPORTS_API_PROVIDER ?? 'sportsdata';
 const tdbVersion = Number(process.env.THESPORTSDB_API_VERSION ?? '1');
 
-// In tests with TSDb v1, allow key=123. In prod/preview, require real key.
 const isTest = process.env.NODE_ENV === 'test' || process.env.CI === '1';
 const isProdLike = process.env.VERCEL === '1' || process.env.NODE_ENV === 'production';
 
-const apiKey =
-  provider === 'thesportsdb'
-    ? (isProdLike ? required('SPORTS_API_KEY') : (process.env.SPORTS_API_KEY ?? '123'))
-    : required('SPORTS_API_KEY', true);
+let apiKey = process.env.SPORTS_API_KEY;
+if (!apiKey && provider === 'thesportsdb' && !isProdLike) {
+  apiKey = '123';
+}
+if (isProdLike && !apiKey) {
+  throw new Error('[env] Missing required env: SPORTS_API_KEY');
+}
 
-export const Env = {
+export const ENV = {
+  NODE_ENV: process.env.NODE_ENV ?? 'development',
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '',
+  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY ?? '',
   provider,
   tdbVersion,
   apiKey,
   isTest,
   isProdLike,
 };
+
+export const Env = ENV;

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -1,5 +1,3 @@
-import 'dotenv/config';
-
 type Provider = 'sportsdata' | 'thesportsdb';
 
 const provider = (process.env.SPORTS_API_PROVIDER ?? 'sportsdata') as Provider;
@@ -16,13 +14,16 @@ if (isProdLike && !apiKey) {
   throw new Error('[env] Missing required env: SPORTS_API_KEY');
 }
 
-export const Env = {
+export const ENV = {
+  NODE_ENV: process.env.NODE_ENV ?? 'development',
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '',
+  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY ?? '',
   provider,
   tdbVersion,
   apiKey,
   isTest,
   isProdLike,
-  SUPABASE_URL: process.env.SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
-  SUPABASE_KEY: process.env.SUPABASE_KEY,
 };
+
+export const Env = ENV;

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,29 +1,18 @@
-import { createClient as _createClient } from '@supabase/supabase-js';
-import { Env } from '@/lib/config/env';
+import { createClient } from '@supabase/supabase-js';
+import { ENV } from '@/lib/config/env';
 
-/** Server/Edge-safe factory (no realtime assumptions) */
-export function createServiceClient() {
-  const url = Env.SUPABASE_URL!;
-  const key = Env.SUPABASE_SERVICE_ROLE_KEY || Env.SUPABASE_KEY || '';
-  return _createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
-}
+export const supabaseClient = createClient(
+  ENV.NEXT_PUBLIC_SUPABASE_URL,
+  ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  { auth: { persistSession: true } }
+);
 
-/** Browser client for UI features that need persisted session */
-export function createBrowserClient() {
-  if (typeof window === 'undefined') throw new Error('createBrowserClient() on server');
-  const url = Env.SUPABASE_URL!;
-  const key = Env.SUPABASE_KEY || '';
-  return _createClient(url, key, { auth: { autoRefreshToken: true, persistSession: true } });
-}
+export const supabaseServer = () =>
+  createClient(ENV.NEXT_PUBLIC_SUPABASE_URL, ENV.SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
 
-/** 🔁 Back-compat named export for tests & legacy code */
-export const supabase = (() => {
-  // Create a lightweight server instance for code paths/tests expecting `supabase`
-  try {
-    return createServiceClient();
-  } catch {
-    // In typecheck-only contexts without env, return a typed dummy
-    return _createClient('https://example.supabase.co', 'anon', { auth: { autoRefreshToken: false, persistSession: false } });
-  }
-})();
+export const createServiceClient = supabaseServer;
+
+export const supabase = supabaseServer();
 

--- a/lib/telemetry/logger.ts
+++ b/lib/telemetry/logger.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../supabaseClient';
+import { supabaseClient, supabaseServer } from '../supabaseClient';
 
 export interface TelemetryEvent {
   level: 'debug' | 'info' | 'warn' | 'error';
@@ -20,7 +20,9 @@ class ConsoleSink implements TelemetrySink {
 class SupabaseSink implements TelemetrySink {
   async log({ level, name, meta }: TelemetryEvent): Promise<void> {
     const entry = { level, name, meta, ts: new Date().toISOString() };
-    const { error } = await supabase.from('telemetry').insert(entry);
+    const client =
+      typeof window === 'undefined' ? supabaseServer() : supabaseClient;
+    const { error } = await client.from('telemetry').insert(entry);
     if (error) {
       console.error('Failed to log telemetry event', error);
     }

--- a/llms.txt
+++ b/llms.txt
@@ -3929,3 +3929,15 @@ Message: chore: remove legacy root page
 Files:
 - pages/index.tsx (+0/-9)
 
+Timestamp: 2025-08-15T04:13:23.932Z
+Commit: 6e185f17deba8dcbf804789117b8461bd037bcbc
+Author: Codex
+Message: feat: streamline env usage and client directives
+Files:
+- app/api/logs/route.ts (+3/-4)
+- components/AccuracySnapshot.tsx (+2/-0)
+- lib/config/env.js (+14/-15)
+- lib/config/env.ts (+7/-6)
+- lib/supabaseClient.ts (+14/-25)
+- lib/telemetry/logger.ts (+4/-2)
+


### PR DESCRIPTION
## Summary
- mark `AccuracySnapshot` as a client component
- drop runtime `dotenv` usage in env config and Supabase helpers
- add edge-safe Supabase client/server and update logger and logs route

## Testing
- `npm run validate-env`
- `npm run typecheck`
- `npm run lint`
- `npx next build` *(fails: Route "app/api/dev-login/route.ts" does not match the required types)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eb23c04f0832395117c8107a9bb8e