### PR TITLE
chore: clean up npm proxy configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+proxy=${NPM_CONFIG_PROXY}
+https-proxy=${NPM_CONFIG_HTTPS_PROXY}

--- a/llms.txt
+++ b/llms.txt
@@ -4002,3 +4002,12 @@ Files:
 - components/UpcomingGamesHero.tsx (+0/-4)
 - package.json (+3/-2)
 
+Timestamp: 2025-08-15T05:22:57.685Z
+Commit: 096d7a617e126ed83e0513a36d1977ccb93eeb7c
+Author: Codex
+Message: chore: remove deprecated npm proxy config
+Files:
+- .npmrc (+2/-0)
+- package.json (+1/-1)
+- vercel.json (+1/-1)
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "bootstrap:env": "node scripts/bootstrap-env.mjs",
     "dev": "npm run bootstrap:env && next dev",
-    "prebuild": "ts-node --project tsconfig.node.json scripts/checkRouteConflicts.ts && ts-node --project tsconfig.node.json scripts/checkMergeMarkers.ts && ts-node --project tsconfig.node.json scripts/assertClientSafeAgents.ts && ts-node --project tsconfig.node.json scripts/removeStaticParamsForDynamicRoutes.ts && npm run fix:revalidate && ts-node --project tsconfig.node.json scripts/guards/validateRevalidate.ts && npm run fix:aliases && npm run guard:aliases && npm run guard:swr && npm run setup:dev",
+    "prebuild": "npm config delete http-proxy || true && npm config delete https-proxy || true && ts-node --project tsconfig.node.json scripts/checkRouteConflicts.ts && ts-node --project tsconfig.node.json scripts/checkMergeMarkers.ts && ts-node --project tsconfig.node.json scripts/assertClientSafeAgents.ts && ts-node --project tsconfig.node.json scripts/removeStaticParamsForDynamicRoutes.ts && npm run fix:revalidate && ts-node --project tsconfig.node.json scripts/guards/validateRevalidate.ts && npm run fix:aliases && npm run guard:aliases && npm run guard:swr && npm run setup:dev",
     "build": "npm run validate-env && npm run check-conflicts && npm run typecheck && npm run lint && next build",
     "start": "npm run validate-env && next start",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand",

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "npm run validate-env && npm run typecheck && npm run lint && next build"
+  "buildCommand": "npm run build"
 }


### PR DESCRIPTION
## Summary
- ensure npm uses supported proxy keys
- remove http-proxy/https-proxy from npm config before builds
- let Vercel build via `npm run build`

## Testing
- `npm config list`
- `npm test`
- `npm run build` *(fails: Conflict markers found in llms.txt)*

------
https://chatgpt.com/codex/tasks/task_e_689ec2abe7448323bb3535796747a2bf