### PR TITLE
fix agent graph imports & types

### DIFF
--- a/lib/agents/demoGraph.ts
+++ b/lib/agents/demoGraph.ts
@@ -1,94 +1,89 @@
-export type AgentRole = 'scout' | 'cruncher' | 'arbiter' | 'explainer';
+import type { AgentNode, AgentLink } from "@/components/AgentFlowVisualizer";
 
-export interface AgentNode {
-  id: string;
-  role: AgentRole;
-  summary: string;
-  logs: string[];
-  lastEvent: string;
-  confidence: number;
-}
-
-export interface AgentLink {
-  source: string;
-  target: string;
-  type: 'data' | 'modeling' | 'arbitration' | 'explain';
-  confidence: number;
-  lastEvent: string;
-}
-
-export interface AgentGraph {
-  nodes: AgentNode[];
-  links: AgentLink[];
-}
-
-// Minimal demo graph used when no live data is available.
-export function getDemoGraph(): AgentGraph {
-  const nodes: AgentNode[] = [
+export const demoGraph: { nodes: AgentNode[]; links: AgentLink[] } = {
+  nodes: [
     {
-      id: 'injuryScout',
-      role: 'scout',
-      summary: 'Scans injury reports and roster depth for advantages.',
-      logs: ['Checked latest injury reports', 'Flagged questionable RB', 'No new injuries'],
-      lastEvent: 'Flagged questionable RB',
+      id: "injuryScout",
+      label: "Injury Scout",
+      role: "scout",
       confidence: 0.82,
-    },
+      summary: "Scans injury reports and roster depth for advantages.",
+      logs: [
+        "Checked latest injury reports",
+        "Flagged questionable RB",
+        "No new injuries",
+      ],
+      lastEvent: "Flagged questionable RB",
+    } as AgentNode,
     {
-      id: 'statCruncher',
-      role: 'cruncher',
-      summary: 'Crunches historical statistics for trends.',
-      logs: ['Parsed efficiency metrics', 'Calculated ELO deltas', 'Highlighted top offense'],
-      lastEvent: 'Highlighted top offense',
+      id: "statCruncher",
+      label: "Stat Cruncher",
+      role: "analyst",
       confidence: 0.74,
-    },
+      summary: "Crunches historical statistics for trends.",
+      logs: [
+        "Parsed efficiency metrics",
+        "Calculated ELO deltas",
+        "Highlighted top offense",
+      ],
+      lastEvent: "Highlighted top offense",
+    } as AgentNode,
     {
-      id: 'lineWatcher',
-      role: 'arbiter',
-      summary: 'Monitors betting line movement to flag sharp signals.',
-      logs: ['Watching line shift', 'Detected late steam', 'Market stabilised'],
-      lastEvent: 'Detected late steam',
+      id: "lineWatcher",
+      label: "Line Watcher",
+      role: "arbiter",
       confidence: 0.68,
-    },
+      summary: "Monitors betting line movement to flag sharp signals.",
+      logs: [
+        "Watching line shift",
+        "Detected late steam",
+        "Market stabilised",
+      ],
+      lastEvent: "Detected late steam",
+    } as AgentNode,
     {
-      id: 'trendsAgent',
-      role: 'explainer',
-      summary: 'Explains recent matchup trends and momentum.',
-      logs: ['Outlined win streak', 'Noted road performance', 'Summarised momentum'],
-      lastEvent: 'Summarised momentum',
+      id: "trendsAgent",
+      label: "Trends Agent",
+      role: "model",
       confidence: 0.65,
-    },
-  ];
-
-  const links: AgentLink[] = [
+      summary: "Explains recent matchup trends and momentum.",
+      logs: [
+        "Outlined win streak",
+        "Noted road performance",
+        "Summarised momentum",
+      ],
+      lastEvent: "Summarised momentum",
+    } as AgentNode,
+  ],
+  links: [
     {
-      source: 'injuryScout',
-      target: 'statCruncher',
-      type: 'data',
+      source: "injuryScout",
+      target: "statCruncher",
       confidence: 0.9,
-      lastEvent: 'Injury update sent',
-    },
+      type: "data",
+      lastEvent: "Injury update sent",
+    } as AgentLink,
     {
-      source: 'statCruncher',
-      target: 'lineWatcher',
-      type: 'modeling',
+      source: "statCruncher",
+      target: "lineWatcher",
       confidence: 0.76,
-      lastEvent: 'Stats packaged for line watch',
-    },
+      type: "modeling",
+      lastEvent: "Stats packaged for line watch",
+    } as AgentLink,
     {
-      source: 'lineWatcher',
-      target: 'trendsAgent',
-      type: 'arbitration',
+      source: "lineWatcher",
+      target: "trendsAgent",
       confidence: 0.6,
-      lastEvent: 'Line swing analysed',
-    },
+      type: "arbitration",
+      lastEvent: "Line swing analysed",
+    } as AgentLink,
     {
-      source: 'trendsAgent',
-      target: 'injuryScout',
-      type: 'explain',
+      source: "trendsAgent",
+      target: "injuryScout",
       confidence: 0.7,
-      lastEvent: 'Trend context shared',
-    },
-  ];
+      type: "explain",
+      lastEvent: "Trend context shared",
+    } as AgentLink,
+  ],
+};
 
-  return { nodes, links };
-}

--- a/llms.txt
+++ b/llms.txt
@@ -4079,3 +4079,11 @@ Files:
 - app/{favicon.ico/route.tsx => icon.tsx} (+4/-12)
 - app/layout.tsx (+4/-4)
 
+Timestamp: 2025-08-15T07:47:43.057Z
+Commit: 1f09cfe7c1dda5f1989e316288aec1a4a0fbb71d
+Author: Codex
+Message: fix agent graph imports & types
+Files:
+- components/AgentFlowVisualizer.tsx (+72/-16)
+- lib/agents/demoGraph.ts (+71/-76)
+


### PR DESCRIPTION
## Summary
- dynamically import ForceGraph2D and add strict AgentNode/AgentLink types
- type-safe demo graph data aligned with visualizer interfaces

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ee2e51b5883238255c2e0aba2075d