### PR TITLE
fix swr import and modernize dev login route

### DIFF
--- a/app/api/dev-login/route.ts
+++ b/app/api/dev-login/route.ts
@@ -2,27 +2,40 @@ import { NextResponse } from 'next/server';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
-// In production, export a no-op 404 to avoid evaluating dev logic/env.
-export const dynamic = 'force-static';
-export const fetchCache = 'force-no-store';
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function POST(req: Request) {
   if (!isDev) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
-  // Dev-only logic lives inside this block so it never runs/imports in prod.
-  const { getPublicSiteUrl } = await import('@/lib/env');
-  const site = getPublicSiteUrl();
-  return NextResponse.json({ ok: true, site });
+  try {
+    const body = await req.json().catch(() => ({}));
+    const { supabaseServer } = await import('@/lib/supabaseClient');
+    const supa = supabaseServer();
+    void supa;
+    void body;
+    return NextResponse.json({ ok: true, mode: 'dev' });
+  } catch (err: any) {
+    return NextResponse.json(
+      { error: err?.message ?? 'Internal error' },
+      { status: 500 },
+    );
+  }
 }
 
-export default async function handler(req: Request) {
+export async function GET(_req: Request) {
   if (!isDev) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
-  const { getPublicSiteUrl } = await import('@/lib/env');
-  const site = getPublicSiteUrl();
-  return NextResponse.json({ ok: true, site });
+  try {
+    return NextResponse.json({ ok: true, mode: 'dev' });
+  } catch (err: any) {
+    return NextResponse.json(
+      { error: err?.message ?? 'Internal error' },
+      { status: 500 },
+    );
+  }
 }

--- a/components/UpcomingGamesHero.tsx
+++ b/components/UpcomingGamesHero.tsx
@@ -1,6 +1,7 @@
+"use client";
+
 import React from 'react';
-// @ts-expect-error -- swr's types may not expose the named export yet
-import { useSWR } from 'swr';
+import useSWR from 'swr';
 import { apiGet } from '@/lib/api';
 import { logEvent } from '@/lib/telemetry/logger';
 

--- a/llms.txt
+++ b/llms.txt
@@ -3962,3 +3962,11 @@ Files:
 - README.md (+15/-1)
 
 
+Timestamp: 2025-08-15T04:47:49.955Z
+Commit: b9c5de3aec22c0c92072ab618d38fc6e0323f4af
+Author: Codex
+Message: refactor: fix swr import and dev login route
+Files:
+- app/api/dev-login/route.ts (+25/-12)
+- components/UpcomingGamesHero.tsx (+3/-2)
+


### PR DESCRIPTION
## Summary
- use default SWR import in UpcomingGamesHero
- rework dev-login API as App Router handlers

## Testing
- `npm test`
- `npm run validate-env`
- `npm run typecheck`
- `npm run lint`
- `npx next build` *(fails: Route "app/api/health/route.ts" does not match the required types of a Next.js Route: "handler" is not a valid field)*

------
https://chatgpt.com/codex/tasks/task_e_689eba2de14c8323a9823dc550ed0319