### PR TITLE
feat: add conflict marker guard

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -4025,3 +4025,17 @@ Files:
 
 
 
+Timestamp: 2025-08-15T05:44:24.826Z
+Commit: a1a1f9d7d3cc7941f01a7422e830dd4c2d8ee1ad
+Author: Codex
+Message: feat: add conflict marker guard
+Files:
+- package.json (+2/-2)
+
+Timestamp: 2025-08-15T05:44:34.038Z
+Commit: 60047d438dff44f4279012b79234108592f14764
+Author: Codex
+Message: chore: add conflict detection script
+Files:
+- scripts/checkConflicts.js (+34/-0)
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bootstrap:env": "node scripts/bootstrap-env.mjs",
     "dev": "npm run bootstrap:env && next dev",
     "prebuild": "npm config delete http-proxy || true && npm config delete https-proxy || true && ts-node --project tsconfig.node.json scripts/checkRouteConflicts.ts && ts-node --project tsconfig.node.json scripts/checkMergeMarkers.ts && ts-node --project tsconfig.node.json scripts/assertClientSafeAgents.ts && ts-node --project tsconfig.node.json scripts/removeStaticParamsForDynamicRoutes.ts && npm run fix:revalidate && ts-node --project tsconfig.node.json scripts/guards/validateRevalidate.ts && npm run fix:aliases && npm run guard:aliases && npm run guard:swr && npm run setup:dev",
-    "build": "npm run validate-env && npm run check-conflicts && npm run typecheck && npm run lint && next build",
+      "build": "npm run check-conflicts && npm run validate-env && npm run typecheck && npm run lint && next build",
     "start": "npm run validate-env && next start",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
     "fix:aliases": "ts-node --project tsconfig.node.json scripts/codemods/aliasImports.ts",
@@ -48,7 +48,7 @@
     "build-storybook": "storybook build",
     "setup:dev": "ts-node --project tsconfig.node.json scripts/bootstrapDevEnv.ts",
     "fix:revalidate": "ts-node --project tsconfig.node.json scripts/codemods/enforceRevalidate.ts",
-    "check-conflicts": "git ls-files -z | xargs -0 grep -nH -E '^(<<<<<<<|=======|>>>>>>>)' && echo 'Conflict markers found' && exit 2 || echo 'No conflict markers'",
+      "check-conflicts": "node scripts/checkConflicts.js",
     "normalize-proxy": "npm config delete http-proxy || true && npm config delete https-proxy || true && npm config delete HTTP-PROXY || true && npm config delete HTTPS-PROXY || true",
     "preinstall": "npm run normalize-proxy",
     "ci-install": "npm ci --prefer-offline --no-audit --no-fund"

--- a/scripts/checkConflicts.js
+++ b/scripts/checkConflicts.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const IGNORED_DIRS = new Set(['.git', '.next', 'node_modules', 'public', '.vercel']);
+const conflictRegex = /^<<<<<<<|^>>>>>>>/m;
+const root = process.cwd();
+
+function scanDir(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRS.has(entry.name)) {
+        scanDir(path.join(dir, entry.name));
+      }
+    } else if (entry.isFile()) {
+      const filePath = path.join(dir, entry.name);
+      let content;
+      try {
+        content = fs.readFileSync(filePath, 'utf8');
+      } catch {
+        continue;
+      }
+      if (content.includes('\u0000')) continue;
+      if (conflictRegex.test(content)) {
+        console.error(`Conflict marker found in ${path.relative(root, filePath)}`);
+        process.exit(1);
+      }
+    }
+  }
+}
+
+scanDir(root);
+process.exit(0);


### PR DESCRIPTION
## Summary
- add script to scan repo for merge conflict markers and exit on first hit
- run conflict guard before build

## Testing
- `npm run check-conflicts`
- `printf '<<<<<<<\n=======\n>>>>>>>\n' > tmp_conflict.txt && npm run check-conflicts` *(fails with path)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec7f702948323b2df5d7c047269ed