### PR TITLE
Normalize Next.js segment config & harden build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           key: ${{ runner.os }}-next-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-next-
+      - name: Segment config guard
+        run: npm run guard:segments
       - env:
           SKIP_BUILD_ENV_CHECK: '1'
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Runtime: Node 20.19.x across local, CI, and Vercel. Vercel uses `engines.node`â€
 - `pages/` is reserved for `pages/api/**` only.
 - During build, any conflicting `pages/*.tsx|jsx` is auto-archived to `archive/pages/**`.
 - Use `npm run guard:dry` to preview moves locally.
+### Segment Config Rules
+- Marketing pages use ISR with `revalidate = 60` and default cache.
+- Product pages are dynamic with `revalidate = 0` and `force-no-store`.
+- Never export objects for `revalidate`; it must be a number or `false`.
+- In Vercel, set Project Settings â†’ Node 20.x to silence the engines warning.
 
 ## Testing
 ```bash

--- a/__tests__/segmentConfig.contract.test.ts
+++ b/__tests__/segmentConfig.contract.test.ts
@@ -1,0 +1,15 @@
+jest.mock('next/navigation', () => ({}));
+
+describe('segment config contract', () => {
+  test('marketing page uses ISR', () => {
+    const mod = require('../app/(marketing)/page.tsx');
+    expect(mod.revalidate).toBe(60);
+    expect(mod.dynamic).toBe('auto');
+  });
+
+  test('product page is dynamic', () => {
+    const mod = require('../app/(product)/predictions/page.tsx');
+    expect(mod.revalidate).toBe(0);
+    expect(mod.dynamic).toBe('force-dynamic');
+  });
+});

--- a/app/(marketing)/impact/page.tsx
+++ b/app/(marketing)/impact/page.tsx
@@ -12,7 +12,9 @@ import {
 } from "recharts";
 import data from "./metrics.json";
 import { Card } from "@/components/ui/card";
-export const revalidate = 60;
+export const revalidate = 60 as const;
+export const dynamic = 'auto';
+export const fetchCache = 'default';
 let motion: any = null;
  export const dynamicParams = true;
 

--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import { Toaster } from "@/components/ui/toaster";
 import SiteHeader from "@/components/layout/SiteHeader";
 import "@/app/globals.css";
-export const revalidate = 60;
+export const revalidate = 60 as const;
+export const dynamic = 'auto';
+export const fetchCache = 'default';
 export const metadata: Metadata = {
   title: "EdgePicks",
   description: "AI-powered sports research assistant",

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -2,7 +2,9 @@ import nextDynamic from 'next/dynamic';
 import Hero from "@/components/Hero";
 import TrustBar from "@/components/TrustBar";
 import ValueProps from "@/components/ValueProps";
-export const revalidate = 60;
+export const revalidate = 60 as const;
+export const dynamic = 'auto';
+export const fetchCache = 'default';
 // Defer LiveStatsStrip until visible (example: small component still lazy for demo)
 const LiveStatsStrip = nextDynamic(() => import("@/components/LiveStatsStrip"), { ssr: false });
 

--- a/app/(marketing)/trust/page.tsx
+++ b/app/(marketing)/trust/page.tsx
@@ -4,7 +4,9 @@ import TrustSummary from '@/components/trust/TrustSummary';
 import AuditActivity from '@/components/trust/AuditActivity';
 import AgentExplainers from '@/components/trust/AgentExplainers';
 import AgreementMeter from '@/components/trust/AgreementMeter';
-export const revalidate = 60;
+export const revalidate = 60 as const;
+export const dynamic = 'auto';
+export const fetchCache = 'default';
 type Tab = 'overview' | 'audit' | 'agents';
 const TrustPage: React.FC = () => {
   const [tab, setTab] = useState<Tab>('overview');

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,9 @@
 import React, { Suspense } from 'react';
 import nextDynamic from 'next/dynamic';
 import Skeleton from '@/components/ui/skeleton';
-export const revalidate = 60;
+export const revalidate = 60 as const;
+export const dynamic = 'auto';
+export const fetchCache = 'default';
 const AboutContent = nextDynamic(() => import('@/components/ui/about-content'), {
   suspense: true,
 });

--- a/app/agent-interface/page.tsx
+++ b/app/agent-interface/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import nextDynamic from 'next/dynamic';
-export const revalidate = 0;
+export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 const AgentFlowVisualizer = nextDynamic(() => import('@/components/AgentFlowVisualizer'), { ssr: false });

--- a/llms.txt
+++ b/llms.txt
@@ -4242,3 +4242,20 @@ Files:
 - pages/demo/nfl.tsx (+0/-49)
 - tests/visual/percy.spec.ts (+1/-1)
 
+Timestamp: 2025-08-19T04:36:22.704Z
+Commit: 26db06ad637366aacb90166b64b7337c5f0179f7
+Author: Codex
+Message: chore: normalize segment config
+Files:
+- .github/workflows/ci.yml (+2/-0)
+- README.md (+5/-0)
+- __tests__/segmentConfig.contract.test.ts (+15/-0)
+- app/(marketing)/impact/page.tsx (+3/-1)
+- app/(marketing)/layout.tsx (+3/-1)
+- app/(marketing)/page.tsx (+3/-1)
+- app/(marketing)/trust/page.tsx (+3/-1)
+- app/about/page.tsx (+3/-1)
+- app/agent-interface/page.tsx (+1/-1)
+- package.json (+1/-0)
+- scripts/guards/segmentConfigGuard.ts (+79/-0)
+

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "preinstall": "node scripts/npmProxyNormalize.mjs",
     "ci-install": "npm ci --prefer-offline --no-audit --no-fund",
     "guard:image": "ts-node --project tsconfig.node.json scripts/guards/imageResponseImportGuard.ts",
+    "guard:segments": "ts-node --project tsconfig.node.json scripts/guards/segmentConfigGuard.ts",
     "analyze": "cross-env ANALYZE=true NODE_ENV=production SPORTS_API_KEY=DUMMY_ANALYZE NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon next build && node scripts/perf/printBundleHints.mjs",
     "analyze:view": "ANALYZE=true next build && npx http-server .next/analyze -p 5050 -o",
     "perf:report": "node scripts/perf/printBundleHints.mjs",

--- a/scripts/guards/segmentConfigGuard.ts
+++ b/scripts/guards/segmentConfigGuard.ts
@@ -1,0 +1,79 @@
+import path from 'path';
+import { Project, SyntaxKind, Node, Expression } from 'ts-morph';
+
+const project = new Project({
+  tsConfigFilePath: path.join(process.cwd(), 'tsconfig.node.json'),
+  skipAddingFilesFromTsConfig: true,
+});
+
+const files = project.addSourceFilesAtPaths('app/**/*.{ts,tsx}');
+
+interface Violation {
+  file: string;
+  export: string;
+  hint: string;
+}
+
+function isNumberOrFalse(expr: Expression | undefined): boolean {
+  if (!expr) return false;
+  const kind = expr.getKind();
+  if (kind === SyntaxKind.FalseKeyword) return true;
+  if (kind === SyntaxKind.NumericLiteral || kind === SyntaxKind.PrefixUnaryExpression) return true;
+  if (kind === SyntaxKind.AsExpression) {
+    return isNumberOrFalse((expr as any).getExpression());
+  }
+  return false;
+}
+
+function getString(expr: Expression | undefined): string | undefined {
+  if (!expr) return undefined;
+  if (Node.isStringLiteral(expr) || Node.isNoSubstitutionTemplateLiteral(expr)) {
+    return expr.getLiteralText();
+  }
+  if (expr.getKind() === SyntaxKind.AsExpression) {
+    return getString((expr as any).getExpression());
+  }
+  return undefined;
+}
+
+const validDynamic = ['auto', 'error', 'force-dynamic', 'force-static'];
+const validFetchCache = ['default', 'only-cache', 'only-no-store', 'force-no-store'];
+
+const violations: Violation[] = [];
+
+for (const sourceFile of files) {
+  const filePath = path.relative(process.cwd(), sourceFile.getFilePath());
+  for (const stmt of sourceFile.getVariableStatements()) {
+    if (!stmt.hasExportKeyword()) continue;
+    for (const decl of stmt.getDeclarations()) {
+      const name = decl.getName();
+      const init = decl.getInitializer();
+      if (name === 'revalidate') {
+        if (!isNumberOrFalse(init)) {
+          violations.push({ file: filePath, export: 'revalidate', hint: 'must be a number or false' });
+        }
+      } else if (name === 'dynamic') {
+        const val = getString(init);
+        if (!val || !validDynamic.includes(val)) {
+          violations.push({ file: filePath, export: 'dynamic', hint: `must be one of ${validDynamic.join(', ')}` });
+        }
+      } else if (name === 'fetchCache') {
+        const val = getString(init);
+        if (!val || !validFetchCache.includes(val)) {
+          violations.push({ file: filePath, export: 'fetchCache', hint: `must be one of ${validFetchCache.join(', ')}` });
+        }
+      } else if (name === 'runtime') {
+        const val = getString(init);
+        if (val === 'edge' && filePath.includes('(marketing)')) {
+          violations.push({ file: filePath, export: 'runtime', hint: 'edge runtime disabled on marketing pages' });
+        }
+      }
+    }
+  }
+}
+
+if (violations.length) {
+  console.error('Segment config violations');
+  console.table(violations);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- standardize marketing pages to ISR with cache defaults and product pages to dynamic no-store
- add segment config guard script with CI integration and contract test
- document segment rules and remind to set Node 20.x in Vercel

## Testing
- `npm run guard:segments`
- `npm run typecheck`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fd5ffa408323923dd5fa845ad5ba