### PR TITLE
kickoff-public-beta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
 # Non-secret defaults for local development and CI
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=changeme
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+BETA_COPY_ENABLED=1
+
 SUPABASE_URL=http://localhost
 SUPABASE_ANON_KEY=test
 # Backwards compatibility
 SUPABASE_KEY=test
-
 
 # Provider: 'sportsdata' | 'thesportsdb'
 SPORTS_API_PROVIDER=thesportsdb

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,2 +1,11 @@
 # Strongly recommended to set explicitly for canonical URLs:
 NEXT_PUBLIC_SITE_URL=https://your-domain.com
+NEXTAUTH_URL=https://your-domain.com
+NEXTAUTH_SECRET=prod-secret
+BETA_COPY_ENABLED=1
+
+# Provider: 'sportsdata' | 'thesportsdb'
+SPORTS_API_PROVIDER=thesportsdb
+# Shared logical key
+SPORTS_API_KEY=prod-key
+THESPORTSDB_API_VERSION=1

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ npm install
 npm run dev
 ```
 
+## How to join the beta
+
+1. Visit [edgepicks.app](https://edgepicks.app)
+2. Click **Continue** to create a guest session. No Google account required.
+
 
 ## Environment
 - `npm run setup:dev` creates `.env.local` with safe defaults.
@@ -116,17 +121,10 @@ We welcome ethical AI contributions with a sustainability focus. Please read [CO
 - Questions: opensource@edgepicks.app
 
 ## Cloud Run production env
+Expose port **8080** and run the built app with `next start -p 8080` (see `Dockerfile`).
 
 Set these on the Cloud Run service (prefer Secret Manager for secrets):
 
 - NEXTAUTH_URL=https://<your-cloud-run-service-url>
-- NEXTAUTH_SECRET=<openssl rand -base64 32>
-- GOOGLE_CLIENT_ID=<OAuth 2.0 Web client ID>
-- GOOGLE_CLIENT_SECRET=<OAuth 2.0 client secret>
-
-**Google Console OAuth settings**
-Authorized redirect URI:
-  https://<your-cloud-run-service-url>/api/auth/callback/google
-
-Authorized JavaScript origins:
-  https://<your-cloud-run-service-url>
+- NEXT_PUBLIC_SITE_URL=https://<your-cloud-run-service-url>
+- NEXTAUTH_SECRET=<secret-from-secret-manager>

--- a/__tests__/AppHeader.test.tsx
+++ b/__tests__/AppHeader.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { useSession } from 'next-auth/react';
-import AppHeader from '../components/AppHeader';
+import AppHeader from '@/components/AppHeader';
 
 jest.mock('next-auth/react', () => ({
   useSession: jest.fn(),
@@ -18,14 +18,14 @@ describe('AppHeader', () => {
     expect(screen.getByText('Live')).toBeInTheDocument();
     const nav = screen.getByRole('navigation');
     expect(nav).toHaveClass('justify-center');
-    const btn = screen.getByRole('button', { name: 'Sign in with Google' });
-    expect(btn).toHaveClass('focus:ring-2');
+    const btn = screen.getByRole('button', { name: 'Continue' });
+    expect(btn).toHaveClass('focus-visible:ring-2');
   });
 
   it('hides sign in when authenticated', () => {
     (useSession as jest.Mock).mockReturnValue({ data: {}, status: 'authenticated' });
     render(<AppHeader />);
-    expect(screen.queryByText('Sign in with Google')).not.toBeInTheDocument();
+    expect(screen.queryByText('Continue')).not.toBeInTheDocument();
   });
 });
 

--- a/__tests__/BetaRibbon.test.tsx
+++ b/__tests__/BetaRibbon.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import BetaRibbon from '../components/BetaRibbon';
+import BetaRibbon from '@/components/BetaRibbon';
 
 describe('BetaRibbon', () => {
   beforeEach(() => {
@@ -11,6 +11,15 @@ describe('BetaRibbon', () => {
     expect(screen.getByText(/Welcome to EdgePicks Beta/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /dismiss beta ribbon/i }));
     expect(localStorage.getItem('betaRibbonDismissed')).toBe('1');
+    rerender(<BetaRibbon />);
+    expect(screen.queryByText(/Welcome to EdgePicks Beta/)).toBeNull();
+  });
+
+  it('allows keyboard dismissal with Escape', () => {
+    const { rerender } = render(<BetaRibbon />);
+    const button = screen.getByRole('button', { name: /dismiss beta ribbon/i });
+    button.focus();
+    fireEvent.keyDown(button, { key: 'Escape' });
     rerender(<BetaRibbon />);
     expect(screen.queryByText(/Welcome to EdgePicks Beta/)).toBeNull();
   });

--- a/__tests__/DisagreementBadge.test.tsx
+++ b/__tests__/DisagreementBadge.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import DisagreementBadge, { computeDisagreement } from '../components/agents/DisagreementBadge';
-import type { AgentOutputs } from '../lib/types';
+import DisagreementBadge, { computeDisagreement } from '@/components/agents/DisagreementBadge';
+import type { AgentOutputs } from '@/lib/types';
 
 describe('computeDisagreement', () => {
   it('calculates fraction of agents not in majority', () => {
@@ -24,15 +24,15 @@ describe('DisagreementBadge component', () => {
     expect(screen.getByText('33% disagree')).toBeInTheDocument();
   });
 
-  it('shows agent picks in tooltip on hover', () => {
+  it('shows agent picks in tooltip on focus', async () => {
     const agents: Partial<AgentOutputs> = {
       injuryScout: { team: 'A', score: 0.7, reason: '' },
       statCruncher: { team: 'B', score: 0.4, reason: '' },
     };
     render(<DisagreementBadge agents={agents} />);
     const badge = screen.getByText(/disagree/);
-    fireEvent.mouseEnter(badge);
-    expect(screen.getByText('InjuryScout: A')).toBeInTheDocument();
+    fireEvent.focus(badge);
+    expect(await screen.findByText('InjuryScout: A')).toBeInTheDocument();
     expect(screen.getByText('StatCruncher: B')).toBeInTheDocument();
   });
 

--- a/__tests__/Navbar.test.tsx
+++ b/__tests__/Navbar.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { useSession } from 'next-auth/react';
-import Navbar from '../components/Navbar';
+import Navbar from '@/components/Navbar';
 
-jest.mock('../components/ThemeToggle', () => () => <div />);
+jest.mock('@/components/ThemeToggle', () => () => <div />);
 jest.mock('next-auth/react', () => ({
   useSession: jest.fn(),
   signIn: jest.fn(),
@@ -20,6 +20,6 @@ describe('Navbar', () => {
   it('renders navigation bar with sign in', () => {
     render(<Navbar />);
     expect(screen.getByRole('navigation')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Sign in with Google' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
   });
 });

--- a/__tests__/Onboarding.a11y.test.tsx
+++ b/__tests__/Onboarding.a11y.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SessionProvider } from 'next-auth/react';
+import Onboarding from '@/components/Onboarding';
+
+describe('Onboarding accessibility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ hasSeen: false })
+    });
+  });
+
+  it('has focusable Skip button', async () => {
+    render(
+      <SessionProvider session={{ user: {}, expires: '' }}>
+        <Onboarding />
+      </SessionProvider>
+    );
+    const skip = await screen.findByRole('button', { name: /skip/i });
+    skip.focus();
+    expect(skip).toHaveFocus();
+    fireEvent.click(skip);
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /skip/i })).toBeNull();
+    });
+  });
+});

--- a/__tests__/Tooltips.a11y.test.tsx
+++ b/__tests__/Tooltips.a11y.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AccessibleTooltip } from '@/components/ui/accessible-tooltip';
+
+describe('AccessibleTooltip', () => {
+  it('supports keyboard activation and ESC dismissal', () => {
+    render(
+      <AccessibleTooltip content="info">
+        <button>Trigger</button>
+      </AccessibleTooltip>
+    );
+    const trigger = screen.getByRole('button', { name: /trigger/i });
+    trigger.focus();
+    expect(screen.getByRole('tooltip')).toHaveTextContent('info');
+    fireEvent.keyDown(trigger, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(trigger).toHaveAttribute('aria-describedby');
+  });
+});

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,32 +1,20 @@
-substitutions:
-  _SERVICE: "edgepicks"   # change if you want another Cloud Run service name
-  _REGION: "us-west2"     # set to your region
-
 steps:
-- name: "gcr.io/cloud-builders/docker"
-  id: "Build Docker image"
-  args: ["build", "-t", "us-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/$_SERVICE:$_COMMIT_SHA", "."]
-
-- name: "gcr.io/cloud-builders/docker"
-  id: "Push Docker image"
-  args: ["push", "us-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/$_SERVICE:$_COMMIT_SHA"]
-
-- name: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
-  id: "Deploy to Cloud Run"
-  entrypoint: gcloud
-  args:
-    [
-      "run","deploy","$_SERVICE",
-      "--image","us-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/$_SERVICE:$_COMMIT_SHA",
-      "--region","$_REGION",
-      "--platform","managed",
-      "--allow-unauthenticated",
-      "--port","8080",
-      "--cpu","1",
-      "--memory","512Mi",
-      "--max-instances","10",
-      "--set-env-vars","NEXT_TELEMETRY_DISABLED=1,HOSTNAME=0.0.0.0"
-    ]
-
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build','-t','$LOCATION-docker.pkg.dev/$PROJECT_ID/edgepicks/app:$COMMIT_SHA','.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push','$LOCATION-docker.pkg.dev/$PROJECT_ID/edgepicks/app:$COMMIT_SHA']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - edgepicks
+      - --image=$LOCATION-docker.pkg.dev/$PROJECT_ID/edgepicks/app:$COMMIT_SHA
+      - --region=$LOCATION
+      - --platform=managed
+      - --allow-unauthenticated
+      - --port=8080
+      - --set-env-vars=NEXTAUTH_URL=https://$SERVICE_URL,NEXT_PUBLIC_SITE_URL=https://$SERVICE_URL
+      - --set-secrets=NEXTAUTH_SECRET=projects/$PROJECT_ID/secrets/NEXTAUTH_SECRET:latest
 images:
-- "us-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/$_SERVICE:$_COMMIT_SHA"
+  - '$LOCATION-docker.pkg.dev/$PROJECT_ID/edgepicks/app:$COMMIT_SHA'

--- a/components/AgentTooltip.tsx
+++ b/components/AgentTooltip.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Tooltip from './Tooltip';
+import { AccessibleTooltip } from './ui/accessible-tooltip';
+import { cloneElement, isValidElement, ReactElement } from 'react';
 import { registry as agentRegistry } from '@/lib/agents/registry';
 import { AgentName } from '@/lib/types';
 import { formatAgentName } from '@/lib/utils';
@@ -13,9 +14,13 @@ interface Props {
 const AgentTooltip: React.FC<Props> = ({ name, children, className }) => {
   const meta = agentRegistry.find((a) => a.name === name);
   if (!meta) return <>{children}</>;
+  const trigger = isValidElement(children)
+    ? cloneElement(children as ReactElement, {
+        className: className ?? children.props.className,
+      })
+    : <span className={className}>{children}</span>;
   return (
-    <Tooltip
-      className={className}
+    <AccessibleTooltip
       content={
         <div>
           <div className="font-medium">{formatAgentName(name)}</div>
@@ -23,8 +28,8 @@ const AgentTooltip: React.FC<Props> = ({ name, children, className }) => {
         </div>
       }
     >
-      {children}
-    </Tooltip>
+      {trigger}
+    </AccessibleTooltip>
   );
 };
 

--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -36,10 +36,10 @@ export default function AppHeader({ isAuthenticated }: Props) {
           <div className="order-2 sm:order-3 flex justify-end items-center min-w-[150px] min-h-[44px]">
             {!authed && (
               <button
-                onClick={() => signIn('google')}
-                className="px-4 py-2 rounded-full bg-blue-600 text-white hover:opacity-90 transition focus:outline-none focus:ring-2 focus:ring-blue-400"
+                onClick={() => signIn('credentials')}
+                className="px-4 py-2 rounded-full bg-blue-600 text-white hover:opacity-90 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
               >
-                Sign in with Google
+                Continue
               </button>
             )}
           </div>

--- a/components/BetaRibbon.tsx
+++ b/components/BetaRibbon.tsx
@@ -22,8 +22,9 @@ export default function BetaRibbon() {
         <span className="text-center w-full sm:text-left">Welcome to EdgePicks Beta — results may shift.</span>
         <button
           onClick={dismiss}
-          className="mt-1 sm:mt-0 sm:ml-4 px-3 py-1 rounded bg-emerald-200 dark:bg-emerald-800 hover:opacity-80 transition-opacity motion-reduce:transition-none"
+          className="mt-1 sm:mt-0 sm:ml-4 px-3 py-1 rounded bg-emerald-200 dark:bg-emerald-800 hover:opacity-80 transition-opacity motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600"
           aria-label="Dismiss beta ribbon"
+          onKeyDown={(e) => e.key === 'Escape' && dismiss()}
         >
           Dismiss
         </button>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,6 +7,7 @@ export default function Footer() {
         <Link href="/terms">Terms</Link>
         <a href="https://github.com" target="_blank" rel="noreferrer">GitHub</a>
         <a href="https://discord.com" target="_blank" rel="noreferrer">Discord</a>
+        <Link href="/dev/preflight">Report an issue</Link>
       </div>
     </footer>
   );

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { loadMotion } from "@/lib/motion/lazy";
 import { buttonVariants } from "@/components/ui/button";
+import { betaCopyEnabled } from "@/lib/flags/beta";
 let motion: any = null;
 
 const container = {
@@ -46,10 +47,16 @@ export default function Hero() {
           variants={item}
           className="text-4xl font-bold leading-tight sm:text-5xl"
         >
-          AI-Powered Sports Picks, Made Transparent.
+          {betaCopyEnabled
+            ? "EdgePicks Beta: transparent AI sports picks"
+            : "AI-Powered Sports Picks, Made Transparent."}
         </motion.h1>
         <motion.p variants={item} className="mt-4 text-lg text-muted-foreground">
-          Our expert agents explain every pick with <span className="font-semibold">live</span> data and evidence you can audit.
+          {betaCopyEnabled
+            ? "Experimental preview — no gameplay guarantees, transparency first."
+            : (
+                <>Our expert agents explain every pick with <span className="font-semibold">live</span> data and evidence you can audit.</>
+              )}
         </motion.p>
         <motion.div
           variants={item}

--- a/components/MatchupCard.tsx
+++ b/components/MatchupCard.tsx
@@ -11,6 +11,7 @@ import { getContribution, formatAgentName } from '@/lib/utils';
 import { registry as agentRegistry } from '@/lib/agents/registry';
 import { getAccuracyHistory } from '@/lib/accuracy';
 import { matchupCard } from '../styles/cardStyles';
+import { AccessibleTooltip } from './ui/accessible-tooltip';
 
 interface BreakdownProps {
   agents: AgentOutputs;
@@ -22,12 +23,9 @@ const ConfidenceBreakdown: React.FC<BreakdownProps> = ({ agents, total }) => {
     <div className="mt-4">
       <div className="flex items-center gap-1 mb-2">
         <h4 className="font-semibold text-sm">Confidence Breakdown</h4>
-        <span
-          className="text-gray-400 text-xs cursor-help"
-          title="Final confidence is the sum of each agent score multiplied by its weight."
-        >
-          ?
-        </span>
+        <AccessibleTooltip content="Final confidence is the sum of each agent score multiplied by its weight.">
+          <span className="text-gray-400 text-xs cursor-help">?</span>
+        </AccessibleTooltip>
       </div>
       <ul className="space-y-2 text-sm">
         {agentRegistry.map(({ name, weight }) => {
@@ -42,15 +40,19 @@ const ConfidenceBreakdown: React.FC<BreakdownProps> = ({ agents, total }) => {
           )}%) to the final pick`;
 
           return (
-            <li key={name} className="flex items-center gap-2 cursor-help" title={tooltip}>
-              <span className="w-28">{display}</span>
-              <div className="flex items-center flex-1 gap-2">
-                <ScoreBar percent={contributionPct} />
-                <span className="w-16 text-right font-mono">{score.toFixed(2)}</span>
-                <span className="w-24 text-right font-mono">
-                  {contribution.toFixed(2)} ({Math.round(contributionPct)}%)
-                </span>
-              </div>
+            <li key={name}>
+              <AccessibleTooltip content={tooltip}>
+                <div className="flex items-center gap-2 cursor-help" tabIndex={0} role="button">
+                  <span className="w-28">{display}</span>
+                  <div className="flex items-center flex-1 gap-2">
+                    <ScoreBar percent={contributionPct} />
+                    <span className="w-16 text-right font-mono">{score.toFixed(2)}</span>
+                    <span className="w-24 text-right font-mono">
+                      {contribution.toFixed(2)} ({Math.round(contributionPct)}%)
+                    </span>
+                  </div>
+                </div>
+              </AccessibleTooltip>
             </li>
           );
         })}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -118,10 +118,10 @@ export default function Navbar() {
             </>
           ) : (
             <button
-              onClick={() => signIn('google')}
-              className="px-2 py-1 border rounded"
+              onClick={() => signIn('credentials')}
+              className="px-2 py-1 border rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
             >
-              Sign in with Google
+              Continue
             </button>
           )}
         </div>

--- a/components/SignInModal.tsx
+++ b/components/SignInModal.tsx
@@ -28,8 +28,11 @@ const SignInModal: React.FC<SignInModalProps> = ({ isOpen, onClose }) => {
     >
       <div className="bg-white p-6 rounded shadow-md w-full max-w-sm">
         <h2 className="text-xl font-semibold mb-4 text-center">Sign in</h2>
-        <Button className="w-full" onClick={() => signIn('google')}>
-          Sign in with Google
+        <Button
+          className="w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+          onClick={() => signIn('credentials')}
+        >
+          Continue
         </Button>
       </div>
     </div>

--- a/components/ValueProps.tsx
+++ b/components/ValueProps.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { loadMotion } from "@/lib/motion/lazy";
+import { betaCopyEnabled } from "@/lib/flags/beta";
 let motion: any = null;
 
 interface Item {
@@ -21,15 +22,21 @@ export default function ValueProps() {
   const items: Item[] = [
     {
       title: "Transparent agents",
-      description: "Every decision traced to its source.",
+      description: betaCopyEnabled
+        ? "Every decision traced to its source; no guarantees."
+        : "Every decision traced to its source.",
     },
     {
       title: "Evidence-linked picks",
-      description: "Tap into the rationale behind every pick.",
+      description: betaCopyEnabled
+        ? "Inspect the rationale behind each pick."
+        : "Tap into the rationale behind every pick.",
     },
     {
       title: "Live accuracy",
-      description: "Performance metrics update in real time.",
+      description: betaCopyEnabled
+        ? "Performance metrics update in real time; expect swings."
+        : "Performance metrics update in real time.",
     },
   ];
 

--- a/components/agents/DisagreementBadge.tsx
+++ b/components/agents/DisagreementBadge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Tooltip from '../Tooltip';
+import { AccessibleTooltip } from '../ui/accessible-tooltip';
 import { AgentOutputs } from '@/lib/types';
 import { formatAgentName } from '@/lib/utils';
 
@@ -40,11 +40,13 @@ const DisagreementBadge: React.FC<Props> = ({ agents, className }) => {
   );
 
   return (
-    <Tooltip content={content} className={className}>
-      <span className="inline-block px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs">
+    <AccessibleTooltip content={content}>
+      <span
+        className={`inline-block px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs ${className || ''}`}
+      >
         {percent}% disagree
       </span>
-    </Tooltip>
+    </AccessibleTooltip>
   );
 };
 

--- a/components/edu/ConfidenceExplainer.tsx
+++ b/components/edu/ConfidenceExplainer.tsx
@@ -1,46 +1,31 @@
 'use client';
 
 import React from 'react';
-import Tooltip from '../Tooltip';
+import { AccessibleTooltip } from '@/components/ui/accessible-tooltip';
 
 const ConfidenceExplainer: React.FC = () => {
   return (
     <div className="text-sm space-y-3">
       <p>
-        <Tooltip
-          content={
-            <div>
-              <strong>Confidence Interval:</strong>
-              <div>95% CI [45%, 55%] means the true value likely falls in that range.</div>
-            </div>
-          }
+        <AccessibleTooltip
+          content="95% CI [45%, 55%] means the true value likely falls in that range."
         >
           <span className="underline cursor-help">CI</span>
-        </Tooltip>{' '}provides the likely range for an estimate.
+        </AccessibleTooltip>{' '}provides the likely range for an estimate.
       </p>
       <p>
-        <Tooltip
-          content={
-            <div>
-              <strong>Number Needed to Treat:</strong>
-              <div>NNT 20 means treating 20 people helps one extra person.</div>
-            </div>
-          }
+        <AccessibleTooltip
+          content="NNT 20 means treating 20 people helps one extra person."
         >
           <span className="underline cursor-help">NNT</span>
-        </Tooltip>{' '}shows the impact of an intervention.
+        </AccessibleTooltip>{' '}shows the impact of an intervention.
       </p>
       <p>
-        <Tooltip
-          content={
-            <div>
-              <strong>Calibration:</strong>
-              <div>If 60% predictions occur 6 out of 10 times, they are well calibrated.</div>
-            </div>
-          }
+        <AccessibleTooltip
+          content="If 60% predictions occur 6 out of 10 times, they are well calibrated."
         >
           <span className="underline cursor-help">Calibration</span>
-        </Tooltip>{' '}checks how probabilities match outcomes.
+        </AccessibleTooltip>{' '}checks how probabilities match outcomes.
       </p>
     </div>
   );

--- a/components/ui/accessible-tooltip.tsx
+++ b/components/ui/accessible-tooltip.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React, { useId } from "react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
+
+interface Props {
+  content: React.ReactNode;
+  children: React.ReactElement;
+}
+
+export function AccessibleTooltip({ content, children }: Props) {
+  const id = useId();
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {React.cloneElement(children, {
+            tabIndex: children.props.tabIndex ?? 0,
+            "aria-describedby": id,
+          })}
+        </TooltipTrigger>
+        <TooltipContent id={id} role="tooltip" className="bg-black text-white px-2 py-1 rounded">
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/components/universal/UniversalAgentInterface.tsx
+++ b/components/universal/UniversalAgentInterface.tsx
@@ -16,7 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { AccessibleTooltip } from "@/components/ui/accessible-tooltip";
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
@@ -190,21 +190,16 @@ function StatusBadge({ status }: { status: AgentEvent["status"] }) {
 function DisagreementChip({ on }: { on?: boolean }) {
   if (!on) return null;
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="rounded-2xl border border-yellow-300 bg-yellow-50 text-yellow-900"
-          >
-            disagreement
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Some agents disagreed — tap to view rationale deltas.</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <AccessibleTooltip content="Some agents disagreed — tap to view rationale deltas.">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="rounded-2xl border border-yellow-300 bg-yellow-50 text-yellow-900"
+      >
+        disagreement
+      </Button>
+    </AccessibleTooltip>
   );
 }
 

--- a/lib/flags/beta.ts
+++ b/lib/flags/beta.ts
@@ -1,0 +1,1 @@
+export const betaCopyEnabled = process.env.BETA_COPY_ENABLED !== '0';

--- a/llms.txt
+++ b/llms.txt
@@ -4168,3 +4168,34 @@ Files:
 - scripts/codemods/iconsToProxy.ts (+10/-0)
 - scripts/validateEnv.ts (+6/-0)
 
+Timestamp: 2025-08-19T03:38:34.905Z
+Commit: cc77086b2651a03469110840f6b3a4b0131d1d6e
+Author: Codex
+Message: feat: prepare beta launch with guest access
+Files:
+- .env.example (+5/-1)
+- .env.production.example (+9/-0)
+- README.md (+8/-10)
+- __tests__/AppHeader.test.tsx (+4/-4)
+- __tests__/BetaRibbon.test.tsx (+10/-1)
+- __tests__/DisagreementBadge.test.tsx (+5/-5)
+- __tests__/Navbar.test.tsx (+3/-3)
+- __tests__/Onboarding.a11y.test.tsx (+27/-0)
+- __tests__/Tooltips.a11y.test.tsx (+18/-0)
+- cloudbuild.yaml (+18/-30)
+- components/AgentTooltip.tsx (+10/-5)
+- components/AppHeader.tsx (+3/-3)
+- components/BetaRibbon.tsx (+2/-1)
+- components/Footer.tsx (+1/-0)
+- components/Hero.tsx (+9/-2)
+- components/MatchupCard.tsx (+17/-15)
+- components/Navbar.tsx (+3/-3)
+- components/SignInModal.tsx (+5/-2)
+- components/ValueProps.tsx (+10/-3)
+- components/agents/DisagreementBadge.tsx (+6/-4)
+- components/edu/ConfidenceExplainer.tsx (+10/-25)
+- components/ui/accessible-tooltip.tsx (+27/-0)
+- components/universal/UniversalAgentInterface.tsx (+11/-16)
+- lib/flags/beta.ts (+1/-0)
+- pages/auth/signin.tsx (+3/-3)
+

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -4,10 +4,10 @@ export default function SignIn() {
   return (
     <div className="flex items-center justify-center min-h-screen">
       <button
-        onClick={() => signIn('google')}
-        className="px-4 py-2 bg-blue-600 text-white rounded"
+        onClick={() => signIn('credentials')}
+        className="px-4 py-2 bg-blue-600 text-white rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
       >
-        Sign in with Google
+        Continue
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- default guest auth with "Continue" button and beta copy gating
- add accessible tooltips and keyboard-dismissable beta ribbon
- document guest-only beta and Cloud Run setup; trim env examples

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3eee4c31483238cd6b49d9000e95a