### PR TITLE
perf(build): fix modularizeImports placement; disable React optimizePackageImports to restore pages SSR; harden JS budget guard

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,15 @@ const nextConfig = {
     formats: ['image/avif', 'image/webp'],
   },
   transpilePackages: ['ioredis', '@upstash/redis'],
+  modularizeImports: {
+    'date-fns': { transform: 'date-fns/{{member}}' },
+    'lodash-es': { transform: 'lodash-es/{{member}}' },
+    // lucide: per docs, importing icons directly is best. This mapping helps when you use named imports.
+    'lucide-react': { transform: 'lucide-react/dist/esm/icons/{{member}}' },
+    'react-use': { transform: 'react-use/esm/{{member}}' },
+  },
+  // ⚠️ DO NOT set optimizePackageImports for 'react' / 'react-dom' in this repo (pages router SSR glitches)
+  // optimizePackageImports: ['react', 'react-dom'],
   webpack: (config, { isServer }) => {
     config.resolve.alias['@'] = path.resolve(__dirname);
 
@@ -116,16 +125,6 @@ const nextConfig = {
   },
   typescript: {
     ignoreBuildErrors: isUnblock,
-  },
-  experimental: {
-    ...(process.env.EXP_DISABLE_TURBOPACK ? {} : {}),
-    modularizeImports: {
-      'date-fns': { transform: 'date-fns/{{member}}' },
-      'lodash-es': { transform: 'lodash-es/{{member}}' },
-      'lucide-react': { transform: 'lucide-react/dist/esm/icons/{{member}}' },
-      'react-use': { transform: 'react-use/esm/{{member}}' },
-    },
-    optimizePackageImports: ['react', 'react-dom'],
   },
   compiler: {
     removeConsole:

--- a/scripts/guards/jsBudgetGuard.js
+++ b/scripts/guards/jsBudgetGuard.js
@@ -1,31 +1,30 @@
 const summary = process.env.BUILD_SUMMARY || '';
-const pickKb = (label) => {
-  const re = new RegExp(label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s+([\\d.]+)\\s*kB', 'i');
+const match = (re) => {
   const m = re.exec(summary);
   return m ? parseFloat(m[1]) : NaN;
 };
 
-const appKb = pickKb('Route (app)[\\s\\S]*?First Load JS shared by all');
-const pagesKb = pickKb('Route (pages)[\\s\\S]*?First Load JS shared by all');
-const LIMIT_APP = 390;   // step down target
-const LIMIT_PAGES = 430; // step down target
+const appKb = match(/Route \(app\)[\s\S]*?First Load JS shared by all\s+([\d.]+)\s*kB/i);
+const pagesKb = match(/Route \(pages\)[\s\S]*?First Load JS shared by all\s+([\d.]+)\s*kB/i);
+const LIMIT_APP = 390;
+const LIMIT_PAGES = 430;
 
-const checks = [
-  ['app', appKb, LIMIT_APP],
-  ['pages', pagesKb, LIMIT_PAGES],
-];
-
+const report = [];
 let fail = false;
-for (const [name, kb, limit] of checks) {
-  if (isNaN(kb)) {
-    console.log(`ℹ️ Could not parse "${name}" first-load size; skipping.`);
-    continue;
-  }
-  if (kb > limit) {
-    console.error(`❌ ${name} First Load JS = ${kb} kB (limit ${limit} kB).`);
+
+const check = (label, kb, limit) => {
+  if (Number.isNaN(kb)) {
+    report.push(`❌ Could not find "${label}" First Load JS in build output.`);
+    fail = true;
+  } else if (kb > limit) {
+    report.push(`❌ ${label} First Load JS = ${kb} kB (limit ${limit} kB).`);
     fail = true;
   } else {
-    console.log(`✅ ${name} JS budget ok: ${kb} kB (limit ${limit} kB).`);
+    report.push(`✅ ${label} JS budget ok: ${kb} kB (limit ${limit} kB).`);
   }
-}
+};
+check('app', appKb, LIMIT_APP);
+check('pages', pagesKb, LIMIT_PAGES);
+
+console.log(report.join('\n'));
 if (fail) process.exit(1);


### PR DESCRIPTION
## Summary
- move `modularizeImports` to Next.js top-level config and drop React `optimizePackageImports`
- tighten JS budget guard to fail when first-load sizes are missing or over limit

## Testing
- `npm run guard:segments`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `CI=1 npm run build` *(fails: app First Load JS = 412 kB (limit 390 kB), pages First Load JS = 436 kB (limit 430 kB))*

------
https://chatgpt.com/codex/tasks/task_e_68a41d44e2e483238d4ad265b15307a2