### PR TITLE
chore: normalize npm proxy config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,5 +4,3 @@ audit=false
 prefer-offline=true
 save-exact=true
 =======
-proxy=${NPM_CONFIG_PROXY}
-https-proxy=${NPM_CONFIG_HTTPS_PROXY}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fix:revalidate": "ts-node --project tsconfig.node.json scripts/codemods/enforceRevalidate.ts",
     "check-conflicts": "git ls-files -z | xargs -0 grep -nH -E '^(<<<<<<<|=======|>>>>>>>)' && echo 'Conflict markers found' && exit 2 || echo 'No conflict markers'",
     "normalize-proxy": "npm config delete http-proxy || true && npm config delete https-proxy || true && npm config delete HTTP-PROXY || true && npm config delete HTTPS-PROXY || true",
-    "preinstall": "npm run normalize-proxy",
+    "preinstall": "node scripts/npmProxyNormalize.mjs",
     "ci-install": "npm ci --prefer-offline --no-audit --no-fund"
   },
   "dependencies": {

--- a/scripts/npmProxyNormalize.mjs
+++ b/scripts/npmProxyNormalize.mjs
@@ -1,0 +1,19 @@
+import { execSync } from 'node:child_process';
+
+const { NPM_CONFIG_PROXY, NPM_CONFIG_HTTPS_PROXY } = process.env;
+const isUrl = v => typeof v === 'string' && /^https?:\/\//i.test(v);
+
+try {
+  if (isUrl(NPM_CONFIG_PROXY) && isUrl(NPM_CONFIG_HTTPS_PROXY)) {
+    execSync(`npm config set proxy "${NPM_CONFIG_PROXY}"`, { stdio: 'inherit' });
+    execSync(`npm config set https-proxy "${NPM_CONFIG_HTTPS_PROXY}"`, { stdio: 'inherit' });
+    console.log('npm proxy set');
+  } else {
+    execSync('npm config delete proxy || true', { stdio: 'inherit' });
+    execSync('npm config delete https-proxy || true', { stdio: 'inherit' });
+    console.log('npm proxy cleared');
+  }
+} catch {
+  // ignore errors
+}
+process.exit(0);


### PR DESCRIPTION
## Summary
- strip proxy fields from `.npmrc`
- run npm proxy normalize script before installs
- add script to set/delete npm proxy based on env

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci` *(fails: lock file's rimraf@3.0.2 does not satisfy rimraf@5.0.10)*

------
https://chatgpt.com/codex/tasks/task_e_689ec7e7377483239fa072d0860eac09