### PR TITLE
feat: add fallback upcoming games

### DIFF
--- a/app/api/upcoming-games/route.ts
+++ b/app/api/upcoming-games/route.ts
@@ -4,7 +4,6 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { ENV } from "@/lib/config/env";
 import { createClient } from "@supabase/supabase-js";
-// Optional: demo fallback if envs aren’t present
 import { getFallbackMatchups } from "@/lib/utils/fallbackMatchups";
 
 function makePublicClient() {
@@ -18,8 +17,8 @@ export async function GET() {
   try {
     const supa = makePublicClient();
     if (!supa) {
-      // No env available: don’t crash build; return safe empty/demo data
-      return NextResponse.json({ games: getFallbackMatchups?.() ?? [] }, { status: 200 });
+      // No env available: don’t crash build; return safe demo data
+      return NextResponse.json({ games: getFallbackMatchups() }, { status: 200 });
     }
 
     // TODO: replace with your actual query

--- a/lib/utils/fallbackMatchups.ts
+++ b/lib/utils/fallbackMatchups.ts
@@ -1,18 +1,37 @@
-import { Matchup } from '../types';
+export interface DemoMatchup {
+  id: string;
+  home: string;
+  away: string;
+  kickoff: string; // ISO timestamp
+  odds: {
+    home: number | null;
+    away: number | null;
+  } | null;
+}
 
-export function getFallbackMatchups(): (Matchup & { useFallback: true })[] {
+export function getFallbackMatchups(): DemoMatchup[] {
   return [
     {
-      id: 'nfl-DAL-NYG-2025-09-07',
-      gameId: 'DAL-NYG-2025-09-07',
-      homeTeam: 'Dallas Cowboys',
-      awayTeam: 'New York Giants',
-      time: '2025-09-07T20:20:00Z',
-      league: 'NFL',
-      homeLogo: 'https://a.espncdn.com/i/teamlogos/nfl/500/dal.png',
-      awayLogo: 'https://a.espncdn.com/i/teamlogos/nfl/500/nyg.png',
-      useFallback: true,
-      source: 'fallback',
+      id: 'demo-nfl-1',
+      home: 'Dallas Cowboys',
+      away: 'New York Giants',
+      kickoff: '2025-09-07T20:20:00Z',
+      odds: { home: null, away: null },
+    },
+    {
+      id: 'demo-nfl-2',
+      home: 'Green Bay Packers',
+      away: 'Chicago Bears',
+      kickoff: '2025-09-14T17:00:00Z',
+      odds: { home: null, away: null },
+    },
+    {
+      id: 'demo-nfl-3',
+      home: 'San Francisco 49ers',
+      away: 'Los Angeles Rams',
+      kickoff: '2025-09-21T20:25:00Z',
+      odds: { home: null, away: null },
     },
   ];
 }
+


### PR DESCRIPTION
## Summary
- add static demo matchups used when Supabase env vars are missing
- import fallback matchups in upcoming-games route and return when no Supabase client

## Testing
- `npm test` *(fails: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ec80b20a08323bca461671e5f8a37