### PR TITLE
chore: add cache headers to API routes

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -6,7 +6,13 @@ import { NextResponse } from "next/server";
 export async function GET() {
   return NextResponse.json(
     { ok: true, service: "edgepicks", status: "healthy" },
-    { status: 200 }
+    {
+      status: 200,
+      headers: {
+        "Cache-Control":
+          "public, max-age=15, s-maxage=60, stale-while-revalidate=300",
+      },
+    }
   );
 }
 

--- a/app/api/upcoming-games/route.ts
+++ b/app/api/upcoming-games/route.ts
@@ -7,6 +7,11 @@ import { createClient } from "@supabase/supabase-js";
 // Optional: demo fallback if envs aren’t present
 import { getFallbackMatchups } from "@/lib/utils/fallbackMatchups";
 
+const cacheHeaders = {
+  "Cache-Control":
+    "public, max-age=15, s-maxage=60, stale-while-revalidate=300",
+};
+
 function makePublicClient() {
   const url = ENV.NEXT_PUBLIC_SUPABASE_URL;
   const key = ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -19,19 +24,25 @@ export async function GET() {
     const supa = makePublicClient();
     if (!supa) {
       // No env available: don’t crash build; return safe empty/demo data
-      return NextResponse.json({ games: getFallbackMatchups?.() ?? [] }, { status: 200 });
+      return NextResponse.json(
+        { games: getFallbackMatchups?.() ?? [] },
+        { status: 200, headers: cacheHeaders }
+      );
     }
 
     // TODO: replace with your actual query
     // const { data, error } = await supa.from("upcoming_games").select("*").limit(100);
     // if (error) throw error;
-    // return NextResponse.json({ games: data ?? [] }, { status: 200 });
+    // return NextResponse.json({ games: data ?? [] }, { status: 200, headers: cacheHeaders });
 
     // Temporary safe response to avoid blocking while wiring the table:
-    return NextResponse.json({ games: [] }, { status: 200 });
+    return NextResponse.json({ games: [] }, { status: 200, headers: cacheHeaders });
   } catch (err: any) {
     // Never throw hard errors that break build; respond with 500 at runtime
-    return NextResponse.json({ error: err?.message ?? "Internal error" }, { status: 500 });
+    return NextResponse.json(
+      { error: err?.message ?? "Internal error" },
+      { status: 500, headers: cacheHeaders }
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared cache control headers to health API
- add cache control headers to upcoming-games API responses

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec812c244832382dbbebf823b116f