### PR TITLE
fix(segments): make revalidate literals only; remove fetchCache exports; tighten guard; update contract tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,11 @@ Marketing routes (`app/(marketing)` and `app/about`) use ISR with:
 
 - `revalidate = 60`
 - `dynamic = 'auto'`
-- `fetchCache = 'default'`
 
 Product and other live-data routes (`app/(product)` and pages like `/agent-interface`, `/maps`, `/onboarding`, `/toast-demo`) are fully dynamic:
 
 - `revalidate = 0`
 - `dynamic = 'force-dynamic'`
-- `fetchCache = 'force-no-store'`
 
 Run `npm run guard:segments` to verify these rules locally. Builds require **Node 20.x**; set the Vercel project accordingly.
 Never export objects for `revalidate`; it must be a number or `false` literal.

--- a/__tests__/segmentConfig.contract.test.ts
+++ b/__tests__/segmentConfig.contract.test.ts
@@ -5,13 +5,20 @@ describe('segment config contract', () => {
     const mod = require('../app/(marketing)/layout.tsx');
     expect(mod.revalidate).toBe(60);
     expect(mod.dynamic).toBe('auto');
-    expect(mod.fetchCache).toBe('default');
+    expect('fetchCache' in mod).toBe(false);
+  });
+
+  test('marketing page uses ISR defaults', () => {
+    const mod = require('../app/(marketing)/impact/page.tsx');
+    expect(mod.revalidate).toBe(60);
+    expect(mod.dynamic).toBe('auto');
+    expect('fetchCache' in mod).toBe(false);
   });
 
   test('product page is fully dynamic', () => {
     const mod = require('../app/(product)/agents/page.tsx');
     expect(mod.revalidate).toBe(0);
     expect(mod.dynamic).toBe('force-dynamic');
-    expect(mod.fetchCache).toBe('force-no-store');
+    expect('fetchCache' in mod).toBe(false);
   });
 });

--- a/app/(marketing)/demo/mlb/page.tsx
+++ b/app/(marketing)/demo/mlb/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import DemoPageClient from '../DemoPageClient';
 export const revalidate = 60 as const;
 export const dynamic = 'auto';
-export const fetchCache = 'default';
 export const metadata: Metadata = { title: 'Demo MLB' };
 
 export default function Page() {

--- a/app/(marketing)/demo/page.tsx
+++ b/app/(marketing)/demo/page.tsx
@@ -8,7 +8,6 @@ import LeagueSection from '@/components/LeagueSection';
 import { fetchUpcomingGames } from '@/lib/data';
 export const revalidate = 60 as const;
 export const dynamic = 'auto';
-export const fetchCache = 'default';
 // Lazy heavy visual components
 const DemoMatchupCarousel = nextDynamic(() => import('@/components/DemoMatchupCarousel'), { ssr: false });
 const AccuracySnapshot = nextDynamic(() => import('@/components/AccuracySnapshot'), { ssr: false });

--- a/app/(marketing)/impact/page.tsx
+++ b/app/(marketing)/impact/page.tsx
@@ -14,7 +14,6 @@ import data from "./metrics.json";
 import { Card } from "@/components/ui/card";
 export const revalidate = 60 as const;
 export const dynamic = 'auto';
-export const fetchCache = 'default';
 let motion: any = null;
  export const dynamicParams = true;
 

--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -4,7 +4,6 @@ import SiteHeader from "@/components/layout/SiteHeader";
 import "@/app/globals.css";
 export const revalidate = 60 as const;
 export const dynamic = 'auto';
-export const fetchCache = 'default';
 export const metadata: Metadata = {
   title: "EdgePicks",
   description: "AI-powered sports research assistant",

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -4,7 +4,6 @@ import TrustBar from "@/components/TrustBar";
 import ValueProps from "@/components/ValueProps";
 export const revalidate = 60 as const;
 export const dynamic = 'auto';
-export const fetchCache = 'default';
 // Defer LiveStatsStrip until visible (example: small component still lazy for demo)
 const LiveStatsStrip = nextDynamic(() => import("@/components/LiveStatsStrip"), { ssr: false });
 

--- a/app/(marketing)/trust/page.tsx
+++ b/app/(marketing)/trust/page.tsx
@@ -6,7 +6,6 @@ import AgentExplainers from '@/components/trust/AgentExplainers';
 import AgreementMeter from '@/components/trust/AgreementMeter';
 export const revalidate = 60 as const;
 export const dynamic = 'auto';
-export const fetchCache = 'default';
 type Tab = 'overview' | 'audit' | 'agents';
 const TrustPage: React.FC = () => {
   const [tab, setTab] = useState<Tab>('overview');

--- a/app/(product)/agents/page.tsx
+++ b/app/(product)/agents/page.tsx
@@ -5,7 +5,6 @@ import { registry, type AgentName } from '@/lib/agents/registry';
 import type { AccuracyPoint } from '@/components/AccuracyTrend';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 
 interface AccuracyHistory {
   history: AccuracyPoint[];

--- a/app/(product)/leaderboard/page.tsx
+++ b/app/(product)/leaderboard/page.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import Leaderboard from '@/components/Leaderboard';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 
 export default function LeaderboardPage() {
   return (

--- a/app/(product)/logs/page.tsx
+++ b/app/(product)/logs/page.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import AgentLogStream from '@/components/AgentLogStream';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 const AgentLogsPage: React.FC = () => {
   return (
     <main className="min-h-screen bg-gray-50 p-6" suppressHydrationWarning>

--- a/app/(product)/predictions/page.tsx
+++ b/app/(product)/predictions/page.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import MatchupInsights from '@/components/predictions/MatchupInsights';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 const PredictionsPage: React.FC = () => {
   return <MatchupInsights />;
 };

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -5,7 +5,6 @@ import { I18nContext } from '@/lib/i18n/config';
 import { LocaleSwitcher } from '@/lib/i18n/LocaleSwitcher';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 
 export default function Page() {
   const { t } = useContext(I18nContext);

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,7 +3,6 @@ import nextDynamic from 'next/dynamic';
 import Skeleton from '@/components/ui/skeleton';
 export const revalidate = 60 as const;
 export const dynamic = 'auto';
-export const fetchCache = 'default';
 const AboutContent = nextDynamic(() => import('@/components/ui/about-content'), {
   suspense: true,
 });

--- a/app/agent-interface/page.tsx
+++ b/app/agent-interface/page.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import nextDynamic from 'next/dynamic';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 const AgentFlowVisualizer = nextDynamic(() => import('@/components/AgentFlowVisualizer'), { ssr: false });
 
 export default function Page() {

--- a/app/ancient/page.tsx
+++ b/app/ancient/page.tsx
@@ -1,7 +1,6 @@
 import AncientTechCard from '@/components/ancient/AncientTechCard';
 export const revalidate = 0 as const;
 export const dynamic = 'force-dynamic';
-export const fetchCache = 'force-no-store';
 
 interface TechData {
   title: string;

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,6 +1,5 @@
 export const revalidate = 0 as const;
 export const dynamic = 'force-dynamic';
-export const fetchCache = 'force-no-store';
 
 export async function GET() {
   return new Response("ok", {

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -5,7 +5,6 @@ import { ENV } from '@/lib/env';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
-export const fetchCache = 'force-no-store';
 
 function streamResponse(readable: ReadableStream): Response {
   return new Response(readable, {

--- a/app/demo-0to1/page.tsx
+++ b/app/demo-0to1/page.tsx
@@ -1,6 +1,5 @@
 export const revalidate = 0 as const;
 export const dynamic = 'force-dynamic';
-export const fetchCache = 'force-no-store';
 
 import UpcomingGamesHero from '@/components/UpcomingGamesHero';
 import AccuracySnapshot from '@/components/AccuracySnapshot';

--- a/app/demo-rtl/page.tsx
+++ b/app/demo-rtl/page.tsx
@@ -1,7 +1,6 @@
 import '../../styles/rtl.css';
 export const revalidate = 0 as const;
 export const dynamic = 'force-dynamic';
-export const fetchCache = 'force-no-store';
 
 export default function RtlDemoPage() {
   return (

--- a/app/dev/preflight/page.tsx
+++ b/app/dev/preflight/page.tsx
@@ -1,6 +1,5 @@
 export const revalidate = 0 as const;
 export const dynamic = 'force-dynamic';
-export const fetchCache = 'force-no-store';
 const DOCS_URL = 'https://github.com/EdgePicks/EdgePicks#environment-variables';
 
 interface EnvVar {

--- a/app/learn-stats/page.tsx
+++ b/app/learn-stats/page.tsx
@@ -4,7 +4,6 @@ import BiasCard from '@/components/edu/BiasCard';
 import ErrorBarsCard from '@/components/edu/ErrorBarsCard';
 export const revalidate = 0 as const;
 export const dynamic = 'force-dynamic';
-export const fetchCache = 'force-no-store';
 
 export default function LearnStatsPage() {
   return (

--- a/app/maps/page.tsx
+++ b/app/maps/page.tsx
@@ -9,7 +9,6 @@ import foodData from './data/food-deserts.json';
 import heatData from './data/heat-islands.json';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 export const dynamicParams = true;
 
 const MapContainer = nextDynamic(() => import('react-leaflet').then(m => m.MapContainer), { ssr: false });

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/lib/profile/prefs';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 export const dynamicParams = true;
 
 const purposes: Purpose[] = ['researcher', 'clinician', 'advocate', 'builder'];

--- a/app/toast-demo/page.tsx
+++ b/app/toast-demo/page.tsx
@@ -4,7 +4,6 @@ import React, { useEffect } from 'react';
 import { toast } from '@/lib/ui/toast';
 export const revalidate = 0 as const;
 export const dynamic = "force-dynamic";
-export const fetchCache = "force-no-store";
 
 export default function ToastDemoPage() {
   useEffect(() => {

--- a/scripts/codemods/enforceRevalidate.ts
+++ b/scripts/codemods/enforceRevalidate.ts
@@ -60,7 +60,7 @@ for (const sourceFile of files) {
 
   const imports = sourceFile.getImportDeclarations();
   const insertIndex = imports.length ? sourceFile.getStatements().indexOf(imports[imports.length-1]) + 1 : 0;
-  sourceFile.insertStatements(insertIndex, `export const revalidate = ${value};\nexport const dynamic = "force-dynamic";\nexport const fetchCache = "force-no-store";`);
+  sourceFile.insertStatements(insertIndex, `export const revalidate = ${value};\nexport const dynamic = "force-dynamic";`);
 
   const newText = sourceFile.getFullText();
   if (original !== newText) {

--- a/scripts/guards/segmentConfigGuard.ts
+++ b/scripts/guards/segmentConfigGuard.ts
@@ -67,6 +67,7 @@ function isRouteEntry(filePath: string): boolean {
 }
 
 const violations: Record<string, string[]> = {};
+const warnings: Record<string, string[]> = {};
 
 function record(file: string, decl: VariableDeclaration | undefined, expected: string) {
   const found = decl ? decl.getText() : '(missing)';
@@ -93,8 +94,30 @@ for (const sourceFile of files) {
   const product = routeFile && isProduct(filePath);
 
   const revalidateDecl = exported.revalidate;
-  if (revalidateDecl && !isLiteralNumberOrFalse(revalidateDecl.getInitializer())) {
-    record(filePath, revalidateDecl, 'export const revalidate = <number | false>;');
+  if (revalidateDecl) {
+    const init = revalidateDecl.getInitializer();
+    if (
+      Node.isObjectLiteralExpression(init) ||
+      Node.isIdentifier(init) ||
+      Node.isCallExpression(init) ||
+      Node.isBinaryExpression(init)
+    ) {
+      record(filePath, revalidateDecl, 'export const revalidate = <number | false>;');
+    } else if (!isLiteralNumberOrFalse(init)) {
+      record(filePath, revalidateDecl, 'export const revalidate = <number | false>;');
+    }
+  }
+
+  const fetchDecl = exported.fetchCache;
+  if (fetchDecl) {
+    const fetch = getString(fetchDecl.getInitializer());
+    if (fetch === 'default') {
+      record(filePath, fetchDecl, '// remove fetchCache export');
+    } else {
+      (warnings[filePath] ??= []).push(
+        `export const fetchCache = '${fetch ?? '<unknown>'}';`
+      );
+    }
   }
 
   if (marketing) {
@@ -106,11 +129,6 @@ for (const sourceFile of files) {
     const dyn = getString(dynamicDecl?.getInitializer());
     if (dyn !== 'auto') {
       record(filePath, dynamicDecl, "export const dynamic = 'auto';");
-    }
-    const fetchDecl = exported.fetchCache;
-    const fetch = getString(fetchDecl?.getInitializer());
-    if (fetch !== 'default') {
-      record(filePath, fetchDecl, "export const fetchCache = 'default';");
     }
     const runtimeDecl = exported.runtime;
     const runtime = getString(runtimeDecl?.getInitializer());
@@ -127,11 +145,6 @@ for (const sourceFile of files) {
     if (dyn !== 'force-dynamic') {
       record(filePath, dynamicDecl, "export const dynamic = 'force-dynamic';");
     }
-    const fetchDecl = exported.fetchCache;
-    const fetch = getString(fetchDecl?.getInitializer());
-    if (fetch !== 'force-no-store') {
-      record(filePath, fetchDecl, "export const fetchCache = 'force-no-store';");
-    }
   }
 }
 
@@ -144,4 +157,14 @@ if (Object.keys(violations).length) {
     }
   }
   process.exit(1);
+}
+
+if (Object.keys(warnings).length) {
+  console.warn('Segment config warnings:');
+  for (const [file, diffs] of Object.entries(warnings)) {
+    console.warn(`\n${file}`);
+    for (const d of diffs) {
+      console.warn(d);
+    }
+  }
 }

--- a/scripts/removeStaticParamsForDynamicRoutes.ts
+++ b/scripts/removeStaticParamsForDynamicRoutes.ts
@@ -32,9 +32,8 @@ async function main() {
     if (!/export\s+const\s+dynamic\s*=/.test(out)) {
       out = `export const dynamic = "force-dynamic";\n${out}`;
     }
-    if (!/export\s+const\s+fetchCache\s*=/.test(out)) {
-      out = `export const fetchCache = "force-no-store";\n${out}`;
-    }
+    // Remove any fetchCache exports; dynamic="force-dynamic" already implies no-store
+    out = out.replace(/export\s+const\s+fetchCache\s*=[^;]+;\n?/g, "");
     // normalize revalidate
     if (/export\s+const\s+revalidate\s*=/.test(out)) {
       out = out.replace(/export\s+const\s+revalidate\s*=\s*[^;]+;/g, "export const revalidate = 0;");


### PR DESCRIPTION
## Summary
- remove all `fetchCache` exports and rely on `dynamic` + `revalidate`
- enforce literal `revalidate` values and forbid non-literals in segment guard
- update contract tests and docs for new caching rules

## Testing
- `npm run guard:segments`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npx next build` *(fails: Missing required env: SPORTS_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a409f66a408323b8001d9e2ab8eccb